### PR TITLE
Update Freshcodex model availability

### DIFF
--- a/crates/freshell-codex/src/model.rs
+++ b/crates/freshell-codex/src/model.rs
@@ -9,7 +9,7 @@
 //!
 //! 1. **menu normalization** ([`normalize_freshcodex_model`] + [`normalize_freshcodex_effort`],
 //!    `fresh-agent-models.ts:101-152`): clamp the model to the freshcodex allowlist
-//!    (fallback `gpt-5.5`); rewrite codex `xhigh → max`; then clamp the effort to the
+//!    (fallback `gpt-6-astra`); rewrite codex `xhigh → max`; then clamp the effort to the
 //!    (normalized) model's `thinkingEfforts`, else its `defaultEffort`, else the last menu
 //!    entry.
 //! 2. **wire mapping** ([`to_codex_reasoning_effort`], `adapter.ts:127-134`): `max`/`xhigh`
@@ -28,7 +28,7 @@
 //! five values that pass through unchanged.
 
 /// `FRESHCODEX_DEFAULT_MODEL` (`fresh-agent-models.ts:15`).
-pub const FRESHCODEX_DEFAULT_MODEL: &str = "gpt-5.5";
+pub const FRESHCODEX_DEFAULT_MODEL: &str = "gpt-6-astra";
 /// `FRESHCODEX_DEFAULT_EFFORT` (`fresh-agent-models.ts:16`).
 pub const FRESHCODEX_DEFAULT_EFFORT: &str = "max";
 
@@ -43,7 +43,7 @@ pub const CHEAPEST_T2_MODEL: &str = "gpt-5.3-codex-spark";
 /// separately (both map to `xhigh`, `adapter.ts:129`).
 pub const FRESHCODEX_EFFORTS_VERBATIM: &[&str] = &["none", "minimal", "low", "medium", "high"];
 
-/// One freshcodex model menu entry (`fresh-agent-models.ts:30-49`).
+/// One freshcodex model menu entry (`fresh-agent-models.ts:30-61`).
 struct ModelOption {
     value: &'static str,
     thinking_efforts: &'static [&'static str],
@@ -51,19 +51,27 @@ struct ModelOption {
 }
 
 /// The freshcodex menu (`FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE.freshcodex`,
-/// `fresh-agent-models.ts:30-49`). `gpt-5.5` and `gpt-5.3-codex-spark` share efforts
-/// `[none,minimal,low,medium,high,max]` (default `max`); `gpt-5.4-flash` omits `max` and
-/// defaults `high`.
+/// `fresh-agent-models.ts:30-61`).
 const FRESHCODEX_MODEL_OPTIONS: &[ModelOption] = &[
     ModelOption {
-        value: "gpt-5.5",
-        thinking_efforts: &["none", "minimal", "low", "medium", "high", "max"],
+        value: "gpt-6-astra",
+        thinking_efforts: &["low", "medium", "high", "xhigh", "max"],
         default_effort: "max",
     },
     ModelOption {
-        value: "gpt-5.4-flash",
-        thinking_efforts: &["none", "minimal", "low", "medium", "high"],
-        default_effort: "high",
+        value: "gpt-5.6-sol",
+        thinking_efforts: &["none", "low", "medium", "high", "xhigh", "max"],
+        default_effort: "max",
+    },
+    ModelOption {
+        value: "gpt-5.6-terra",
+        thinking_efforts: &["none", "low", "medium", "high", "xhigh", "max"],
+        default_effort: "max",
+    },
+    ModelOption {
+        value: "gpt-5.6-luna",
+        thinking_efforts: &["none", "low", "medium", "high", "xhigh", "max"],
+        default_effort: "max",
     },
     ModelOption {
         value: "gpt-5.3-codex-spark",
@@ -77,9 +85,7 @@ fn find_option(model: &str) -> Option<&'static ModelOption> {
 }
 
 /// `normalizeFreshcodexModel(model)` (`fresh-agent-models.ts:101-104`): keep the model iff
-/// it is in the freshcodex allowlist, else fall back to `gpt-5.5`. Consequence
-/// (`codex-gptmini.json` provenance): `gpt-5.4-mini` is silently rewritten to `gpt-5.5`;
-/// `gpt-5.3-codex-spark` is the only non-flagship model reachable through freshcodex.
+/// it is in the freshcodex allowlist, else fall back to `gpt-6-astra`.
 pub fn normalize_freshcodex_model(model: Option<&str>) -> String {
     match model.and_then(find_option) {
         Some(option) => option.value.to_string(),
@@ -256,17 +262,31 @@ mod tests {
     #[test]
     fn model_clamps_to_freshcodex_allowlist() {
         // Allowlisted models pass through.
-        assert_eq!(normalize_freshcodex_model(Some("gpt-5.5")), "gpt-5.5");
         assert_eq!(
-            normalize_freshcodex_model(Some("gpt-5.4-flash")),
-            "gpt-5.4-flash"
+            normalize_freshcodex_model(Some("gpt-6-astra")),
+            "gpt-6-astra"
+        );
+        assert_eq!(
+            normalize_freshcodex_model(Some("gpt-5.6-sol")),
+            "gpt-5.6-sol"
+        );
+        assert_eq!(
+            normalize_freshcodex_model(Some("gpt-5.6-terra")),
+            "gpt-5.6-terra"
+        );
+        assert_eq!(
+            normalize_freshcodex_model(Some("gpt-5.6-luna")),
+            "gpt-5.6-luna"
         );
         assert_eq!(
             normalize_freshcodex_model(Some("gpt-5.3-codex-spark")),
             "gpt-5.3-codex-spark"
         );
-        // gpt-5.4-mini (in the codex catalog, NOT the freshcodex allowlist) → gpt-5.5.
-        assert_eq!(normalize_freshcodex_model(Some("gpt-5.4-mini")), "gpt-5.5");
+        // Retired/unknown models fall back to the current freshcodex default.
+        assert_eq!(
+            normalize_freshcodex_model(Some("gpt-5.4-mini")),
+            FRESHCODEX_DEFAULT_MODEL
+        );
         // Unknown / missing → the freshcodex default.
         assert_eq!(
             normalize_freshcodex_model(Some("random")),
@@ -311,35 +331,33 @@ mod tests {
     }
 
     #[test]
-    fn effort_menu_for_flash_omits_max_and_defaults_high() {
-        let flash = Some("gpt-5.4-flash");
-        // flash has no `max` on its menu; `xhigh → max` then clamps to defaultEffort `high`.
+    fn effort_menu_for_gpt_56_models_keeps_current_reasoning_levels() {
+        let terra = Some("gpt-5.6-terra");
         assert_eq!(
-            normalize_freshcodex_effort(flash, Some("xhigh")).as_deref(),
-            Some("high")
+            normalize_freshcodex_effort(terra, Some("xhigh")).as_deref(),
+            Some("max")
         );
         assert_eq!(
-            normalize_freshcodex_effort(flash, Some("max")).as_deref(),
-            Some("high")
+            normalize_freshcodex_effort(terra, Some("max")).as_deref(),
+            Some("max")
         );
-        // On-menu efforts kept, including the DEV-0003 pair.
         assert_eq!(
-            normalize_freshcodex_effort(flash, Some("none")).as_deref(),
+            normalize_freshcodex_effort(terra, Some("none")).as_deref(),
             Some("none")
         );
         assert_eq!(
-            normalize_freshcodex_effort(flash, Some("minimal")).as_deref(),
-            Some("minimal")
+            normalize_freshcodex_effort(terra, Some("minimal")).as_deref(),
+            Some("max")
         );
         assert_eq!(
-            normalize_freshcodex_effort(flash, None).as_deref(),
-            Some("high")
+            normalize_freshcodex_effort(terra, None).as_deref(),
+            Some("max")
         );
     }
 
     #[test]
     fn effort_for_unknown_model_uses_default_model_menu() {
-        // An unknown model normalizes to gpt-5.5, whose menu includes `max`.
+        // An unknown model normalizes to gpt-6-astra, whose menu includes `max`.
         let unknown = Some("mystery-model");
         assert_eq!(
             normalize_freshcodex_effort(unknown, Some("medium")).as_deref(),

--- a/crates/freshell-freshagent/src/codex.rs
+++ b/crates/freshell-freshagent/src/codex.rs
@@ -6500,7 +6500,7 @@ pub(crate) mod tests {
                 st.handle_send(serde_json::from_value(json!({
                 "provider":"codex", "sessionType":"freshcodex", "sessionId":"thread-1", "text":"Look at this",
                 "images":[{"data":"aGVsbG8=", "mediaType":"image/png"}],
-                "settings":{"model":"gpt-5.5", "effort":"low", "permissionMode":"never", "sandbox":"read-only", "cwd":"/tmp"}
+                "settings":{"model":"gpt-6-astra", "effort":"low", "permissionMode":"never", "sandbox":"read-only", "cwd":"/tmp"}
             })).unwrap()).await;
             }
         });
@@ -6519,10 +6519,10 @@ pub(crate) mod tests {
             .expect("accepted settings survive resume");
         peer.disconnect();
         st.shutdown().await;
-        assert_eq!(saved.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(saved.model.as_deref(), Some("gpt-6-astra"));
         assert_eq!(saved.effort.as_deref(), Some("low"));
         assert_eq!(saved.permission_mode.as_deref(), Some("never"));
-        assert_eq!(params["model"], "gpt-5.5");
+        assert_eq!(params["model"], "gpt-6-astra");
         assert_eq!(params["effort"], "low");
         assert_eq!(params["approvalPolicy"], "never");
         assert_eq!(params["sandboxPolicy"]["type"], "readOnly");

--- a/crates/freshell-freshagent/src/model_capabilities.rs
+++ b/crates/freshell-freshagent/src/model_capabilities.rs
@@ -496,14 +496,24 @@ fn static_models(session_type: SessionType) -> Vec<ModelCapability> {
     let rows: &[Row] = match session_type {
         SessionType::FreshCodex => &[
             (
-                "gpt-5.5",
-                "GPT-5.5",
-                &["none", "minimal", "low", "medium", "high", "max"],
+                "gpt-6-astra",
+                "GPT-6 Astra",
+                &["low", "medium", "high", "xhigh", "max"],
             ),
             (
-                "gpt-5.4-flash",
-                "GPT-5.4 Flash",
-                &["none", "minimal", "low", "medium", "high"],
+                "gpt-5.6-sol",
+                "GPT-5.6 Sol",
+                &["none", "low", "medium", "high", "xhigh", "max"],
+            ),
+            (
+                "gpt-5.6-terra",
+                "GPT-5.6 Terra",
+                &["none", "low", "medium", "high", "xhigh", "max"],
+            ),
+            (
+                "gpt-5.6-luna",
+                "GPT-5.6 Luna",
+                &["none", "low", "medium", "high", "xhigh", "max"],
             ),
             (
                 "gpt-5.3-codex-spark",

--- a/crates/freshell-freshagent/src/model_capabilities_tests.rs
+++ b/crates/freshell-freshagent/src/model_capabilities_tests.rs
@@ -309,19 +309,35 @@ async fn codex_serves_static_catalog() {
             "fetchedAt": 1_000,
             "models": [
                 {
-                    "id": "gpt-5.5",
-                    "displayName": "GPT-5.5",
+                    "id": "gpt-6-astra",
+                    "displayName": "GPT-6 Astra",
                     "provider": "codex",
                     "supportsEffort": true,
-                    "supportedEffortLevels": ["none", "minimal", "low", "medium", "high", "max"],
+                    "supportedEffortLevels": ["low", "medium", "high", "xhigh", "max"],
                     "supportsAdaptiveThinking": true,
                 },
                 {
-                    "id": "gpt-5.4-flash",
-                    "displayName": "GPT-5.4 Flash",
+                    "id": "gpt-5.6-sol",
+                    "displayName": "GPT-5.6 Sol",
                     "provider": "codex",
                     "supportsEffort": true,
-                    "supportedEffortLevels": ["none", "minimal", "low", "medium", "high"],
+                    "supportedEffortLevels": ["none", "low", "medium", "high", "xhigh", "max"],
+                    "supportsAdaptiveThinking": true,
+                },
+                {
+                    "id": "gpt-5.6-terra",
+                    "displayName": "GPT-5.6 Terra",
+                    "provider": "codex",
+                    "supportsEffort": true,
+                    "supportedEffortLevels": ["none", "low", "medium", "high", "xhigh", "max"],
+                    "supportsAdaptiveThinking": true,
+                },
+                {
+                    "id": "gpt-5.6-luna",
+                    "displayName": "GPT-5.6 Luna",
+                    "provider": "codex",
+                    "supportsEffort": true,
+                    "supportedEffortLevels": ["none", "low", "medium", "high", "xhigh", "max"],
                     "supportsAdaptiveThinking": true,
                 },
                 {
@@ -503,8 +519,8 @@ async fn get_freshcodex_serves_static_catalog_over_http() {
     let (status, body) = get(app, &format!("{CAP}/freshcodex?cwd=/ignored"), true).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["runtimeProvider"], json!("codex"));
-    assert_eq!(body["models"].as_array().unwrap().len(), 3);
-    assert_eq!(body["models"][0]["id"], json!("gpt-5.5"));
+    assert_eq!(body["models"].as_array().unwrap().len(), 5);
+    assert_eq!(body["models"][0]["id"], json!("gpt-6-astra"));
     assert_eq!(probe.call_count().await, 0);
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -858,7 +858,7 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); transi
                 <div class="fresh-turn"><div class="fresh-role">Assistant</div><div class="fresh-activity">thought · 1 tool used</div><div class="fresh-copy">The pane keeps real geometry. Transcript text follows the terminal font size; metadata becomes a rail only when the pane has enough width.</div></div>
               </div>
               <div class="fresh-strip">
-                <button type="button" class="fresh-strip-chip" title="gpt-5.5 · effort max">GPT-5.5<i data-lucide="chevron-down" class="icon-xs"></i></button>
+                <button type="button" class="fresh-strip-chip" title="gpt-6-astra · effort max">GPT-6 Astra<i data-lucide="chevron-down" class="icon-xs"></i></button>
                 <span class="fresh-strip-ctx" role="meter" aria-label="Context window used" aria-valuemin="0" aria-valuemax="100" aria-valuenow="47" title="96,000 / 200,000 tokens (47% full) — compacts at 100%"><span>context</span><span class="fresh-strip-meter"><i style="width:47%"></i></span><span class="fresh-strip-pct">47%</span></span>
               </div>
               <div class="fresh-composer">

--- a/shared/fresh-agent-models.ts
+++ b/shared/fresh-agent-models.ts
@@ -12,7 +12,7 @@ export type FreshAgentModelOption = {
   defaultEffort?: string
 }
 
-export const FRESHCODEX_DEFAULT_MODEL = 'gpt-5.5'
+export const FRESHCODEX_DEFAULT_MODEL = 'gpt-6-astra'
 export const FRESHCODEX_DEFAULT_EFFORT = 'max'
 export const FRESHCLAUDE_DEFAULT_EFFORT = 'high'
 export const FRESHOPENCODE_DEFAULT_EFFORT = 'max'
@@ -29,15 +29,27 @@ export const FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE = {
   freshcodex: [
     {
       value: FRESHCODEX_DEFAULT_MODEL,
-      label: 'GPT-5.5',
-      thinkingEfforts: ['none', 'minimal', 'low', 'medium', 'high', 'max'],
+      label: 'GPT-6 Astra',
+      thinkingEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
       defaultEffort: FRESHCODEX_DEFAULT_EFFORT,
     },
     {
-      value: 'gpt-5.4-flash',
-      label: 'GPT-5.4 Flash',
-      thinkingEfforts: ['none', 'minimal', 'low', 'medium', 'high'],
-      defaultEffort: 'high',
+      value: 'gpt-5.6-sol',
+      label: 'GPT-5.6 Sol',
+      thinkingEfforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: FRESHCODEX_DEFAULT_EFFORT,
+    },
+    {
+      value: 'gpt-5.6-terra',
+      label: 'GPT-5.6 Terra',
+      thinkingEfforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: FRESHCODEX_DEFAULT_EFFORT,
+    },
+    {
+      value: 'gpt-5.6-luna',
+      label: 'GPT-5.6 Luna',
+      thinkingEfforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: FRESHCODEX_DEFAULT_EFFORT,
     },
     {
       value: 'gpt-5.3-codex-spark',

--- a/src/components/ExtensionsView.tsx
+++ b/src/components/ExtensionsView.tsx
@@ -140,7 +140,7 @@ function ConfigField({ item, field, onConfigChange, cwdDrafts, cwdErrors }: Conf
         id={fieldId}
         type="text"
         value={field.value as string}
-        placeholder={field.key === 'model' ? (item.id === 'codex' ? 'e.g. gpt-5.5' : 'e.g. claude-3-5-sonnet') : undefined}
+        placeholder={field.key === 'model' ? (item.id === 'codex' ? 'e.g. gpt-6-astra' : 'e.g. claude-3-5-sonnet') : undefined}
         aria-label={field.label}
         onChange={(e) => onConfigChange(item, field.key, e.target.value)}
         className="h-8 w-full px-2 text-xs bg-muted border-0 rounded-md placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-border sm:max-w-[14rem]"

--- a/test/unit/client/components/fresh-agent/FreshAgentModelDialog.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentModelDialog.test.tsx
@@ -151,7 +151,7 @@ function seedFreshcodexPane(
   seedPane(store, {
     sessionType: 'freshcodex',
     provider: 'codex',
-    model: 'gpt-5.5',
+    model: 'gpt-6-astra',
     effort: 'max',
     ...overrides,
   })
@@ -543,7 +543,7 @@ describe('FreshAgentModelDialog (freshcodex)', () => {
     const store = createStore()
     seedFreshcodexPane(store, { effort: 'low' })
     renderDialog(store, { open: true })
-    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.5 · low' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-6 Astra · low' }))
     expect(paneContent(store).effort).toBe('low')
   })
 
@@ -551,11 +551,11 @@ describe('FreshAgentModelDialog (freshcodex)', () => {
     const store = createStore()
     seedFreshcodexPane(store)
     const view = renderDialog(store, { open: true })
-    fireEvent.click(screen.getByRole('option', { name: /GPT-5\.4 Flash/ }))
+    fireEvent.click(screen.getByRole('option', { name: /GPT-5\.6 Luna/ }))
     view.rerender(<Provider store={store}><StoreBackedDialog open={false} /></Provider>)
     view.rerender(<Provider store={store}><StoreBackedDialog open /></Provider>)
-    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.5 · max' }))
-    expect(paneContent(store).model).toBe('gpt-5.5')
+    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-6 Astra · max' }))
+    expect(paneContent(store).model).toBe('gpt-6-astra')
   })
   it('uses the static freshcodex table without probing the catalog endpoint', async () => {
     const store = createStore()
@@ -566,14 +566,14 @@ describe('FreshAgentModelDialog (freshcodex)', () => {
     await screen.findByRole('dialog', { name: 'Model and thinking level' })
     expect(getFreshAgentModelCapabilitiesSpy).not.toHaveBeenCalled()
     // the current model is marked everywhere it appears (Recent + its group)
-    expect(screen.getAllByRole('option', { name: /GPT-5\.5.*current/ }).length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByRole('option', { name: /GPT-5\.4 Flash/ })).toBeInTheDocument()
+    expect(screen.getAllByRole('option', { name: /GPT-6 Astra.*current/ }).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByRole('option', { name: /GPT-5\.6 Luna/ })).toBeInTheDocument()
 
-    // GPT-5.5 levels canonically ordered
-    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-5.5' })
+    // GPT-6 Astra levels canonically ordered
+    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-6 Astra' })
     const levelNames = Array.from(levelsList.querySelectorAll('[role="option"]')).map((el) => el.textContent)
-    expect(levelNames.map((name) => name?.replace(/last used|highest|current|●/g, '').trim())).toEqual(['none', 'minimal', 'low', 'medium', 'high', 'max'])
-    expect(screen.getByRole('button', { name: 'Use GPT-5.5 · max' })).toBeInTheDocument()
+    expect(levelNames.map((name) => name?.replace(/last used|highest|current|●/g, '').trim())).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
+    expect(screen.getByRole('button', { name: 'Use GPT-6 Astra · max' })).toBeInTheDocument()
   })
 
   it('commits a freshcodex model + level under the freshcodex provider defaults and MRU scope', async () => {
@@ -583,28 +583,28 @@ describe('FreshAgentModelDialog (freshcodex)', () => {
 
     renderDialog(store, { open: true, onClose })
 
-    fireEvent.click(await screen.findByRole('option', { name: /GPT-5\.4 Flash/ }))
-    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-5.4 Flash' })
+    fireEvent.click(await screen.findByRole('option', { name: /GPT-5\.6 Luna/ }))
+    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-5.6 Luna' })
     fireEvent.click(Array.from(levelsList.querySelectorAll('[role="option"]')).find((el) => el.textContent?.includes('low'))!)
-    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.4 Flash · low' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.6 Luna · low' }))
 
     expect(onClose).toHaveBeenCalled()
     const content = paneContent(store)
-    expect(content.model).toBe('gpt-5.4-flash')
+    expect(content.model).toBe('gpt-5.6-luna')
     expect(content.effort).toBe('low')
 
     expect(saveServerSettingsPatchSpy).toHaveBeenCalledWith({
       freshAgent: {
         providers: {
           freshcodex: {
-            modelSelection: { kind: 'exact', modelId: 'gpt-5.4-flash' },
+            modelSelection: { kind: 'exact', modelId: 'gpt-5.6-luna' },
             effort: 'low',
           },
         },
       },
     })
     const levelMru = JSON.parse(window.localStorage.getItem('freshcodex.modelLevelMru.v1') ?? '[]')
-    expect(levelMru).toEqual([expect.objectContaining({ modelId: 'gpt-5.4-flash', level: 'low' })])
+    expect(levelMru).toEqual([expect.objectContaining({ modelId: 'gpt-5.6-luna', level: 'low' })])
   })
 })
 

--- a/test/unit/client/components/fresh-agent/FreshAgentSettingsButton.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentSettingsButton.test.tsx
@@ -250,15 +250,15 @@ describe('FreshAgentSettingsButton', () => {
     seedPane(store, {
       sessionType: 'freshcodex',
       provider: 'codex',
-      model: 'gpt-5.5',
+      model: 'gpt-6-astra',
       effort: 'max',
     })
 
     renderButton(store)
     fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }))
 
-    expect(screen.getByRole('button', { name: /GPT-5\.5 · max.*Change/ })).toBeInTheDocument()
-    expect(screen.queryByRole('radio', { name: 'GPT-5.4 Flash' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /GPT-6 Astra · max.*Change/ })).toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: 'GPT-5.6 Luna' })).not.toBeInTheDocument()
     expect(screen.queryByRole('combobox', { name: 'Thinking level' })).not.toBeInTheDocument()
   })
 
@@ -267,7 +267,7 @@ describe('FreshAgentSettingsButton', () => {
     seedPane(store, {
       sessionType: 'freshcodex',
       provider: 'codex',
-      model: 'gpt-5.5',
+      model: 'gpt-6-astra',
       effort: 'max',
     })
 
@@ -276,19 +276,19 @@ describe('FreshAgentSettingsButton', () => {
     fireEvent.click(screen.getByRole('button', { name: /Change/ }))
 
     await screen.findByRole('dialog', { name: 'Model and thinking level' })
-    fireEvent.click(screen.getByRole('option', { name: /GPT-5\.4 Flash/ }))
-    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-5.4 Flash' })
+    fireEvent.click(screen.getByRole('option', { name: /GPT-5\.6 Luna/ }))
+    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-5.6 Luna' })
     const lowOption = Array.from(levelsList.querySelectorAll('[role="option"]')).find((el) => el.textContent?.includes('low'))
     expect(lowOption).toBeDefined()
     fireEvent.click(lowOption!)
-    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.4 Flash · low' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.6 Luna · low' }))
 
     await waitFor(() => {
       expect(saveServerSettingsPatchSpy).toHaveBeenCalledWith({
         freshAgent: {
           providers: {
             freshcodex: {
-              modelSelection: { kind: 'exact', modelId: 'gpt-5.4-flash' },
+              modelSelection: { kind: 'exact', modelId: 'gpt-5.6-luna' },
               effort: 'low',
             },
           },

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -1226,7 +1226,7 @@ describe('FreshAgentView', () => {
       requestId: 'req-create',
       sessionType: 'freshcodex',
       provider: 'codex',
-      model: 'gpt-5.5',
+      model: 'gpt-6-astra',
       effort: 'max',
     }))
 
@@ -1789,7 +1789,7 @@ describe('FreshAgentView', () => {
 
     wsMock.send.mockClear()
 
-    expect(screen.queryByRole('radio', { name: 'GPT-5.5' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: 'GPT-6 Astra' })).not.toBeInTheDocument()
     expect(screen.queryByRole('combobox', { name: 'Thinking level' })).not.toBeInTheDocument()
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
@@ -4271,7 +4271,7 @@ describe('FreshAgentView', () => {
         createRequestId: 'req-flash',
         sessionId: 'thread-flash',
         status: 'idle',
-        model: 'gpt-5.5',
+        model: 'gpt-6-astra',
         effort: 'max',
       },
     }))
@@ -4287,34 +4287,34 @@ describe('FreshAgentView', () => {
     // separate Thinking dropdown. Only the compact Model row remains.
     expect(screen.queryByRole('radiogroup', { name: 'Model' })).not.toBeInTheDocument()
     expect(screen.queryByRole('combobox', { name: 'Thinking level' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /GPT-5\.5 · max.*Change/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /GPT-6 Astra · max.*Change/ })).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /Change/ }))
     await screen.findByRole('dialog', { name: 'Model and thinking level' })
-    fireEvent.click(screen.getByRole('option', { name: /GPT-5\.4 Flash/ }))
+    fireEvent.click(screen.getByRole('option', { name: /GPT-5\.6 Luna/ }))
 
-    // GPT-5.4 Flash declares none..high (no xhigh/max); levels arrive in
+    // GPT-5.6 Luna declares the current GPT-5.6 reasoning levels in
     // canonical order.
-    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-5.4 Flash' })
+    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-5.6 Luna' })
     const levelTexts = Array.from(levelsList.querySelectorAll('[role="option"]')).map((el) => el.textContent)
     expect(levelTexts.map((text) => text?.replace(/last used|highest|current|●/g, '').trim())).toEqual(
-      ['none', 'minimal', 'low', 'medium', 'high'],
+      ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.4 Flash · high' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.6 Luna · max' }))
 
     await waitFor(() => {
       const layout = store.getState().panes.layouts['tab-1']
       expect(layout?.type).toBe('leaf')
-      expect(layout?.type === 'leaf' && layout.content.kind === 'fresh-agent' ? layout.content.model : null).toBe('gpt-5.4-flash')
-      expect(layout?.type === 'leaf' && layout.content.kind === 'fresh-agent' ? layout.content.effort : null).toBe('high')
+      expect(layout?.type === 'leaf' && layout.content.kind === 'fresh-agent' ? layout.content.model : null).toBe('gpt-5.6-luna')
+      expect(layout?.type === 'leaf' && layout.content.kind === 'fresh-agent' ? layout.content.effort : null).toBe('max')
     })
     expect(saveServerSettingsPatchSpy).toHaveBeenCalledWith({
       freshAgent: {
         providers: {
           freshcodex: {
-            modelSelection: { kind: 'exact', modelId: 'gpt-5.4-flash' },
-            effort: 'high',
+            modelSelection: { kind: 'exact', modelId: 'gpt-5.6-luna' },
+            effort: 'max',
           },
         },
       },
@@ -4333,7 +4333,7 @@ describe('FreshAgentView', () => {
         createRequestId: 'req-persist-settings',
         sessionId: 'thread-persist-settings',
         status: 'idle',
-        model: 'gpt-5.4-flash',
+        model: 'gpt-5.6-luna',
         permissionMode: 'on-request',
         effort: 'medium',
       },
@@ -4347,13 +4347,13 @@ describe('FreshAgentView', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }))
     // Thinking now persists through the Change… dialog, not a retired dropdown.
-    fireEvent.click(screen.getByRole('button', { name: /GPT-5\.4 Flash · medium.*Change/ }))
+    fireEvent.click(screen.getByRole('button', { name: /GPT-5\.6 Luna · medium.*Change/ }))
     await screen.findByRole('dialog', { name: 'Model and thinking level' })
-    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-5.4 Flash' })
+    const levelsList = screen.getByRole('listbox', { name: 'Thinking levels for GPT-5.6 Luna' })
     const highOption = Array.from(levelsList.querySelectorAll('[role="option"]')).find((el) => el.textContent?.includes('high'))
     expect(highOption).toBeDefined()
     fireEvent.click(highOption!)
-    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.4 Flash · high' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use GPT-5.6 Luna · high' }))
     fireEvent.change(screen.getByRole('combobox', { name: 'Permission mode' }), {
       target: { value: 'never' },
     })
@@ -4362,7 +4362,7 @@ describe('FreshAgentView', () => {
       freshAgent: {
         providers: {
           freshcodex: {
-            modelSelection: { kind: 'exact', modelId: 'gpt-5.4-flash' },
+            modelSelection: { kind: 'exact', modelId: 'gpt-5.6-luna' },
             effort: 'high',
           },
         },
@@ -4389,7 +4389,7 @@ describe('FreshAgentView', () => {
         createRequestId: 'req-style',
         sessionId: 'thread-style',
         status: 'idle',
-        model: 'gpt-5.4-flash',
+        model: 'gpt-5.6-luna',
         effort: 'high',
         style: 'sans',
       },
@@ -5435,7 +5435,7 @@ describe('FreshAgentView', () => {
     })
 
     expect(screen.getByText('Codex turn')).toBeInTheDocument()
-    expect(screen.queryByRole('radio', { name: 'GPT-5.5' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: 'GPT-6 Astra' })).not.toBeInTheDocument()
     expect(screen.queryByRole('radio', { name: 'custom-codex-model' })).not.toBeInTheDocument()
   })
 
@@ -5620,7 +5620,7 @@ describe('FreshAgentView', () => {
       sessionId: 'codex-thread-lost',
       sessionType: 'freshcodex',
       provider: 'codex',
-      model: 'gpt-5.5',
+      model: 'gpt-6-astra',
     }))
     store.dispatch(initLayout({
       tabId: 'tab-1',
@@ -6716,7 +6716,7 @@ describe('FreshAgentView /model slash command', () => {
       content: modelCommandPaneContent({
         sessionType: 'freshcodex',
         provider: 'codex',
-        model: 'gpt-5.5',
+        model: 'gpt-6-astra',
         effort: 'max',
       }),
     }))

--- a/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.createContent.test.tsx
@@ -430,7 +430,7 @@ describe('createContentForType with ext: prefix', () => {
           enabled: true,
           providers: {
             freshcodex: {
-              modelSelection: { kind: 'exact', modelId: 'gpt-5.4-flash' },
+              modelSelection: { kind: 'exact', modelId: 'gpt-5.6-luna' },
               defaultPermissionMode: 'never',
               effort: 'high',
               style: 'serif',
@@ -465,8 +465,8 @@ describe('createContentForType with ext: prefix', () => {
       if (paneContent.kind !== 'fresh-agent') return
       expect(paneContent.sessionType).toBe('freshcodex')
       expect(paneContent.provider).toBe('codex')
-      expect(paneContent.modelSelection).toEqual({ kind: 'exact', modelId: 'gpt-5.4-flash' })
-      expect(paneContent.model).toBe('gpt-5.4-flash')
+      expect(paneContent.modelSelection).toEqual({ kind: 'exact', modelId: 'gpt-5.6-luna' })
+      expect(paneContent.model).toBe('gpt-5.6-luna')
       expect(paneContent.permissionMode).toBe('never')
       expect(paneContent.effort).toBe('high')
       expect(paneContent.style).toBe('serif')

--- a/test/unit/client/components/panes/PaneContainer.test.tsx
+++ b/test/unit/client/components/panes/PaneContainer.test.tsx
@@ -2149,7 +2149,7 @@ describe('PaneContainer', () => {
           expect(paneContent.sessionType).toBe('freshcodex')
           expect(paneContent.provider).toBe('codex')
           expect(paneContent.initialCwd).toBe('/home/user/freshcodex-project')
-          expect(paneContent.model).toBe('gpt-5.5')
+          expect(paneContent.model).toBe('gpt-6-astra')
           expect(paneContent.effort).toBe('max')
         }
       })
@@ -2162,12 +2162,12 @@ describe('PaneContainer', () => {
       }))
     })
 
-    it('normalizes stale Freshcodex effort from provider settings against the active model', async () => {
+    it('normalizes saved Freshcodex effort from provider settings against the active model', async () => {
       const node = createPickerNode('pane-1')
       const store = createStoreWithClaude(
         node,
         undefined,
-        { codex: { model: 'gpt-5.4-flash' } },
+        { codex: { model: 'gpt-5.6-luna' } },
         ['claude', 'codex'],
         { claude: true, codex: true },
         { freshcodex: { effort: 'xhigh' } },
@@ -2191,8 +2191,8 @@ describe('PaneContainer', () => {
         const paneContent = (state.layouts['tab-1'] as Extract<PaneNode, { type: 'leaf' }>).content
         expect(paneContent.kind).toBe('fresh-agent')
         if (paneContent.kind === 'fresh-agent') {
-          expect(paneContent.model).toBe('gpt-5.4-flash')
-          expect(paneContent.effort).toBe('high')
+          expect(paneContent.model).toBe('gpt-5.6-luna')
+          expect(paneContent.effort).toBe('max')
         }
       })
     })

--- a/test/unit/client/lib/fresh-agent-model-capabilities.test.ts
+++ b/test/unit/client/lib/fresh-agent-model-capabilities.test.ts
@@ -643,18 +643,20 @@ describe('fresh-agent-model-capabilities static catalog mapping', () => {
       status: 'fresh',
     })
     expect(capabilities?.models.map((model) => model.id)).toEqual([
-      'gpt-5.5',
-      'gpt-5.4-flash',
+      'gpt-6-astra',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
       'gpt-5.3-codex-spark',
     ])
     expect(capabilities?.models[0]).toMatchObject({
-      displayName: 'GPT-5.5',
+      displayName: 'GPT-6 Astra',
       provider: 'codex',
       supportsEffort: true,
-      supportedEffortLevels: ['none', 'minimal', 'low', 'medium', 'high', 'max'],
+      supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
       supportsAdaptiveThinking: false,
     })
-    expect(capabilities?.models[1]?.supportedEffortLevels).toEqual(['none', 'minimal', 'low', 'medium', 'high'])
+    expect(capabilities?.models[1]?.supportedEffortLevels).toEqual(['none', 'low', 'medium', 'high', 'xhigh', 'max'])
     for (const model of capabilities?.models ?? []) {
       expect(model.source).toEqual({ id: 'openai', displayName: 'openai' })
     }

--- a/test/unit/shared/fresh-agent-models.test.ts
+++ b/test/unit/shared/fresh-agent-models.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  FRESHCODEX_DEFAULT_MODEL,
   FRESHOPENCODE_DEFAULT_EFFORT,
   FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE,
   getFreshAgentThinkingOptions,
@@ -26,6 +27,25 @@ describe('fresh-agent-models freshopencode static menu', () => {
 
   it('returns undefined for resolveFreshAgentModelOption when the model is not in the empty static menu', () => {
     expect(resolveFreshAgentModelOption('freshopencode', 'opencode-go/glm-5.2')).toBeUndefined()
+  })
+})
+
+describe('fresh-agent-models freshcodex static menu', () => {
+  it('tracks the current Codex model availability list', () => {
+    expect(FRESHCODEX_DEFAULT_MODEL).toBe('gpt-6-astra')
+    expect(FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE.freshcodex.map((option) => option.value)).toEqual([
+      'gpt-6-astra',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.3-codex-spark',
+    ])
+  })
+
+  it('falls back retired or unknown freshcodex models to the current default', () => {
+    expect(normalizeFreshAgentModel('freshcodex', 'codex', 'gpt-5.4')).toBe('gpt-6-astra')
+    expect(normalizeFreshAgentModel('freshcodex', 'codex', 'gpt-5.4-mini')).toBe('gpt-6-astra')
+    expect(normalizeFreshAgentModel('freshcodex', 'codex', 'unknown-model')).toBe('gpt-6-astra')
   })
 })
 


### PR DESCRIPTION
## Summary
- default Freshcodex to gpt-6-astra
- update Freshcodex static model lists to GPT-6 Astra, GPT-5.6 Sol/Terra/Luna, and GPT-5.3 Codex Spark
- align TypeScript and Rust model normalization/capability tests

## Test plan
- npm run test:vitest -- run test/unit/shared/fresh-agent-models.test.ts test/unit/client/lib/fresh-agent-model-capabilities.test.ts test/unit/client/components/fresh-agent/FreshAgentModelDialog.test.tsx test/unit/client/components/fresh-agent/FreshAgentSettingsButton.test.tsx test/unit/client/components/panes/PaneContainer.test.tsx test/unit/client/components/panes/PaneContainer.createContent.test.tsx test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
- npm run typecheck
- npm run lint
- npm run build
- cargo fmt --check
- cargo test -p freshell-codex -- --nocapture
- cargo test -p freshell-freshagent -- --nocapture

Note: pre-worktree broad base gate was waived because origin/main cloud vitest job failed before tests with /usr/local/bin/e2e-entrypoint.sh: Permission denied.