### PR TITLE
feat(client): sidebar pinned status-tier ordering + close-tab activity ratchet

### DIFF
--- a/docs/plans/2026-08-22-sidebar-pinned-status-sort.md
+++ b/docs/plans/2026-08-22-sidebar-pinned-status-sort.md
@@ -7,7 +7,7 @@
 ## User Request
 
 ### Requested result
-Change Freshell's left-panel (sidebar) session list ordering: (1) within the pinned section (sessions open in tabs on this device), order sessions in four status tiers — busy on this device (blue) first, then needs-attention/turn-complete on this device (green), then busy on other devices (blue ring), then open on other devices (green ring) — with remaining pinned sessions after those tiers and existing time-based ordering within each tier; and (2) treat closing a tab as a user touch on that session: ratchet its locally-stored activity timestamp at close time so the just-closed session sorts near the top of the non-pinned (grey) section under the default activity sort mode.
+Change Freshell's left-panel (sidebar) session list ordering: (1) within the pinned section (sessions open in tabs on this device), order sessions in four status tiers — busy on this device (blue icon) first, then open here, not busy, with no remote-busy/open state (the row's persistent green open-here icon; this tier covers needs-attention/turn-complete rows and all other idle pinned rows alike), then busy on other devices (blue ring), then open on other devices (green ring) — with existing time-based ordering within each tier; the four tiers are a strict partition of the pinned section — every pinned row belongs to exactly one of them, so there is no separate "remaining pinned" bucket (requester confirmed this partition semantics on 2026-08-29, choosing it over a reading where tier 2 would contain only attention-flagged rows); and (2) treat closing a tab as a user touch on that session: ratchet its locally-stored activity timestamp at close time so the just-closed session sorts near the top of the non-pinned (grey) section under the default activity sort mode.
 
 ### Explicit constraints
 - None stated beyond the requested result.
@@ -25,7 +25,7 @@ Change Freshell's left-panel (sidebar) session list ordering: (1) within the pin
 
 1. **Documented deviation from decision C's recommended shape — C's own blessed alternative is chosen: tier data is passed as a `sortSessionItems` option, not stamped as a `pinnedTier` item field by `buildSessionItems`.** Rationale, from verification: (a) stamping would force the high-churn activity slices (`codexActivity`/`claudeActivity`/`opencodeActivity`/`amplifierActivity`/`freshAgent.sessions` — new record objects per WS message) into `buildSessionItems`' input rail, re-running the full build+filter+sort on every blue blink; the repo contains zero `resultEqualityCheck` usage to stabilize a sub-selector (grep over `src/` finds none), while Sidebar.tsx:375-391 already computes exactly the primitive busy-key array (`shallowEqual`) and remote-activity record the sort needs. (b) The item-identity precedent from the remote-status-rings work is that status travels as props/sets, never as item fields. (c) The option shape leaves `buildSessionItems`, `SidebarSessionItem`, and every existing build test untouched.
 2. **Decision C's "CRITICAL lockstep" (`isSessionItemEqual` must compare new fields or `useStableArray` swallows reorders) is resolved vacuously, verified:** `useStableArray` (src/hooks/useStableArray.ts:23-28) compares pairwise by index and `isSessionItemEqual` (Sidebar.tsx:142-165) compares `sessionId`, so any reorder of distinct sessions always adopts the new array; and under the chosen option shape there are no new item fields at all, so `isSessionItemEqual`, `areSessionItemsEqual`, `areSidebarItemPropsEqual`, and `Sidebar.render-stability.test.tsx` need no changes. Busy flips re-sort because `busySessionKeys` content changes (intended); unrelated WS churn cannot reach the selector (the component edge already reduces it to shallow-equal primitives).
-3. **Documented refinement of tier-2 semantics per binding decision A:** the user-facing "needs-attention/turn-complete on this device (green)" tier is implemented as the sidebar's actual local green affordance — open here, not busy here, no remote state. Verification: the Sidebar never consumes turn-completion attention (`attentionByTab`/`attentionByPane` are tabId/paneId-keyed, no session-key projection exists, and `closeTab` clears them), so a pinned row's only local green is the persistent `hasTab` icon (Sidebar.tsx:1063-1070); decision A fixes this as a strict four-way partition with no fifth tier, so tier 2 is the catch-all for "remaining pinned sessions," ordered second. No new attention machinery is built (decision F: no new UI, no visual changes).
+3. **Documented refinement of tier-2 semantics per binding decision A:** the user-facing "needs-attention/turn-complete on this device (green)" tier is implemented as the sidebar's actual local green affordance — open here, not busy here, no remote state. Verification: the Sidebar never consumes turn-completion attention (`attentionByTab`/`attentionByPane` are tabId/paneId-keyed, no session-key projection exists, and `closeTab` clears them), so a pinned row's only local green is the persistent `hasTab` icon (Sidebar.tsx:1063-1070); decision A fixes this as a strict four-way partition with no fifth tier, so tier 2 is the catch-all for "remaining pinned sessions," ordered second. This interpretation was confirmed as the requester's intent on 2026-08-29 (explicit choice over an attention-flagged-only tier 2; wording carried into the User Request block above). No new attention machinery is built (decision F: no new UI, no visual changes).
 4. **Close-ratchet ref derivation uses `collectSessionRefsFromTabs([tab], panes)`, not `getTabSessionRefs`** — verified: `getTabSessionRefs` (src/lib/session-utils.ts:325-329) returns `[]` when the tab has no layout, while `collectSessionRefsFromTabs([tab], panes)` additionally resolves layout-less tabs through `buildTabFallbackLocator` (session-utils.ts:143-157, 268-305). The ratchet must cover both.
 5. **Accepted residual (decision D, recorded):** the ratchet is applied unconditionally in the thunk, so REST/MCP/server-broadcast tab closes (which flow through the same `closeTab` thunk on every connected client) also ratchet — ratcheting a mirrored close is harmless-to-useful.
 6. **Behavior boundaries (decision D, plain):** (i) the float is visible under the default `activity` sort only; `recency`/`recency-pinned` receive no ratchet input by existing design (`selectSessionActivityForSort` returns the shared `EMPTY_ACTIVITY` for non-`activity` modes, sidebarSelectors.ts:59-63), so no float there; (ii) a session whose only sidebar row was a client-side fallback row (never indexed by the server) disappears on close and cannot float — the ratchet value is stored and takes effect once the session is indexed.
@@ -427,7 +427,13 @@ Append inside `describe('activity sort mode')` in test/unit/client/components/Si
       ]
 
       const tabs = [
-        { id: 'tab-busy', terminalId, resumeSessionId: busySid, mode: 'codex' },
+        // Explicit sessionRef is load-bearing for this fixture: production
+        // `extractSessionLocators` does not treat a codex `resumeSessionId`
+        // as a locator, so without it this tab produces no session ref,
+        // `hasTab` stays false, and tier sorting never applies to the row
+        // (proven by executed check: extractSessionLocators(codex terminal
+        // content with only resumeSessionId) returns []).
+        { id: 'tab-busy', terminalId, resumeSessionId: busySid, sessionRef: { provider: 'codex', sessionId: busySid }, mode: 'codex' },
         { id: 'tab-idle', resumeSessionId: idleSid, mode: 'claude' },
       ]
 
@@ -715,7 +721,11 @@ In test/unit/client/components/Sidebar.test.tsx: extend the line-8 import to `im
       })
 
       const buttons = () => screen.getAllByRole('button').filter(
-        (btn) => btn.textContent?.endsWith('session')
+        // endsWith would never match: every session row button's textContent
+        // ends with the appended relative-timestamp span (Sidebar.tsx), so
+        // match with `includes`, exactly like the existing ratchet-float test
+        // at Sidebar.test.tsx:1154 ff.
+        (btn) => btn.textContent?.includes('session')
       )
 
       // Pinned first, then grey newest-first.

--- a/docs/plans/2026-08-22-sidebar-pinned-status-sort.md
+++ b/docs/plans/2026-08-22-sidebar-pinned-status-sort.md
@@ -1,0 +1,869 @@
+# Pinned Status-Tier Sorting and Close-Tab Activity Ratchet Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+## User Request
+
+### Requested result
+Change Freshell's left-panel (sidebar) session list ordering: (1) within the pinned section (sessions open in tabs on this device), order sessions in four status tiers — busy on this device (blue) first, then needs-attention/turn-complete on this device (green), then busy on other devices (blue ring), then open on other devices (green ring) — with remaining pinned sessions after those tiers and existing time-based ordering within each tier; and (2) treat closing a tab as a user touch on that session: ratchet its locally-stored activity timestamp at close time so the just-closed session sorts near the top of the non-pinned (grey) section under the default activity sort mode.
+
+### Explicit constraints
+- None stated beyond the requested result.
+
+### Accepted tradeoffs and residuals
+- None stated.
+
+**Goal:** Pinned sidebar sessions order into four status tiers (busy here → plain open here → busy elsewhere → open elsewhere) under the tab-pinning sort modes, and closing a tab bumps that session's activity timestamp so it floats to the top of the grey section under the default activity sort.
+
+**Architecture:** Tiering lives in the pure sort path: `sortSessionItems` (src/store/selectors/sidebarSelectors.ts) gains an optional `pinnedStatus` option (`busySessionKeys: ReadonlySet<string>`, `remoteActivity: Record<string, 'busy' | 'open'>`) and a strict four-way `resolvePinnedStatusTier` partition applied only inside the pinned (`hasTab`) group of `activity` and `recency-pinned` modes; `makeSelectSortedSessionItems` accepts the status bag as a fourth passthrough argument, and `Sidebar.tsx` feeds it the already-memoized `busySessionKeySet` / `selectRemoteSessionActivity` values it computes for row props. The close-tab touch is three lines in the `closeTab` thunk (src/store/tabsSlice.ts): derive the closing tab's session refs from the pre-close snapshot and dispatch the existing ratchet-only `updateSessionActivity` per ref, letting the 5s-debounced persistence middleware handle localStorage.
+
+**Tech Stack:** TypeScript, React 18, Redux Toolkit (`createSelector` / `createSlice` / `createAsyncThunk`), Vitest + Testing Library.
+
+### Planner-verified design decisions (binding decisions A–F applied, with evidence at base `97373172509e8124e6d4bab833f13fb8663a1309`)
+
+1. **Documented deviation from decision C's recommended shape — C's own blessed alternative is chosen: tier data is passed as a `sortSessionItems` option, not stamped as a `pinnedTier` item field by `buildSessionItems`.** Rationale, from verification: (a) stamping would force the high-churn activity slices (`codexActivity`/`claudeActivity`/`opencodeActivity`/`amplifierActivity`/`freshAgent.sessions` — new record objects per WS message) into `buildSessionItems`' input rail, re-running the full build+filter+sort on every blue blink; the repo contains zero `resultEqualityCheck` usage to stabilize a sub-selector (grep over `src/` finds none), while Sidebar.tsx:375-391 already computes exactly the primitive busy-key array (`shallowEqual`) and remote-activity record the sort needs. (b) The item-identity precedent from the remote-status-rings work is that status travels as props/sets, never as item fields. (c) The option shape leaves `buildSessionItems`, `SidebarSessionItem`, and every existing build test untouched.
+2. **Decision C's "CRITICAL lockstep" (`isSessionItemEqual` must compare new fields or `useStableArray` swallows reorders) is resolved vacuously, verified:** `useStableArray` (src/hooks/useStableArray.ts:23-28) compares pairwise by index and `isSessionItemEqual` (Sidebar.tsx:142-165) compares `sessionId`, so any reorder of distinct sessions always adopts the new array; and under the chosen option shape there are no new item fields at all, so `isSessionItemEqual`, `areSessionItemsEqual`, `areSidebarItemPropsEqual`, and `Sidebar.render-stability.test.tsx` need no changes. Busy flips re-sort because `busySessionKeys` content changes (intended); unrelated WS churn cannot reach the selector (the component edge already reduces it to shallow-equal primitives).
+3. **Documented refinement of tier-2 semantics per binding decision A:** the user-facing "needs-attention/turn-complete on this device (green)" tier is implemented as the sidebar's actual local green affordance — open here, not busy here, no remote state. Verification: the Sidebar never consumes turn-completion attention (`attentionByTab`/`attentionByPane` are tabId/paneId-keyed, no session-key projection exists, and `closeTab` clears them), so a pinned row's only local green is the persistent `hasTab` icon (Sidebar.tsx:1063-1070); decision A fixes this as a strict four-way partition with no fifth tier, so tier 2 is the catch-all for "remaining pinned sessions," ordered second. No new attention machinery is built (decision F: no new UI, no visual changes).
+4. **Close-ratchet ref derivation uses `collectSessionRefsFromTabs([tab], panes)`, not `getTabSessionRefs`** — verified: `getTabSessionRefs` (src/lib/session-utils.ts:325-329) returns `[]` when the tab has no layout, while `collectSessionRefsFromTabs([tab], panes)` additionally resolves layout-less tabs through `buildTabFallbackLocator` (session-utils.ts:143-157, 268-305). The ratchet must cover both.
+5. **Accepted residual (decision D, recorded):** the ratchet is applied unconditionally in the thunk, so REST/MCP/server-broadcast tab closes (which flow through the same `closeTab` thunk on every connected client) also ratchet — ratcheting a mirrored close is harmless-to-useful.
+6. **Behavior boundaries (decision D, plain):** (i) the float is visible under the default `activity` sort only; `recency`/`recency-pinned` receive no ratchet input by existing design (`selectSessionActivityForSort` returns the shared `EMPTY_ACTIVITY` for non-`activity` modes, sidebarSelectors.ts:59-63), so no float there; (ii) a session whose only sidebar row was a client-side fallback row (never indexed by the server) disappears on close and cannot float — the ratchet value is stored and takes effect once the session is indexed.
+7. **Testing-level dispositions (decisions E/F):** unit + component + integration coverage is specified per task below. No new e2e spec: tiering is a pure client-side composition of data whose end-to-end production paths already have coverage (busy derivation in `pane-activity` unit tests, remote-ring data flow in `test/e2e-browser/specs/sidebar-remote-status-rings-rust.spec.ts`); a meaningful tier-ordering e2e would require two devices plus a streaming agent, adding cost without exercising any new production path. `docs/index.html` is not updated: the mock does not encode row-order semantics and no new control, section, setting, or visual affordance is introduced (decision F default: skip).
+
+## Global Constraints
+
+- Server uses NodeNext/ESM (relative imports include .js) — client code follows existing TS/React/Redux Toolkit conventions.
+- Coordinated test commands: focused vitest via `npm run test:vitest -- run <paths>` (never raw npx vitest); broad suites through the coordinator (`npm test`) from the worktree.
+- TDD red/green/refactor for every change; no coverage reductions, no skipped tests.
+- Commit author identity inherited from repo config — do not touch git config.
+- Commit messages: conventional, focused.
+
+### Task 1: Status-tier ordering inside `sortSessionItems`
+
+**Files:**
+- Modify: src/store/selectors/sidebarSelectors.ts:670-754 (`sortSessionItems`; insert the exported tier types/helper immediately above it, after line 668)
+- Test: test/unit/client/store/selectors/sidebarSelectors.test.ts (new `describe('pinned status tiers')` inside `describe('sortSessionItems')`, after the `activity mode` block starting at line 1160)
+
+**Interfaces:**
+- Consumes: existing `sortSessionItems(items, sortMode, options?)` (sidebarSelectors.ts:670), `createSessionItem(overrides)` test builder (test file lines 13-26), `SidebarSessionItem` (sidebarSelectors.ts:14-48).
+- Produces:
+  - `export type PinnedStatusTier = 1 | 2 | 3 | 4`
+  - `export interface PinnedSortStatus { busySessionKeys?: ReadonlySet<string>; remoteActivity?: Record<string, 'busy' | 'open'> }`
+  - `export function resolvePinnedStatusTier(item: SidebarSessionItem, pinnedStatus?: PinnedSortStatus): PinnedStatusTier`
+  - `sortSessionItems(items: SidebarSessionItem[], sortMode: string, options?: { disableTabPinning?: boolean; pinnedStatus?: PinnedSortStatus }): SidebarSessionItem[]` (Task 2 consumes the widened signature).
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+```ts
+    describe('pinned status tiers', () => {
+      const pinned = (id: string, timestamp: number, extra: Partial<SidebarSessionItem> = {}) =>
+        createSessionItem({ id, sessionId: id, timestamp, hasTab: true, ...extra })
+
+      it('orders pinned rows into four tiers: busy here, plain open here, remote busy, remote open', () => {
+        // Legacy time order would be remote-open > remote-busy > plain-open > busy-here.
+        const items = [
+          pinned('remote-open', 4000),
+          pinned('remote-busy', 3000),
+          pinned('plain-open', 2000),
+          pinned('busy-here', 1000),
+        ]
+
+        const sorted = sortSessionItems(items, 'activity', {
+          pinnedStatus: {
+            busySessionKeys: new Set(['claude:busy-here']),
+            remoteActivity: { 'claude:remote-busy': 'busy', 'claude:remote-open': 'open' },
+          },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['busy-here', 'plain-open', 'remote-busy', 'remote-open'])
+      })
+
+      it('treats local-busy as tier 1 even when the session is also busy remotely', () => {
+        const items = [pinned('both', 1000), pinned('plain', 2000)]
+
+        const sorted = sortSessionItems(items, 'activity', {
+          pinnedStatus: {
+            busySessionKeys: new Set(['claude:both']),
+            remoteActivity: { 'claude:both': 'busy' },
+          },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['both', 'plain'])
+      })
+
+      it('keeps (ratchetedActivity ?? timestamp) ordering within a tier in activity mode', () => {
+        const items = [
+          pinned('old-ratcheted', 5000, { ratchetedActivity: 4000 }),
+          pinned('new-untouched', 3000),
+        ]
+
+        const sorted = sortSessionItems(items, 'activity', { pinnedStatus: {} })
+
+        expect(sorted.map((i) => i.id)).toEqual(['old-ratcheted', 'new-untouched'])
+      })
+
+      it('applies the same tiers in recency-pinned mode with timestamp ordering within a tier', () => {
+        const items = [
+          pinned('remote-open', 4000),
+          pinned('busy-here', 1000),
+          pinned('plain', 3000),
+        ]
+
+        const sorted = sortSessionItems(items, 'recency-pinned', {
+          pinnedStatus: {
+            busySessionKeys: new Set(['claude:busy-here']),
+            remoteActivity: { 'claude:remote-open': 'open' },
+          },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['busy-here', 'plain', 'remote-open'])
+      })
+
+      it('flattens tiers when disableTabPinning is set (active search)', () => {
+        const items = [
+          pinned('remote-open', 4000),
+          pinned('busy-here', 1000),
+        ]
+
+        const sorted = sortSessionItems(items, 'activity', {
+          disableTabPinning: true,
+          pinnedStatus: {
+            busySessionKeys: new Set(['claude:busy-here']),
+            remoteActivity: { 'claude:remote-open': 'open' },
+          },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['remote-open', 'busy-here'])
+      })
+
+      it('applies tiers within the archived partition (archived still last)', () => {
+        const items = [
+          createSessionItem({ id: 'arch-plain', sessionId: 'arch-plain', timestamp: 2000, hasTab: true, archived: true }),
+          createSessionItem({ id: 'arch-busy', sessionId: 'arch-busy', timestamp: 1000, hasTab: true, archived: true }),
+          createSessionItem({ id: 'live', sessionId: 'live', timestamp: 500, hasTab: false }),
+        ]
+
+        const sorted = sortSessionItems(items, 'activity', {
+          pinnedStatus: { busySessionKeys: new Set(['claude:arch-busy']) },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['live', 'arch-busy', 'arch-plain'])
+      })
+
+      it('ignores pinnedStatus in recency and project modes', () => {
+        const pinnedStatus = { busySessionKeys: new Set(['claude:busy-here']) }
+
+        const recency = sortSessionItems([pinned('busy-here', 1000), pinned('plain', 2000)], 'recency', { pinnedStatus })
+        expect(recency.map((i) => i.id)).toEqual(['plain', 'busy-here'])
+
+        const project = sortSessionItems([
+          createSessionItem({ id: 'busy-here', sessionId: 'busy-here', timestamp: 1000, hasTab: true, projectPath: '/b' }),
+          createSessionItem({ id: 'plain', sessionId: 'plain', timestamp: 2000, hasTab: true, projectPath: '/a' }),
+        ], 'project', { pinnedStatus })
+        expect(project.map((i) => i.id)).toEqual(['plain', 'busy-here'])
+      })
+
+      it('leaves legacy pinned ordering untouched when pinnedStatus is omitted', () => {
+        const sorted = sortSessionItems([pinned('older', 1000), pinned('newer', 2000)], 'activity')
+
+        expect(sorted.map((i) => i.id)).toEqual(['newer', 'older'])
+      })
+    })
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+```bash
+npm run test:vitest -- run test/unit/client/store/selectors/sidebarSelectors.test.ts -t 'pinned status tiers'
+```
+
+FAIL because `sortSessionItems` has no `pinnedStatus` option — the pure time-based pinned order is produced and the four-tier expectation receives `['remote-open', 'remote-busy', 'plain-open', 'busy-here']` instead of `['busy-here', 'plain-open', 'remote-busy', 'remote-open']`. (The three decision-B gating tests — `flattens tiers when disableTabPinning is set`, `ignores pinnedStatus in recency and project modes`, `leaves legacy pinned ordering untouched when pinnedStatus is omitted` — are expected green at red: they assert boundaries the step-3 code could wrongly change, and fail on such a mis-implementation.)
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Insert immediately above `sortSessionItems` (after line 668) in src/store/selectors/sidebarSelectors.ts:
+
+```ts
+export type PinnedStatusTier = 1 | 2 | 3 | 4
+
+export interface PinnedSortStatus {
+  /** Sessions currently busy on this device, keyed `provider:sessionId`. */
+  busySessionKeys?: ReadonlySet<string>
+  /** Per-session activity on OTHER devices (the fold already resolves busy-over-open). */
+  remoteActivity?: Record<string, 'busy' | 'open'>
+}
+
+/**
+ * Strict 4-way partition of pinned (hasTab) rows (coordinator decision A):
+ *   1 = busy on this device (blue) · 2 = open here, not busy, no remote state
+ *   3 = busy on another device (blue ring data) · 4 = open on another device (green ring data)
+ * Local busy beats any remote state; tier 2 is the catch-all "remaining pinned"
+ * bucket — exactly the rows rendering the sidebar's plain local green icon.
+ */
+export function resolvePinnedStatusTier(
+  item: SidebarSessionItem,
+  pinnedStatus?: PinnedSortStatus,
+): PinnedStatusTier {
+  const key = `${item.provider}:${item.sessionId}`
+  if (pinnedStatus?.busySessionKeys?.has(key)) return 1
+  const remote = pinnedStatus?.remoteActivity?.[key]
+  if (remote === 'busy') return 3
+  if (remote === 'open') return 4
+  return 2
+}
+```
+
+Widen the options type and sort pinned groups by tier first. Replace the whole `sortSessionItems` (lines 670-754) with:
+
+```ts
+export function sortSessionItems(
+  items: SidebarSessionItem[],
+  sortMode: string,
+  options?: { disableTabPinning?: boolean; pinnedStatus?: PinnedSortStatus },
+): SidebarSessionItem[] {
+  const sorted = [...items]
+
+  const active = sorted.filter((i) => !i.archived)
+  const archived = sorted.filter((i) => i.archived)
+
+  const compareBySessionKey = (a: SidebarSessionItem, b: SidebarSessionItem) =>
+    a.provider.localeCompare(b.provider) || a.sessionId.localeCompare(b.sessionId)
+
+  const compareByRecency = (a: SidebarSessionItem, b: SidebarSessionItem) =>
+    b.timestamp - a.timestamp || compareBySessionKey(a, b)
+  const compareByActivity = (a: SidebarSessionItem, b: SidebarSessionItem) => {
+    const aHasRatcheted = typeof a.ratchetedActivity === 'number'
+    const bHasRatcheted = typeof b.ratchetedActivity === 'number'
+    if (aHasRatcheted !== bHasRatcheted) return aHasRatcheted ? -1 : 1
+    const aTime = a.ratchetedActivity ?? a.timestamp
+    const bTime = b.ratchetedActivity ?? b.timestamp
+    return bTime - aTime || compareBySessionKey(a, b)
+  }
+
+  // Pinned status tier asc, then the mode's existing within-tier time
+  // comparator (decisions A/B). With no pinnedStatus every pinned row is
+  // tier 2, so tiering degenerates to the legacy comparators exactly.
+  const tierOf = (item: SidebarSessionItem) => resolvePinnedStatusTier(item, options?.pinnedStatus)
+
+  const sortByMode = (list: SidebarSessionItem[]) => {
+    const copy = [...list]
+
+    if (sortMode === 'recency') {
+      return copy.sort(compareByRecency)
+    }
+
+    if (sortMode === 'recency-pinned') {
+      if (options?.disableTabPinning) {
+        return copy.sort(compareByRecency)
+      }
+
+      const withTabs = copy.filter((i) => i.hasTab)
+      const withoutTabs = copy.filter((i) => !i.hasTab)
+
+      withTabs.sort((a, b) => {
+        const tierDelta = tierOf(a) - tierOf(b)
+        if (tierDelta !== 0) return tierDelta
+        return compareByRecency(a, b)
+      })
+      withoutTabs.sort(compareByRecency)
+
+      return [...withTabs, ...withoutTabs]
+    }
+
+    if (sortMode === 'activity') {
+      if (options?.disableTabPinning) {
+        return copy.sort(compareByActivity)
+      }
+
+      const withTabs = copy.filter((i) => i.hasTab)
+      const withoutTabs = copy.filter((i) => !i.hasTab)
+
+      withTabs.sort((a, b) => {
+        const tierDelta = tierOf(a) - tierOf(b)
+        if (tierDelta !== 0) return tierDelta
+        const aTime = a.ratchetedActivity ?? a.timestamp
+        const bTime = b.ratchetedActivity ?? b.timestamp
+        return bTime - aTime || compareBySessionKey(a, b)
+      })
+
+      withoutTabs.sort((a, b) => {
+        const aHasRatcheted = typeof a.ratchetedActivity === 'number'
+        const bHasRatcheted = typeof b.ratchetedActivity === 'number'
+        if (aHasRatcheted !== bHasRatcheted) return aHasRatcheted ? -1 : 1
+        const aTime = a.ratchetedActivity ?? a.timestamp
+        const bTime = b.ratchetedActivity ?? b.timestamp
+        return bTime - aTime || compareBySessionKey(a, b)
+      })
+
+      return [...withTabs, ...withoutTabs]
+    }
+
+    if (sortMode === 'project') {
+      return copy.sort((a, b) => {
+        const projA = a.projectPath || a.subtitle || ''
+        const projB = b.projectPath || b.subtitle || ''
+        if (projA !== projB) return projA.localeCompare(projB)
+        return b.timestamp - a.timestamp || compareBySessionKey(a, b)
+      })
+    }
+
+    return copy
+  }
+
+  return [...sortByMode(active), ...sortByMode(archived)]
+}
+```
+
+- [ ] **Step 4: Run the focused test**
+
+```bash
+npm run test:vitest -- run test/unit/client/store/selectors/sidebarSelectors.test.ts
+```
+
+Expected: PASS (all of `sortSessionItems`, including the new `pinned status tiers` block, plus the unchanged legacy describes).
+
+- [ ] **Step 5: Refactor while green** — No-op by design: the tier/within-tier composition is already factored as `tierOf` + the mode comparator, and the only structural duplication (the two pinned branches) mirrors the pre-existing per-mode branch structure of this function; extracting a shared pinned-sort helper would couple `recency-pinned` and `activity` comparators that decision B deliberately keeps distinct.
+
+- [ ] **Step 6: Run impacted-test verification** — the sibling suites that import this module:
+
+```bash
+npm run test:vitest -- run test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts test/unit/client/store/selectors/sidebarSelectors.runningTerminal.test.ts
+```
+
+Expected: PASS. These call `sortSessionItems`/`buildSessionItems`/`makeSelectSortedSessionItems` without `pinnedStatus`; the all-tier-2 degeneration guarantees legacy order byte-for-byte.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/store/selectors/sidebarSelectors.ts test/unit/client/store/selectors/sidebarSelectors.test.ts && git commit -m "feat(client): order pinned sidebar sessions by local/remote status tiers"
+```
+
+### Task 2: Feed status data through `makeSelectSortedSessionItems` and `Sidebar.tsx`
+
+**Files:**
+- Modify: src/store/selectors/sidebarSelectors.ts:50-74 (module consts + input selectors), :756-811 (`makeSelectSortedSessionItems` input list, result func, final call)
+- Modify: src/components/Sidebar.tsx:23 (import type), :339 and :375-391 (relocate status computations above the selector call site, pass the memoized status bag)
+- Test: test/unit/client/store/selectors/sidebarSelectors.test.ts (`describe('makeSelectSortedSessionItems')`, after line 1024)
+- Test: test/unit/client/components/Sidebar.test.tsx (`describe('activity sort mode')`, after the test ending at line 1200)
+
+**Interfaces:**
+- Consumes: `PinnedSortStatus` (Task 1), widened `sortSessionItems` options (Task 1), `busySessionKeySet` (Sidebar.tsx:385, `Set<string>` memoized from `shallowEqual`-selected `busySessionKeys`), `remoteActivityBySessionKey` (Sidebar.tsx:390, `selectRemoteSessionActivity` from src/store/selectors/tabsRegistrySelectors.ts:162-165), `createSelectorState` / `createFallbackTab` test builders (test file lines 28-113), `createTestStore` / `renderSidebar` / `sessionId` harness (Sidebar.test.tsx lines 71-280).
+- Produces: `makeSelectSortedSessionItems()` selector callable as `(state, terminals, filter, pinnedStatus?)`; omitting the fourth argument (all existing callers) behaves exactly as today via a shared module-level `EMPTY_PINNED_STATUS`.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Append to `describe('makeSelectSortedSessionItems')` in test/unit/client/store/selectors/sidebarSelectors.test.ts:
+
+```ts
+    it('orders pinned sessions by status tier when pinnedStatus is provided, flat under applied search', () => {
+      const busy = createFallbackTab('tab-busy', 'busy-s', 'Busy Session', '/tmp/a', 'codex')
+      const idle = createFallbackTab('tab-idle', 'idle-s', 'Idle Session', '/tmp/b', 'claude')
+      const projects = [
+        {
+          projectPath: '/tmp',
+          sessions: [
+            { sessionId: 'busy-s', provider: 'codex', projectPath: '/tmp', lastActivityAt: 1000, title: 'Busy Session', cwd: '/tmp' },
+            { sessionId: 'idle-s', provider: 'claude', projectPath: '/tmp', lastActivityAt: 9000, title: 'Idle Session', cwd: '/tmp' },
+          ],
+        },
+      ] as any
+      const makeState = (extra: { appliedQuery?: string; appliedSearchTier?: 'title' } = {}) =>
+        createSelectorState({
+          projects,
+          tabs: [busy.tab, idle.tab],
+          panes: {
+            layouts: { 'tab-busy': busy.layout, 'tab-idle': idle.layout },
+            activePane: {},
+            paneTitles: {},
+          },
+          sortMode: 'activity',
+          ...extra,
+        })
+      const selectSortedItems = makeSelectSortedSessionItems()
+      const pinnedStatus = { busySessionKeys: new Set(['codex:busy-s']), remoteActivity: {} }
+
+      // Omitted pinnedStatus: legacy pinned time order (newest first).
+      expect(selectSortedItems(makeState(), [], '').map((i) => i.sessionId)).toEqual(['idle-s', 'busy-s'])
+      // Provided pinnedStatus: busy session leads the pinned section.
+      expect(selectSortedItems(makeState(), [], '', pinnedStatus).map((i) => i.sessionId)).toEqual(['busy-s', 'idle-s'])
+      // Applied server search flattens pinning; tiers go with it (decision B).
+      expect(
+        selectSortedItems(makeState({ appliedQuery: 'Session', appliedSearchTier: 'title' }), [], '', pinnedStatus)
+          .map((i) => i.sessionId),
+      ).toEqual(['idle-s', 'busy-s'])
+    })
+```
+
+Append inside `describe('activity sort mode')` in test/unit/client/components/Sidebar.test.tsx (after the `uses ratcheted sessionActivity for closed tabs (preserves position)` block at lines 1154-1200):
+
+```tsx
+    it('orders a locally busy pinned session ahead of a newer idle pinned session', async () => {
+      const now = Date.now()
+      const busySid = sessionId('busy-pinned')
+      const idleSid = sessionId('idle-pinned')
+      const terminalId = 'term-busy-tier'
+      const projects: ProjectGroup[] = [
+        {
+          projectPath: '/home/user/project',
+          sessions: [
+            {
+              sessionId: busySid,
+              provider: 'codex',
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 60000,
+              title: 'Busy pinned session',
+              cwd: '/home/user/project',
+            },
+            {
+              sessionId: idleSid,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 1000,
+              title: 'Idle pinned session',
+              cwd: '/home/user/project',
+            },
+          ],
+        },
+      ]
+
+      const tabs = [
+        { id: 'tab-busy', terminalId, resumeSessionId: busySid, mode: 'codex' },
+        { id: 'tab-idle', resumeSessionId: idleSid, mode: 'claude' },
+      ]
+
+      const store = createTestStore({
+        projects,
+        tabs,
+        sortMode: 'activity',
+        codexActivity: {
+          byTerminalId: {
+            [terminalId]: {
+              terminalId,
+              sessionId: 'session-codex',
+              phase: 'busy',
+              lastActivityAt: 10,
+            },
+          },
+        },
+      })
+      renderSidebar(store, [])
+
+      await act(async () => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const buttons = screen.getAllByRole('button').filter(
+        (btn) => btn.textContent?.includes('pinned session')
+      )
+
+      // Busy (older) must lead the pinned section; idle (newer) follows.
+      expect(buttons[0]).toHaveTextContent('Busy pinned session')
+      expect(buttons[1]).toHaveTextContent('Idle pinned session')
+    })
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+```bash
+npm run test:vitest -- run test/unit/client/store/selectors/sidebarSelectors.test.ts -t 'orders pinned sessions by status tier'
+npm run test:vitest -- run test/unit/client/components/Sidebar.test.tsx -t 'orders a locally busy pinned session ahead'
+```
+
+FAIL because `makeSelectSortedSessionItems` has no fourth input/argument, so the provided `pinnedStatus` is ignored: the tiered call returns legacy order `['idle-s', 'busy-s']` instead of `['busy-s', 'idle-s']`; and the component feeds the selector only `(state, terminals, '')`, so the idle (newer) row renders first instead of the busy row.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+In src/store/selectors/sidebarSelectors.ts, after the `EMPTY_PANE_LAST_INPUT_AT` const (line 52):
+
+```ts
+const EMPTY_PINNED_STATUS: PinnedSortStatus = { busySessionKeys: new Set<string>(), remoteActivity: {} }
+```
+
+After the `selectFilter` input selector (line 74):
+
+```ts
+const selectPinnedStatus = (
+  _state: RootState,
+  _terminals: BackgroundTerminal[],
+  _filter: string,
+  pinnedStatus?: PinnedSortStatus,
+): PinnedSortStatus => pinnedStatus ?? EMPTY_PINNED_STATUS
+```
+
+In `makeSelectSortedSessionItems` (lines 756-811): append `selectPinnedStatus,` to the input-selector array after `selectFilter,`; append `pinnedStatus` as the final parameter of the result func (after `filter`); change the final call to:
+
+```ts
+      return sortSessionItems(filtered, sortMode, {
+        disableTabPinning: appliedQuery.trim().length > 0,
+        pinnedStatus,
+      })
+```
+
+In src/components/Sidebar.tsx: extend the existing sidebarSelectors import (line 23 area) with the type: `import { makeSelectSortedSessionItems, type PinnedSortStatus, ... } from '@/store/selectors/sidebarSelectors'`. Then relocate the four status computations currently at lines 375-391 (`busySessionKeys` selector, `busySessionKeySet` memo, `remoteActivityBySessionKey` selector, `sameDeviceSessionKeys` selector) to immediately BEFORE the current selector call site (line 339), and replace line 339 with the memoized status bag plus the 4-arg call:
+
+```ts
+  const busySessionKeys = useAppSelector((state) => collectBusySessionKeys({
+    tabs: state.tabs.tabs,
+    paneLayouts: state.panes?.layouts ?? EMPTY_LAYOUTS,
+    codexActivityByTerminalId: state.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID,
+    claudeActivityByTerminalId: state.claudeActivity?.byTerminalId ?? EMPTY_CLAUDE_ACTIVITY_BY_ID,
+    amplifierActivityByTerminalId: state.amplifierActivity?.byTerminalId ?? EMPTY_AMPLIFIER_ACTIVITY_BY_ID,
+    opencodeActivityByTerminalId: state.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID,
+    paneRuntimeActivityByPaneId: state.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID,
+    freshAgentSessions: state.freshAgent?.sessions ?? EMPTY_FRESH_AGENT_SESSIONS,
+  }), shallowEqual)
+  const busySessionKeySet = useMemo(() => new Set(busySessionKeys), [busySessionKeys])
+  const remoteActivityBySessionKey = useAppSelector(selectRemoteSessionActivity)
+  const sameDeviceSessionKeys = useAppSelector(selectSameDeviceSessionKeys)
+
+  // Pinned status input for the sort selector (decision C, alternative shape):
+  // reuse the already-memoized busy set and remote record so the selector only
+  // recomputes when the primitive status data actually changes — busy flips
+  // re-sort (intended); remote record identity changes at most once per
+  // registry snapshot reply (~30s), and useStableArray absorbs no-op re-sorts.
+  const pinnedSortStatus = useMemo<PinnedSortStatus>(
+    () => ({ busySessionKeys: busySessionKeySet, remoteActivity: remoteActivityBySessionKey }),
+    [busySessionKeySet, remoteActivityBySessionKey],
+  )
+  const localFilteredItems = useAppSelector((state) => selectSortedItems(state, terminals, '', pinnedSortStatus))
+```
+
+`localOpenSessionKeys` (lines 392-414) and `localSessionKeys` (lines 415-419) stay where they are; they do not feed the selector. Hook order is static in all renders, so the relocation is safe.
+
+- [ ] **Step 4: Run the focused test**
+
+```bash
+npm run test:vitest -- run test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/components/Sidebar.test.tsx
+```
+
+Expected: PASS, including both new tests and all pre-existing sort/ring/activity describes (unchanged rows render in unchanged order because every status set is empty in the old fixtures).
+
+- [ ] **Step 5: Refactor while green** — No-op by design: the component edge already had the exact memoization layering this needs (`shallowEqual` busy keys, memoized busy set, `useMemo` status bag); the selector gains a single passthrough input matching the existing `selectTerminals`/`selectFilter` pattern, and duplication was deliberately avoided by consuming the component's busy set instead of recomputing identity inside the selector.
+
+- [ ] **Step 6: Run impacted-test verification** — every suite touching the selector or the Sidebar row pipeline:
+
+```bash
+npm run test:vitest -- run test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/store/selectors/sidebarSelectors.visibility.test.ts test/unit/client/store/selectors/sidebarSelectors.runningTerminal.test.ts test/unit/client/components/Sidebar.test.tsx test/unit/client/components/Sidebar.render-stability.test.tsx test/unit/client/components/App.ws-bootstrap.test.tsx
+```
+
+Expected: PASS. `App.ws-bootstrap.test.tsx:626` and the sibling selector suites call the selector with three arguments and take the `EMPTY_PINNED_STATUS` default; `Sidebar.render-stability.test.tsx` asserts comparators that are unchanged (no new item fields — planner note 2).
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/store/selectors/sidebarSelectors.ts src/components/Sidebar.tsx test/unit/client/store/selectors/sidebarSelectors.test.ts test/unit/client/components/Sidebar.test.tsx && git commit -m "feat(client): feed busy/remote status into the sidebar sort selector"
+```
+
+### Task 3: Close-tab activity ratchet in the `closeTab` thunk
+
+**Files:**
+- Modify: src/store/tabsSlice.ts:7 (extend the existing session-utils import), imports block (add `updateSessionActivity`, near line 13), :485-486 (insert the ratchet immediately after `const layout = stateBeforeClose.panes.layouts[tabId]`)
+- Test: test/unit/client/store/tabsSlice.test.ts (new `describe('closeTab session activity ratchet')` after the `closeTab with multiple panes` block ending at line 578)
+- Test: test/unit/client/components/Sidebar.test.tsx (`describe('activity sort mode')`, after the Task 2 test)
+- Test: test/integration/activity-sort.test.tsx (new `it` after the existing test)
+
+**Interfaces:**
+- Consumes: `collectSessionRefsFromTabs(tabs, panes): SessionRef[]` (src/lib/session-utils.ts:294-305), `updateSessionActivity({ sessionId, provider?, lastInputAt })` — ratchet-only (src/store/sessionActivitySlice.ts:81-96, composite key via `makeSessionKey`, lines 13-17), `closeTab` thunk (tabsSlice.ts:480-536, pre-close snapshot at line 483), `VALID_CLAUDE_SESSION_ID` const (tabsSlice.test.ts:19), `splitPane` action (src/store/panesSlice.ts:1163, exported at 2406), `sessionActivityPersistMiddleware` / `SESSION_ACTIVITY_PERSIST_DEBOUNCE_MS` / `resetSessionActivityFlushListenersForTests` (src/store/sessionActivityPersistence.ts:4,51,59), `SESSION_ACTIVITY_STORAGE_KEY` (src/store/sessionActivitySlice.ts:2,4).
+- Produces: no new exported names; behavior: every `closeTab` dispatch ratchets `sessionActivity.sessions['provider:sessionId']` to `Date.now()` for each of the closing tab's session refs.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add to test/unit/client/store/tabsSlice.test.ts — extend the line-14 import to `import panesReducer, { initLayout, splitPane } from '../../../../src/store/panesSlice'` and add `import sessionActivityReducer from '../../../../src/store/sessionActivitySlice'`, then:
+
+```ts
+  describe('closeTab session activity ratchet', () => {
+    const SECOND_CLAUDE_ID = '550e8400-e29b-41d4-a716-446655440001'
+
+    function createRatchetStore(sessions: Record<string, number> = {}) {
+      return configureStore({
+        reducer: {
+          tabs: tabsReducer,
+          panes: panesReducer,
+          sessionActivity: sessionActivityReducer,
+        },
+        preloadedState: { sessionActivity: { sessions } },
+      })
+    }
+
+    it('ratchets activity for every session ref of the closing tab', async () => {
+      const store = createRatchetStore()
+      store.dispatch(addTab({ mode: 'claude' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({
+        tabId,
+        content: {
+          kind: 'terminal',
+          mode: 'claude',
+          resumeSessionId: VALID_CLAUDE_SESSION_ID,
+          sessionRef: { provider: 'claude', sessionId: VALID_CLAUDE_SESSION_ID },
+        },
+      }))
+      const leafId = (store.getState().panes.layouts[tabId] as any).id
+      store.dispatch(splitPane({
+        tabId,
+        paneId: leafId,
+        direction: 'horizontal',
+        newContent: {
+          kind: 'terminal',
+          mode: 'claude',
+          resumeSessionId: SECOND_CLAUDE_ID,
+          sessionRef: { provider: 'claude', sessionId: SECOND_CLAUDE_ID },
+        },
+      }))
+
+      const beforeClose = Date.now()
+      await store.dispatch(closeTab(tabId))
+
+      const sessions = store.getState().sessionActivity.sessions
+      expect(sessions[`claude:${VALID_CLAUDE_SESSION_ID}`]).toBeGreaterThanOrEqual(beforeClose)
+      expect(sessions[`claude:${SECOND_CLAUDE_ID}`]).toBeGreaterThanOrEqual(beforeClose)
+    })
+
+    it('records no activity when closing a sessionless shell tab', async () => {
+      const store = createRatchetStore()
+      store.dispatch(addTab({ mode: 'shell' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({ tabId, content: { kind: 'terminal', mode: 'shell' } }))
+
+      await store.dispatch(closeTab(tabId))
+
+      expect(store.getState().sessionActivity.sessions).toEqual({})
+    })
+
+    it('never downgrades a newer existing ratchet value', async () => {
+      const future = Date.now() + 60_000
+      const store = createRatchetStore({ [`claude:${VALID_CLAUDE_SESSION_ID}`]: future })
+      store.dispatch(addTab({ mode: 'claude' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({
+        tabId,
+        content: { kind: 'terminal', mode: 'claude', resumeSessionId: VALID_CLAUDE_SESSION_ID },
+      }))
+
+      await store.dispatch(closeTab(tabId))
+
+      expect(store.getState().sessionActivity.sessions[`claude:${VALID_CLAUDE_SESSION_ID}`]).toBe(future)
+    })
+
+    it('ratchets layout-less tabs via tab-level fallback identity', async () => {
+      const store = createRatchetStore()
+      store.dispatch(hydrateTabs({
+        tabs: [{
+          id: 'layout-less',
+          createRequestId: 'layout-less',
+          title: 'Layout-less',
+          status: 'running',
+          mode: 'claude',
+          resumeSessionId: VALID_CLAUDE_SESSION_ID,
+          createdAt: 1,
+        } as any],
+        activeTabId: 'layout-less',
+      }))
+
+      const beforeClose = Date.now()
+      await store.dispatch(closeTab('layout-less'))
+
+      expect(store.getState().sessionActivity.sessions[`claude:${VALID_CLAUDE_SESSION_ID}`])
+        .toBeGreaterThanOrEqual(beforeClose)
+    })
+  })
+```
+
+In test/unit/client/components/Sidebar.test.tsx: extend the line-8 import to `import tabsReducer, { closeTab } from '@/store/tabsSlice'`, then append inside `describe('activity sort mode')`:
+
+```tsx
+    it('floats a just-closed session to the top of the grey section', async () => {
+      const now = Date.now()
+      const closerSid = sessionId('closing-float')
+      const greyNewerSid = sessionId('grey-newer')
+      const greyOlderSid = sessionId('grey-older')
+      const projects: ProjectGroup[] = [
+        {
+          projectPath: '/home/user/project',
+          sessions: [
+            {
+              sessionId: closerSid,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 7200000,
+              title: 'Closing session',
+              cwd: '/home/user/project',
+            },
+            {
+              sessionId: greyNewerSid,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 1000,
+              title: 'Grey newer session',
+              cwd: '/home/user/project',
+            },
+            {
+              sessionId: greyOlderSid,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 5000,
+              title: 'Grey older session',
+              cwd: '/home/user/project',
+            },
+          ],
+        },
+      ]
+
+      const tabs = [{ id: 'tab-closing', resumeSessionId: closerSid, mode: 'claude' }]
+      const store = createTestStore({ projects, tabs, sortMode: 'activity' })
+      renderSidebar(store, [])
+
+      await act(async () => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const buttons = () => screen.getAllByRole('button').filter(
+        (btn) => btn.textContent?.endsWith('session')
+      )
+
+      // Pinned first, then grey newest-first.
+      expect(buttons()[0]).toHaveTextContent('Closing session')
+      expect(buttons()[1]).toHaveTextContent('Grey newer session')
+      expect(buttons()[2]).toHaveTextContent('Grey older session')
+
+      const beforeClose = Date.now()
+      await act(async () => {
+        await store.dispatch(closeTab('tab-closing') as any)
+        vi.advanceTimersByTime(100)
+      })
+
+      // The close ratcheted the session's activity timestamp...
+      expect(store.getState().sessionActivity.sessions[`claude:${closerSid}`])
+        .toBeGreaterThanOrEqual(beforeClose)
+      // ...so the stale session — sort order [newer, older, closer] without it —
+      // lands on top of the grey section instead of sinking below both.
+      expect(buttons()).toHaveLength(3)
+      expect(buttons()[0]).toHaveTextContent('Closing session')
+      expect(buttons()[0]).toHaveAttribute('data-has-tab', 'false')
+      expect(buttons()[1]).toHaveTextContent('Grey newer session')
+      expect(buttons()[2]).toHaveTextContent('Grey older session')
+    })
+```
+
+In test/integration/activity-sort.test.tsx: extend the storage-key import to `import sessionActivityReducer, { SESSION_ACTIVITY_STORAGE_KEY } from '@/store/sessionActivitySlice'`, and add:
+
+```tsx
+import tabsReducer, { addTab, closeTab } from '@/store/tabsSlice'
+import panesReducer, { initLayout } from '@/store/panesSlice'
+import {
+  sessionActivityPersistMiddleware,
+  SESSION_ACTIVITY_PERSIST_DEBOUNCE_MS,
+  resetSessionActivityFlushListenersForTests,
+} from '@/store/sessionActivityPersistence'
+```
+
+inside `beforeEach` after `localStorage.clear()`: `resetSessionActivityFlushListenersForTests()`, then append:
+
+```tsx
+  it('persists the close-tab activity ratchet to localStorage after the debounce', async () => {
+    const claudeSessionId = '550e8400-e29b-41d4-a716-446655440000'
+    const store = configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        sessionActivity: sessionActivityReducer,
+      },
+      middleware: (getDefault) => getDefault().concat(sessionActivityPersistMiddleware),
+    })
+
+    store.dispatch(addTab({ mode: 'claude' }))
+    const tabId = store.getState().tabs.tabs[0].id
+    store.dispatch(initLayout({
+      tabId,
+      content: {
+        kind: 'terminal',
+        mode: 'claude',
+        resumeSessionId: claudeSessionId,
+        sessionRef: { provider: 'claude', sessionId: claudeSessionId },
+      },
+    }))
+
+    const beforeClose = Date.now()
+    await store.dispatch(closeTab(tabId))
+
+    expect(store.getState().sessionActivity.sessions[`claude:${claudeSessionId}`])
+      .toBeGreaterThanOrEqual(beforeClose)
+    expect(localStorage.getItem(SESSION_ACTIVITY_STORAGE_KEY)).toBeNull()
+
+    vi.advanceTimersByTime(SESSION_ACTIVITY_PERSIST_DEBOUNCE_MS)
+
+    const persisted = JSON.parse(localStorage.getItem(SESSION_ACTIVITY_STORAGE_KEY) || '{}')
+    expect(persisted[`claude:${claudeSessionId}`]).toBeGreaterThanOrEqual(beforeClose)
+  })
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+```bash
+npm run test:vitest -- run test/unit/client/store/tabsSlice.test.ts -t 'closeTab session activity ratchet'
+npm run test:vitest -- run test/unit/client/components/Sidebar.test.tsx -t 'floats a just-closed session'
+npm run test:vitest -- run test/integration/activity-sort.test.tsx
+```
+
+FAIL because `closeTab` never dispatches `updateSessionActivity`: the ratchet assertions read `undefined` (`expected undefined to be >= <timestamp>`), and in the Sidebar float test the closed session sinks to `['Grey newer session', 'Grey older session', 'Closing session']`.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+In src/store/tabsSlice.ts: extend line 7 to `import { findTabIdForSession, collectSessionRefsFromTabs } from '@/lib/session-utils'` and add (grouped with the other store imports, after the tabRegistrySlice import at line 13): `import { updateSessionActivity } from './sessionActivitySlice'`. Then insert immediately after line 485 (`const layout = stateBeforeClose.panes.layouts[tabId]`):
+
+```ts
+    // Closing a tab counts as a user touch on its sessions: ratchet each
+    // session's locally-stored activity timestamp so the just-closed session
+    // floats to the top of the unpinned (grey) section under the default
+    // 'activity' sort. Refs come from the pre-close snapshot via
+    // collectSessionRefsFromTabs([tab], panes) — chosen over getTabSessionRefs
+    // because it also covers layout-less tabs via buildTabFallbackLocator
+    // (session-utils.ts:143-157). Unconditional by design: REST/MCP/server-
+    // broadcast closes flow through this same thunk on every connected client
+    // (accepted residual: ratcheting a mirrored close is harmless-to-useful).
+    if (tab) {
+      const touchedAt = Date.now()
+      for (const ref of collectSessionRefsFromTabs([tab], stateBeforeClose.panes)) {
+        dispatch(updateSessionActivity({
+          sessionId: ref.sessionId,
+          provider: ref.provider,
+          lastInputAt: touchedAt,
+        }))
+      }
+    }
+```
+
+- [ ] **Step 4: Run the focused test**
+
+```bash
+npm run test:vitest -- run test/unit/client/store/tabsSlice.test.ts test/unit/client/components/Sidebar.test.tsx test/integration/activity-sort.test.tsx
+```
+
+Expected: PASS, including all new tests and every pre-existing close-tab, sort, and persistence test.
+
+- [ ] **Step 5: Refactor while green** — No-op by design: the insertion is a single guarded loop that reuses the existing pure extractor and the existing ratchet-only action; no helper extraction is warranted for three lines, and the slice/middleware already handle monotonicity, pruning, and persistence.
+
+- [ ] **Step 6: Run impacted-test verification** — every suite that dispatches or pins `closeTab` / `removeTab` / session-activity behavior:
+
+```bash
+npm run test:vitest -- run test/unit/client/store/tabsSlice.test.ts test/unit/client/store/tabsSlice.closed-registry.test.ts test/unit/client/store/tabsSlice.reopen.test.ts test/unit/client/store/turnCompletionSlice.test.ts test/unit/client/store/persistTabsEmptyGuard.test.ts test/unit/client/store/sessionActivitySlice.test.ts test/unit/client/store/sessionActivityPersistence.test.ts test/unit/client/components/Sidebar.test.tsx test/integration/activity-sort.test.tsx
+```
+
+Expected: PASS. Stores in adjacency suites without a `sessionActivity` reducer silently ignore the added dispatches; attention-clearing, closed-snapshot, reopen-stack, and tombstone assertions are behaviorally untouched.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/store/tabsSlice.ts test/unit/client/store/tabsSlice.test.ts test/unit/client/components/Sidebar.test.tsx test/integration/activity-sort.test.tsx && git commit -m "feat(client): ratchet session activity when a tab closes"
+```
+
+## Final gate (after the last task, before any PR)
+
+- [ ] Typecheck + lint + full coordinated suite from the worktree:
+
+```bash
+npm run lint
+FRESHELL_TEST_SUMMARY="sidebar-pinned-status-sort final gate" npm run check
+```
+
+Expected: both exit 0.
+
+- [ ] Confirm dispositions: no new e2e spec and no `docs/index.html` update (rationale in planner notes 7); no settings, toggles, or visual changes (decision F); no changes to remote-ring render suppression, ring visuals, or busy/green icon visuals.
+- [ ] Stop before `gh pr create`: PR creation requires explicit user approval per repo rules.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   filterSessionItemsByAgent,
   filterSessionItemsByRepo,
   makeSelectSortedSessionItems,
+  type PinnedSortStatus,
   type SidebarSessionItem,
 } from '@/store/selectors/sidebarSelectors'
 import { ContextIds } from '@/components/context-menu/context-menu-constants'
@@ -336,7 +337,30 @@ export default function Sidebar({
     store,
   ])
 
-  const localFilteredItems = useAppSelector((state) => selectSortedItems(state, terminals, ''))
+  const busySessionKeys = useAppSelector((state) => collectBusySessionKeys({
+    tabs: state.tabs.tabs,
+    paneLayouts: state.panes?.layouts ?? EMPTY_LAYOUTS,
+    codexActivityByTerminalId: state.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID,
+    claudeActivityByTerminalId: state.claudeActivity?.byTerminalId ?? EMPTY_CLAUDE_ACTIVITY_BY_ID,
+    amplifierActivityByTerminalId: state.amplifierActivity?.byTerminalId ?? EMPTY_AMPLIFIER_ACTIVITY_BY_ID,
+    opencodeActivityByTerminalId: state.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID,
+    paneRuntimeActivityByPaneId: state.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID,
+    freshAgentSessions: state.freshAgent?.sessions ?? EMPTY_FRESH_AGENT_SESSIONS,
+  }), shallowEqual)
+  const busySessionKeySet = useMemo(() => new Set(busySessionKeys), [busySessionKeys])
+  const remoteActivityBySessionKey = useAppSelector(selectRemoteSessionActivity)
+  const sameDeviceSessionKeys = useAppSelector(selectSameDeviceSessionKeys)
+
+  // Pinned status input for the sort selector (decision C, alternative shape):
+  // reuse the already-memoized busy set and remote record so the selector only
+  // recomputes when the primitive status data actually changes — busy flips
+  // re-sort (intended); remote record identity changes at most once per
+  // registry snapshot reply (~30s), and useStableArray absorbs no-op re-sorts.
+  const pinnedSortStatus = useMemo<PinnedSortStatus>(
+    () => ({ busySessionKeys: busySessionKeySet, remoteActivity: remoteActivityBySessionKey }),
+    [busySessionKeySet, remoteActivityBySessionKey],
+  )
+  const localFilteredItems = useAppSelector((state) => selectSortedItems(state, terminals, '', pinnedSortStatus))
   // Options come from the PRE-repo-filter list so every repo stays listed while
   // one is selected; the current selection is retained even if its rows are
   // temporarily absent (e.g. mid-search), keeping the controlled select valid.
@@ -372,23 +396,10 @@ export default function Sidebar({
   // value actually changes — the custom memo comparator on SidebarItem
   // handles that independently.
   const sortedItems = useStableArray(computedItems, isSessionItemEqual)
-  const busySessionKeys = useAppSelector((state) => collectBusySessionKeys({
-    tabs: state.tabs.tabs,
-    paneLayouts: state.panes?.layouts ?? EMPTY_LAYOUTS,
-    codexActivityByTerminalId: state.codexActivity?.byTerminalId ?? EMPTY_CODEX_ACTIVITY_BY_ID,
-    claudeActivityByTerminalId: state.claudeActivity?.byTerminalId ?? EMPTY_CLAUDE_ACTIVITY_BY_ID,
-    amplifierActivityByTerminalId: state.amplifierActivity?.byTerminalId ?? EMPTY_AMPLIFIER_ACTIVITY_BY_ID,
-    opencodeActivityByTerminalId: state.opencodeActivity?.byTerminalId ?? EMPTY_OPENCODE_ACTIVITY_BY_ID,
-    paneRuntimeActivityByPaneId: state.paneRuntimeActivity?.byPaneId ?? EMPTY_PANE_RUNTIME_ACTIVITY_BY_ID,
-    freshAgentSessions: state.freshAgent?.sessions ?? EMPTY_FRESH_AGENT_SESSIONS,
-  }), shallowEqual)
-  const busySessionKeySet = useMemo(() => new Set(busySessionKeys), [busySessionKeys])
 
   // Remote status rings (R3): a ring appears only when the session is NOT open
   // on this device. Remote activity comes from other devices' pushed registry
   // snapshots; the suppression set unions three local identity sources.
-  const remoteActivityBySessionKey = useAppSelector(selectRemoteSessionActivity)
-  const sameDeviceSessionKeys = useAppSelector(selectSameDeviceSessionKeys)
   const localOpenSessionKeys = useAppSelector((state) => {
     const keys = new Set<string>()
     for (const ref of collectSessionRefsFromTabs(

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -63,7 +63,7 @@ import {
   getCreateSessionStateFromRef,
   isStaleSessionIdentityMismatch,
 } from '@/components/terminal-view-utils'
-import { foldTerminalAliasActivity, reconcileTerminalSessionAssociation } from '@/lib/terminal-session-association'
+import { reconcileTerminalSessionAssociation } from '@/lib/terminal-session-association'
 import { copyText, readText } from '@/lib/clipboard'
 import { registerTerminalActions } from '@/lib/pane-action-registry'
 import { registerTerminalCaptureHandler } from '@/lib/screenshot-capture-env'
@@ -4768,19 +4768,12 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
           // Durability identity is itself a binding path: the sidebar rekeys
           // the terminal's row from codex:terminal:<id> to
           // codex:<durabilitySessionId> (mirroring getCodexDurabilitySessionId
-          // in selectors/sidebarSelectors.ts), so fold the close-tab alias the
-          // same way reconcileTerminalSessionAssociation does for sessionRef.
-          const durabilitySessionId = durability?.durableThreadId
-            ?? durability?.candidate?.candidateThreadId
-          if (durabilitySessionId) {
-            foldTerminalAliasActivity({
-              dispatch,
-              state: appStore.getState(),
-              terminalId: tid,
-              provider: 'codex',
-              sessionId: durabilitySessionId,
-            })
-          }
+          // in selectors/sidebarSelectors.ts). The close-tab alias fold for
+          // that rekey lives in fetchTerminalDirectoryWindow (the store-level
+          // directory-apply choke point): the Node server broadcasts
+          // terminals.changed immediately after this frame, so the refreshed
+          // directory item carries durability identity and the fold runs there
+          // whether or not any pane is still mounted.
           updateContent({ codexDurability: durability })
           const currentTab = tabHasSinglePaneRef.current ? tabRef.current : undefined
           if (currentTab) {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -63,7 +63,7 @@ import {
   getCreateSessionStateFromRef,
   isStaleSessionIdentityMismatch,
 } from '@/components/terminal-view-utils'
-import { reconcileTerminalSessionAssociation } from '@/lib/terminal-session-association'
+import { foldTerminalAliasActivity, reconcileTerminalSessionAssociation } from '@/lib/terminal-session-association'
 import { copyText, readText } from '@/lib/clipboard'
 import { registerTerminalActions } from '@/lib/pane-action-registry'
 import { registerTerminalCaptureHandler } from '@/lib/screenshot-capture-env'
@@ -4764,6 +4764,22 @@ function TerminalView({ tabId, paneId, paneContent, hidden }: TerminalViewProps)
               durability,
             })
             return
+          }
+          // Durability identity is itself a binding path: the sidebar rekeys
+          // the terminal's row from codex:terminal:<id> to
+          // codex:<durabilitySessionId> (mirroring getCodexDurabilitySessionId
+          // in selectors/sidebarSelectors.ts), so fold the close-tab alias the
+          // same way reconcileTerminalSessionAssociation does for sessionRef.
+          const durabilitySessionId = durability?.durableThreadId
+            ?? durability?.candidate?.candidateThreadId
+          if (durabilitySessionId) {
+            foldTerminalAliasActivity({
+              dispatch,
+              state: appStore.getState(),
+              terminalId: tid,
+              provider: 'codex',
+              sessionId: durabilitySessionId,
+            })
           }
           updateContent({ codexDurability: durability })
           const currentTab = tabHasSinglePaneRef.current ? tabRef.current : undefined

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -6,7 +6,7 @@ import { isNonShellMode } from '@/lib/coding-cli-utils'
 import { resolveFreshAgentType } from '@/lib/fresh-agent-registry'
 import type { PaneContent, PaneNode } from '@/store/paneTypes'
 import type { RootState } from '@/store/store'
-import type { CodingCliProviderName } from '@/store/types'
+import type { BackgroundTerminal, CodingCliProviderName } from '@/store/types'
 import { isValidClaudeSessionId } from '@/lib/claude-session-id'
 
 type SessionMatchLocator = {
@@ -302,6 +302,41 @@ export function collectSessionRefsFromTabs(
     })),
     sessionKey,
   )
+}
+
+export interface LiveTerminalFallbackIdentity {
+  provider: CodingCliProviderName
+  /** activity/sessionActivity bucket key: `<mode>:terminal:<terminalId>` */
+  key: string
+}
+
+/**
+ * Identity of the sidebar's live-terminal fallback row for a registry
+ * terminal WITHOUT canonical session identity (see the `for (const terminal
+ * of terminals)` loop in store/selectors/sidebarSelectors.ts): shown keyed
+ * `<mode>:terminal:<terminalId>`, read from sessionActivity under that key.
+ * Returns undefined exactly when the registry terminal produces no such row:
+ * not running, carrying a sessionRef (canonical identity instead), shell or
+ * unset mode, or codex with a durability session id — that row is keyed
+ * `codex:<durabilitySessionId>` and is covered by the canonical refs loop.
+ * The predicate MUST stay in sync with the sidebar selector's loop guard.
+ */
+export function liveTerminalFallbackIdentity(
+  terminal: Pick<BackgroundTerminal, 'terminalId' | 'status' | 'mode' | 'sessionRef' | 'codexDurability'> | undefined,
+): LiveTerminalFallbackIdentity | undefined {
+  if (!terminal) return undefined
+  if (terminal.status !== 'running') return undefined
+  if (terminal.sessionRef) return undefined
+  if (!isNonShellMode(terminal.mode)) return undefined
+  if (
+    terminal.mode === 'codex'
+    && (terminal.codexDurability?.durableThreadId
+      ?? terminal.codexDurability?.candidate?.candidateThreadId)
+  ) {
+    return undefined
+  }
+  const provider = terminal.mode as CodingCliProviderName
+  return { provider, key: `${provider}:terminal:${terminal.terminalId}` }
 }
 
 export function getActiveSessionRefForTab(state: RootState, tabId: string): SessionRef | undefined {

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -304,39 +304,65 @@ export function collectSessionRefsFromTabs(
   )
 }
 
-export interface LiveTerminalFallbackIdentity {
+export interface LiveTerminalRowIdentity {
   provider: CodingCliProviderName
-  /** activity/sessionActivity bucket key: `<mode>:terminal:<terminalId>` */
+  /** activity/sessionActivity bucket key the sidebar row reads */
   key: string
 }
 
 /**
- * Identity of the sidebar's live-terminal fallback row for a registry
- * terminal WITHOUT canonical session identity (see the `for (const terminal
- * of terminals)` loop in store/selectors/sidebarSelectors.ts): shown keyed
- * `<mode>:terminal:<terminalId>`, read from sessionActivity under that key.
- * Returns undefined exactly when the registry terminal produces no such row:
- * not running, carrying a sessionRef (canonical identity instead), shell or
- * unset mode, or codex with a durability session id — that row is keyed
- * `codex:<durabilitySessionId>` and is covered by the canonical refs loop.
- * The predicate MUST stay in sync with the sidebar selector's loop guard.
+ * Activity key of the sidebar row a closing tab's leaf content corresponds
+ * to, for contents whose own canonical identity (extractSessionLocators) is
+ * empty — those contents are already ratcheted by the canonical refs loop in
+ * closeTab, so this returns undefined for them (never a second key).
+ *
+ * For the rest, the registry terminal (resolved by the caller via the
+ * content's terminalId) decides, in priority order:
+ *
+ * 1. registry sessionRef → the canonical `<provider>:<sessionId>` row key
+ *    (the identity-less alias would be junk: no row ever reads it);
+ * 2. registry codex durability → the canonical `codex:<durabilitySessionId>`
+ *    row key (mirrors getCodexDurabilitySessionId in sidebarSelectors.ts);
+ * 3. running, identity-less, non-shell registry terminal → the live-terminal
+ *    fallback row key `<mode>:terminal:<terminalId>` (the `for (const
+ *    terminal of terminals)` loop in store/selectors/sidebarSelectors.ts —
+ *    the predicate MUST stay in sync with that loop's guard);
+ * 4. NO registry entry at all (directory not yet loaded, failed, stale, or
+ *    paged out) → the content's own `<mode>:terminal:<terminalId>` key, so
+ *    the still-running terminal's fallback row sorts fresh once it appears.
+ *
+ * Returns undefined when no sidebar row can result: non-terminal content,
+ * no terminalId, or a registry terminal that exists but is not running and
+ * carries no canonical identity (its live row is gone).
  */
-export function liveTerminalFallbackIdentity(
+export function liveTerminalRowIdentity(
+  content: PaneContent,
   terminal: Pick<BackgroundTerminal, 'terminalId' | 'status' | 'mode' | 'sessionRef' | 'codexDurability'> | undefined,
-): LiveTerminalFallbackIdentity | undefined {
-  if (!terminal) return undefined
-  if (terminal.status !== 'running') return undefined
-  if (terminal.sessionRef) return undefined
-  if (!isNonShellMode(terminal.mode)) return undefined
-  if (
-    terminal.mode === 'codex'
-    && (terminal.codexDurability?.durableThreadId
-      ?? terminal.codexDurability?.candidate?.candidateThreadId)
-  ) {
-    return undefined
+): LiveTerminalRowIdentity | undefined {
+  if (content.kind !== 'terminal' || !content.terminalId) return undefined
+  if (extractSessionLocators(content).length > 0) return undefined
+
+  if (terminal) {
+    const sessionRef = sanitizeSessionLocator(terminal.sessionRef)
+    if (sessionRef) {
+      return { provider: sessionRef.provider, key: `${sessionRef.provider}:${sessionRef.sessionId}` }
+    }
+    const durabilitySessionId = terminal.mode === 'codex'
+      ? terminal.codexDurability?.durableThreadId
+        ?? terminal.codexDurability?.candidate?.candidateThreadId
+      : undefined
+    if (durabilitySessionId) {
+      return { provider: 'codex', key: `codex:${durabilitySessionId}` }
+    }
+    if (terminal.status !== 'running') return undefined
+    if (!isNonShellMode(terminal.mode)) return undefined
+    const provider = terminal.mode as CodingCliProviderName
+    return { provider, key: `${provider}:terminal:${terminal.terminalId}` }
   }
-  const provider = terminal.mode as CodingCliProviderName
-  return { provider, key: `${provider}:terminal:${terminal.terminalId}` }
+
+  if (!isNonShellMode(content.mode)) return undefined
+  const provider = content.mode as CodingCliProviderName
+  return { provider, key: `${provider}:terminal:${content.terminalId}` }
 }
 
 export function getActiveSessionRefForTab(state: RootState, tabId: string): SessionRef | undefined {

--- a/src/lib/terminal-session-association.ts
+++ b/src/lib/terminal-session-association.ts
@@ -4,13 +4,46 @@ import {
   buildTerminalDurableSessionRefUpdate,
   flushPersistedLayoutNow,
 } from '@/store/persistControl'
+import { updateSessionActivity } from '@/store/sessionActivitySlice'
 import type { PaneNode, TerminalPaneContent } from '@/store/paneTypes'
 import type { RootState } from '@/store/store'
 import type { CodingCliProviderName } from '@/store/types'
 import { sanitizeSessionRef, type SessionRef } from '@shared/session-contract'
 
 type Dispatch = (action: any) => unknown
-type SessionAssociationState = Pick<RootState, 'panes' | 'tabs'>
+type SessionAssociationState = Pick<RootState, 'panes' | 'tabs' | 'sessionActivity'>
+
+/**
+ * Migration fold for the close-tab ratchet alias: a terminal identity-less
+ * at close time had its touch recorded under
+ * `<provider>:terminal:<terminalId>` (liveTerminalRowIdentity in
+ * lib/session-utils.ts — the sidebar's identity-less live-terminal row key).
+ * When the terminal later acquires canonical identity, the sidebar rekeys
+ * the row to `<provider>:<sessionId>` and reads activity only from there,
+ * so the alias timestamp must be folded across at each binding point
+ * (sessionRef association here; codex durability in TerminalView's
+ * terminal.codex.durability.updated handler). updateSessionActivity is
+ * ratchet-only (max wins), so folding is safe even when the canonical key
+ * already holds a newer value. The alias entry may remain stored — no
+ * selector reads it once identity binds.
+ */
+export function foldTerminalAliasActivity({
+  dispatch,
+  state,
+  terminalId,
+  provider,
+  sessionId,
+}: {
+  dispatch: Dispatch
+  state: Pick<RootState, 'sessionActivity'>
+  terminalId: string
+  provider: string
+  sessionId: string
+}): void {
+  const aliasAt = state.sessionActivity?.sessions?.[`${provider}:terminal:${terminalId}`]
+  if (typeof aliasAt !== 'number') return
+  dispatch(updateSessionActivity({ sessionId, provider, lastInputAt: aliasAt }))
+}
 
 function collectMatchingTerminalPanes(
   node: PaneNode | undefined,
@@ -77,6 +110,18 @@ export function reconcileTerminalSessionAssociation({
   if (!sessionRef) return 'ignored'
 
   const state = getState()
+
+  // Alias migration must NOT depend on the pane-match outcome below: the
+  // orphan case is precisely a post-close association, where the tab is gone
+  // and no pane is left to match.
+  foldTerminalAliasActivity({
+    dispatch,
+    state,
+    terminalId,
+    provider: sessionRef.provider,
+    sessionId: sessionRef.sessionId,
+  })
+
   let matchedAnyPane = false
   let conflictingPane = false
   let shouldFlush = false

--- a/src/lib/terminal-session-association.ts
+++ b/src/lib/terminal-session-association.ts
@@ -21,11 +21,13 @@ type SessionAssociationState = Pick<RootState, 'panes' | 'tabs' | 'sessionActivi
  * When the terminal later acquires canonical identity, the sidebar rekeys
  * the row to `<provider>:<sessionId>` and reads activity only from there,
  * so the alias timestamp must be folded across at each binding point
- * (sessionRef association here; codex durability in TerminalView's
- * terminal.codex.durability.updated handler). updateSessionActivity is
- * ratchet-only (max wins), so folding is safe even when the canonical key
- * already holds a newer value. The alias entry may remain stored — no
- * selector reads it once identity binds.
+ * (sessionRef association here; codex durability identity in
+ * fetchTerminalDirectoryWindow in store/terminalDirectoryThunks.ts — the
+ * store-level directory-apply choke point, reached by every
+ * terminals.changed refresh whether or not any pane is mounted).
+ * updateSessionActivity is ratchet-only (max wins), so folding is safe even
+ * when the canonical key already holds a newer value. The alias entry may
+ * remain stored — no selector reads it once identity binds.
  */
 export function foldTerminalAliasActivity({
   dispatch,
@@ -111,17 +113,6 @@ export function reconcileTerminalSessionAssociation({
 
   const state = getState()
 
-  // Alias migration must NOT depend on the pane-match outcome below: the
-  // orphan case is precisely a post-close association, where the tab is gone
-  // and no pane is left to match.
-  foldTerminalAliasActivity({
-    dispatch,
-    state,
-    terminalId,
-    provider: sessionRef.provider,
-    sessionId: sessionRef.sessionId,
-  })
-
   let matchedAnyPane = false
   let conflictingPane = false
   let shouldFlush = false
@@ -157,6 +148,21 @@ export function reconcileTerminalSessionAssociation({
   }
 
   if (conflictingPane) return 'conflict'
+
+  // Alias migration runs only once the association is known NOT to conflict:
+  // folding a rejected frame's alias onto the pane's canonical session would
+  // stamp recent activity onto a session that never bound, visibly
+  // misordering the sidebar. It must NOT depend on the pane-match outcome --
+  // the orphan case is precisely a post-close association, where the tab is
+  // gone and no pane is left to match.
+  foldTerminalAliasActivity({
+    dispatch,
+    state,
+    terminalId,
+    provider: sessionRef.provider,
+    sessionId: sessionRef.sessionId,
+  })
+
   if (!matchedAnyPane) return 'ignored'
 
   dispatch(reconcileTerminalSessionRefByTerminalId({ terminalId, sessionRef }))

--- a/src/lib/terminal-session-association.ts
+++ b/src/lib/terminal-session-association.ts
@@ -14,6 +14,31 @@ type Dispatch = (action: any) => unknown
 type SessionAssociationState = Pick<RootState, 'panes' | 'tabs' | 'sessionActivity'>
 
 /**
+ * Shared ratchet-only migration core: copy the activity stored under one
+ * sidebar row key onto a canonical session key. updateSessionActivity is
+ * ratchet-only (max wins), so folding is safe even when the canonical key
+ * already holds a newer value. The source entry may remain stored — old keys
+ * are pruned by the slice's existing retention.
+ */
+function foldSessionActivityFromKey({
+  dispatch,
+  state,
+  fromKey,
+  provider,
+  sessionId,
+}: {
+  dispatch: Dispatch
+  state: Pick<RootState, 'sessionActivity'>
+  fromKey: string
+  provider: string
+  sessionId: string
+}): void {
+  const fromAt = state.sessionActivity?.sessions?.[fromKey]
+  if (typeof fromAt !== 'number') return
+  dispatch(updateSessionActivity({ sessionId, provider, lastInputAt: fromAt }))
+}
+
+/**
  * Migration fold for the close-tab ratchet alias: a terminal identity-less
  * at close time had its touch recorded under
  * `<provider>:terminal:<terminalId>` (liveTerminalRowIdentity in
@@ -25,9 +50,6 @@ type SessionAssociationState = Pick<RootState, 'panes' | 'tabs' | 'sessionActivi
  * fetchTerminalDirectoryWindow in store/terminalDirectoryThunks.ts — the
  * store-level directory-apply choke point, reached by every
  * terminals.changed refresh whether or not any pane is mounted).
- * updateSessionActivity is ratchet-only (max wins), so folding is safe even
- * when the canonical key already holds a newer value. The alias entry may
- * remain stored — no selector reads it once identity binds.
  */
 export function foldTerminalAliasActivity({
   dispatch,
@@ -42,9 +64,47 @@ export function foldTerminalAliasActivity({
   provider: string
   sessionId: string
 }): void {
-  const aliasAt = state.sessionActivity?.sessions?.[`${provider}:terminal:${terminalId}`]
-  if (typeof aliasAt !== 'number') return
-  dispatch(updateSessionActivity({ sessionId, provider, lastInputAt: aliasAt }))
+  foldSessionActivityFromKey({
+    dispatch,
+    state,
+    fromKey: `${provider}:terminal:${terminalId}`,
+    provider,
+    sessionId,
+  })
+}
+
+/**
+ * Migration fold for a canonical-to-canonical rebind (codex fork handoff):
+ * a terminal closed while carrying the PARENT identity had its touch
+ * recorded under `<provider>:<previousSessionId>` — liveTerminalRowIdentity
+ * deliberately yields no terminal alias for identity-bearing content. When
+ * the rebind is accepted and the sidebar rekeys the row to
+ * `<provider>:<sessionId>`, the superseded key's timestamp must be folded
+ * across the same way the terminal alias is, or the child row loses the
+ * close-touch float. previousSessionId equal to sessionId folds nothing
+ * (source and target would be the same key).
+ */
+export function foldCanonicalSessionActivity({
+  dispatch,
+  state,
+  provider,
+  previousSessionId,
+  sessionId,
+}: {
+  dispatch: Dispatch
+  state: Pick<RootState, 'sessionActivity'>
+  provider: string
+  previousSessionId: string
+  sessionId: string
+}): void {
+  if (previousSessionId.length === 0 || previousSessionId === sessionId) return
+  foldSessionActivityFromKey({
+    dispatch,
+    state,
+    fromKey: `${provider}:${previousSessionId}`,
+    provider,
+    sessionId,
+  })
 }
 
 function collectMatchingTerminalPanes(
@@ -162,6 +222,21 @@ export function reconcileTerminalSessionAssociation({
     provider: sessionRef.provider,
     sessionId: sessionRef.sessionId,
   })
+
+  // Canonical-to-canonical migration on a server-authoritative rebind:
+  // previousSessionId names the superseded session, whose stored activity
+  // (e.g. the close-tab touch recorded under the parent key — identity-
+  // bearing closes never write a terminal alias) folds onto the new key.
+  // Same conflict-gate and pane-match independence rules as the alias fold.
+  if (typeof previousSessionId === 'string') {
+    foldCanonicalSessionActivity({
+      dispatch,
+      state,
+      provider: sessionRef.provider,
+      previousSessionId,
+      sessionId: sessionRef.sessionId,
+    })
+  }
 
   if (!matchedAnyPane) return 'ignored'
 

--- a/src/store/selectors/sidebarSelectors.ts
+++ b/src/store/selectors/sidebarSelectors.ts
@@ -667,10 +667,38 @@ export function filterSessionItemsByVisibility(
   })
 }
 
+export type PinnedStatusTier = 1 | 2 | 3 | 4
+
+export interface PinnedSortStatus {
+  /** Sessions currently busy on this device, keyed `provider:sessionId`. */
+  busySessionKeys?: ReadonlySet<string>
+  /** Per-session activity on OTHER devices (the fold already resolves busy-over-open). */
+  remoteActivity?: Record<string, 'busy' | 'open'>
+}
+
+/**
+ * Strict 4-way partition of pinned (hasTab) rows (coordinator decision A):
+ *   1 = busy on this device (blue) · 2 = open here, not busy, no remote state
+ *   3 = busy on another device (blue ring data) · 4 = open on another device (green ring data)
+ * Local busy beats any remote state; tier 2 is the catch-all "remaining pinned"
+ * bucket — exactly the rows rendering the sidebar's plain local green icon.
+ */
+export function resolvePinnedStatusTier(
+  item: SidebarSessionItem,
+  pinnedStatus?: PinnedSortStatus,
+): PinnedStatusTier {
+  const key = `${item.provider}:${item.sessionId}`
+  if (pinnedStatus?.busySessionKeys?.has(key)) return 1
+  const remote = pinnedStatus?.remoteActivity?.[key]
+  if (remote === 'busy') return 3
+  if (remote === 'open') return 4
+  return 2
+}
+
 export function sortSessionItems(
   items: SidebarSessionItem[],
   sortMode: string,
-  options?: { disableTabPinning?: boolean },
+  options?: { disableTabPinning?: boolean; pinnedStatus?: PinnedSortStatus },
 ): SidebarSessionItem[] {
   const sorted = [...items]
 
@@ -691,6 +719,11 @@ export function sortSessionItems(
     return bTime - aTime || compareBySessionKey(a, b)
   }
 
+  // Pinned status tier asc, then the mode's existing within-tier time
+  // comparator (decisions A/B). With no pinnedStatus every pinned row is
+  // tier 2, so tiering degenerates to the legacy comparators exactly.
+  const tierOf = (item: SidebarSessionItem) => resolvePinnedStatusTier(item, options?.pinnedStatus)
+
   const sortByMode = (list: SidebarSessionItem[]) => {
     const copy = [...list]
 
@@ -706,7 +739,11 @@ export function sortSessionItems(
       const withTabs = copy.filter((i) => i.hasTab)
       const withoutTabs = copy.filter((i) => !i.hasTab)
 
-      withTabs.sort(compareByRecency)
+      withTabs.sort((a, b) => {
+        const tierDelta = tierOf(a) - tierOf(b)
+        if (tierDelta !== 0) return tierDelta
+        return compareByRecency(a, b)
+      })
       withoutTabs.sort(compareByRecency)
 
       return [...withTabs, ...withoutTabs]
@@ -721,6 +758,8 @@ export function sortSessionItems(
       const withoutTabs = copy.filter((i) => !i.hasTab)
 
       withTabs.sort((a, b) => {
+        const tierDelta = tierOf(a) - tierOf(b)
+        if (tierDelta !== 0) return tierDelta
         const aTime = a.ratchetedActivity ?? a.timestamp
         const bTime = b.ratchetedActivity ?? b.timestamp
         return bTime - aTime || compareBySessionKey(a, b)

--- a/src/store/selectors/sidebarSelectors.ts
+++ b/src/store/selectors/sidebarSelectors.ts
@@ -50,6 +50,7 @@ export interface SidebarSessionItem {
 const EMPTY_ACTIVITY: Record<string, number> = {}
 const EMPTY_STRINGS: string[] = []
 const EMPTY_PANE_LAST_INPUT_AT: Record<string, number | undefined> = {}
+const EMPTY_PINNED_STATUS: PinnedSortStatus = { busySessionKeys: new Set<string>(), remoteActivity: {} }
 
 const selectProjects = (state: RootState) => state.sessions.windows?.sidebar?.projects ?? state.sessions.projects
 const selectTabs = (state: RootState) => state.tabs.tabs
@@ -72,6 +73,12 @@ const selectAppliedQuery = (state: RootState) => state.sessions.windows?.sidebar
 const selectAppliedSearchTier = (state: RootState) => state.sessions.windows?.sidebar?.appliedSearchTier
 const selectTerminals = (_state: RootState, terminals: BackgroundTerminal[]) => terminals
 const selectFilter = (_state: RootState, _terminals: BackgroundTerminal[], filter: string) => filter
+const selectPinnedStatus = (
+  _state: RootState,
+  _terminals: BackgroundTerminal[],
+  _filter: string,
+  pinnedStatus?: PinnedSortStatus,
+): PinnedSortStatus => pinnedStatus ?? EMPTY_PINNED_STATUS
 
 function getProjectName(projectPath: string): string {
   return getLeafDirectoryName(projectPath) ?? projectPath
@@ -812,6 +819,7 @@ export const makeSelectSortedSessionItems = () =>
       selectAppliedSearchTier,
       selectTerminals,
       selectFilter,
+      selectPinnedStatus,
     ],
     (
       projects,
@@ -830,7 +838,8 @@ export const makeSelectSortedSessionItems = () =>
       appliedQuery,
       appliedSearchTier,
       terminals,
-      filter
+      filter,
+      pinnedStatus
     ) => {
       const items = buildSessionItems(projects, tabs, panes, terminals, sessionActivity, worktreeGrouping, paneLastInputAt)
       const visible = filterSessionItemsByVisibility(items, {
@@ -845,6 +854,7 @@ export const makeSelectSortedSessionItems = () =>
       const filtered = filterSessionItems(searchAware, filter)
       return sortSessionItems(filtered, sortMode, {
         disableTabPinning: appliedQuery.trim().length > 0,
+        pinnedStatus,
       })
     }
   )

--- a/src/store/selectors/sidebarSelectors.ts
+++ b/src/store/selectors/sidebarSelectors.ts
@@ -477,6 +477,10 @@ export function buildSessionItems(
   }
 
   for (const terminal of terminals || []) {
+    // Row-identity contract: the guard below must stay in sync with
+    // liveTerminalFallbackIdentity in lib/session-utils.ts — the close-tab
+    // ratchet in tabsSlice.ts uses it to write the activity key this loop
+    // reads (`<mode>:terminal:<terminalId>` at :522) for identity-less rows.
     if (terminal.status !== 'running') continue
     if (terminal.sessionRef) continue
     if (!terminal.mode || terminal.mode === 'shell' || !isNonShellMode(terminal.mode)) continue

--- a/src/store/selectors/sidebarSelectors.ts
+++ b/src/store/selectors/sidebarSelectors.ts
@@ -478,7 +478,7 @@ export function buildSessionItems(
 
   for (const terminal of terminals || []) {
     // Row-identity contract: the guard below must stay in sync with
-    // liveTerminalFallbackIdentity in lib/session-utils.ts — the close-tab
+    // liveTerminalRowIdentity in lib/session-utils.ts — the close-tab
     // ratchet in tabsSlice.ts uses it to write the activity key this loop
     // reads (`<mode>:terminal:<terminalId>` at :522) for identity-less rows.
     if (terminal.status !== 'running') continue

--- a/src/store/selectors/sidebarSelectors.ts
+++ b/src/store/selectors/sidebarSelectors.ts
@@ -480,7 +480,8 @@ export function buildSessionItems(
     // Row-identity contract: the guard below must stay in sync with
     // liveTerminalRowIdentity in lib/session-utils.ts — the close-tab
     // ratchet in tabsSlice.ts uses it to write the activity key this loop
-    // reads (`<mode>:terminal:<terminalId>` at :522) for identity-less rows.
+    // reads for identity-less rows: `<mode>:terminal:<terminalId>`, built
+    // below from liveTerminalSessionId and read via sessionActivity[key].
     if (terminal.status !== 'running') continue
     if (terminal.sessionRef) continue
     if (!terminal.mode || terminal.mode === 'shell' || !isNonShellMode(terminal.mode)) continue

--- a/src/store/tabsSlice.ts
+++ b/src/store/tabsSlice.ts
@@ -4,8 +4,8 @@ import { nanoid } from 'nanoid'
 import { closePane, initLayout, restoreLayout, removeLayout, updatePaneContent, updatePaneTitleByTerminalId, updatePaneTitle } from './panesSlice'
 import { clearTabAttention, clearPaneAttention } from './turnCompletionSlice.js'
 import type { PaneContent, PaneNode } from './paneTypes'
-import { findTabIdForSession, collectSessionRefsFromTabs, liveTerminalFallbackIdentity } from '@/lib/session-utils'
-import { collectTerminalIds } from '@/lib/pane-utils'
+import { findTabIdForSession, collectSessionRefsFromTabs, liveTerminalRowIdentity } from '@/lib/session-utils'
+import { collectPaneContents } from '@/lib/pane-utils'
 import { getProviderLabel } from '@/lib/coding-cli-utils'
 import { basenameSegment } from '@shared/path-basename'
 import { buildResumeContent } from '@/lib/session-type-utils'
@@ -503,19 +503,24 @@ export const closeTab = createAsyncThunk(
           lastInputAt: touchedAt,
         }))
       }
-      // The sidebar also renders running registry terminals WITHOUT canonical
-      // session identity as fallback rows keyed `<mode>:terminal:<terminalId>`
-      // (the live-terminal loop in selectors/sidebarSelectors.ts). Those rows
-      // persist in the grey section after close — the terminal keeps running —
-      // so ratchet that key as well. Registry read uses the same guarded
-      // cross-slice cast as Sidebar.tsx / the tabRegistry read below.
+      // Leaf contents whose own canonical locators are empty still correspond
+      // to sidebar rows the canonical loop above cannot reach: registry-only
+      // canonical identity (sessionRef / codex durability known only to the
+      // registry), live-terminal fallback rows keyed
+      // `<mode>:terminal:<terminalId>`, and terminals whose registry entry
+      // hasn't loaded yet. liveTerminalRowIdentity resolves the right key (or
+      // none) per content; registry read uses the same guarded cross-slice
+      // cast as Sidebar.tsx / the tabRegistry read below.
       if (layout) {
         const directoryItems = (stateBeforeClose as {
           terminalDirectory?: RootState['terminalDirectory']
         }).terminalDirectory?.windows?.sidebar?.items
-        for (const terminalId of collectTerminalIds(layout)) {
-          const identity = liveTerminalFallbackIdentity(
-            directoryItems?.find((item) => item.terminalId === terminalId),
+        for (const content of collectPaneContents(layout)) {
+          const identity = liveTerminalRowIdentity(
+            content,
+            content.kind === 'terminal' && content.terminalId
+              ? directoryItems?.find((item) => item.terminalId === content.terminalId)
+              : undefined,
           )
           if (!identity) continue
           // identity.key is pre-composed and contains colons, so

--- a/src/store/tabsSlice.ts
+++ b/src/store/tabsSlice.ts
@@ -4,7 +4,8 @@ import { nanoid } from 'nanoid'
 import { closePane, initLayout, restoreLayout, removeLayout, updatePaneContent, updatePaneTitleByTerminalId, updatePaneTitle } from './panesSlice'
 import { clearTabAttention, clearPaneAttention } from './turnCompletionSlice.js'
 import type { PaneContent, PaneNode } from './paneTypes'
-import { findTabIdForSession, collectSessionRefsFromTabs } from '@/lib/session-utils'
+import { findTabIdForSession, collectSessionRefsFromTabs, liveTerminalFallbackIdentity } from '@/lib/session-utils'
+import { collectTerminalIds } from '@/lib/pane-utils'
 import { getProviderLabel } from '@/lib/coding-cli-utils'
 import { basenameSegment } from '@shared/path-basename'
 import { buildResumeContent } from '@/lib/session-type-utils'
@@ -501,6 +502,31 @@ export const closeTab = createAsyncThunk(
           provider: ref.provider,
           lastInputAt: touchedAt,
         }))
+      }
+      // The sidebar also renders running registry terminals WITHOUT canonical
+      // session identity as fallback rows keyed `<mode>:terminal:<terminalId>`
+      // (the live-terminal loop in selectors/sidebarSelectors.ts). Those rows
+      // persist in the grey section after close — the terminal keeps running —
+      // so ratchet that key as well. Registry read uses the same guarded
+      // cross-slice cast as Sidebar.tsx / the tabRegistry read below.
+      if (layout) {
+        const directoryItems = (stateBeforeClose as {
+          terminalDirectory?: RootState['terminalDirectory']
+        }).terminalDirectory?.windows?.sidebar?.items
+        for (const terminalId of collectTerminalIds(layout)) {
+          const identity = liveTerminalFallbackIdentity(
+            directoryItems?.find((item) => item.terminalId === terminalId),
+          )
+          if (!identity) continue
+          // identity.key is pre-composed and contains colons, so
+          // makeSessionKey passes it through unchanged (provider is kept for
+          // parity with the dispatch above, not for key construction).
+          dispatch(updateSessionActivity({
+            sessionId: identity.key,
+            provider: identity.provider,
+            lastInputAt: touchedAt,
+          }))
+        }
       }
     }
     const tabRegistryState = (stateBeforeClose as { tabRegistry?: RootState['tabRegistry'] }).tabRegistry

--- a/src/store/tabsSlice.ts
+++ b/src/store/tabsSlice.ts
@@ -4,13 +4,14 @@ import { nanoid } from 'nanoid'
 import { closePane, initLayout, restoreLayout, removeLayout, updatePaneContent, updatePaneTitleByTerminalId, updatePaneTitle } from './panesSlice'
 import { clearTabAttention, clearPaneAttention } from './turnCompletionSlice.js'
 import type { PaneContent, PaneNode } from './paneTypes'
-import { findTabIdForSession } from '@/lib/session-utils'
+import { findTabIdForSession, collectSessionRefsFromTabs } from '@/lib/session-utils'
 import { getProviderLabel } from '@/lib/coding-cli-utils'
 import { basenameSegment } from '@shared/path-basename'
 import { buildResumeContent } from '@/lib/session-type-utils'
 import { getFreshAgentProviderConfig, getFreshAgentProviderLabel } from '@/lib/fresh-agent-provider-utils'
 import { resolveFreshAgentType } from '@/lib/fresh-agent-registry'
 import { recordClosedTabSnapshot, pushReopenEntry, popReopenEntry } from './tabRegistrySlice'
+import { updateSessionActivity } from './sessionActivitySlice'
 import { clearDraft } from '@/lib/draft-store'
 import {
   buildClosedTabRegistryRecord,
@@ -483,6 +484,25 @@ export const closeTab = createAsyncThunk(
     const stateBeforeClose = getState() as RootState
     const tab = stateBeforeClose.tabs.tabs.find((item) => item.id === tabId)
     const layout = stateBeforeClose.panes.layouts[tabId]
+    // Closing a tab counts as a user touch on its sessions: ratchet each
+    // session's locally-stored activity timestamp so the just-closed session
+    // floats to the top of the unpinned (grey) section under the default
+    // 'activity' sort. Refs come from the pre-close snapshot via
+    // collectSessionRefsFromTabs([tab], panes) — chosen over getTabSessionRefs
+    // because it also covers layout-less tabs via buildTabFallbackLocator
+    // (session-utils.ts:143-157). Unconditional by design: REST/MCP/server-
+    // broadcast closes flow through this same thunk on every connected client
+    // (accepted residual: ratcheting a mirrored close is harmless-to-useful).
+    if (tab) {
+      const touchedAt = Date.now()
+      for (const ref of collectSessionRefsFromTabs([tab], stateBeforeClose.panes)) {
+        dispatch(updateSessionActivity({
+          sessionId: ref.sessionId,
+          provider: ref.provider,
+          lastInputAt: touchedAt,
+        }))
+      }
+    }
     const tabRegistryState = (stateBeforeClose as { tabRegistry?: RootState['tabRegistry'] }).tabRegistry
     const serverInstanceId = stateBeforeClose.connection?.serverInstanceId || UNKNOWN_SERVER_INSTANCE_ID
     if (tab && layout && tabRegistryState) {

--- a/src/store/terminalDirectoryThunks.ts
+++ b/src/store/terminalDirectoryThunks.ts
@@ -2,7 +2,10 @@ import {
   getTerminalDirectoryPage,
   searchTerminalView,
 } from '@/lib/api'
-import { foldTerminalAliasActivity } from '@/lib/terminal-session-association'
+import {
+  foldCanonicalSessionActivity,
+  foldTerminalAliasActivity,
+} from '@/lib/terminal-session-association'
 import type { AppDispatch, RootState } from './store'
 import {
   clearTerminalSearch,
@@ -14,7 +17,37 @@ import {
   setTerminalSearchError,
   setTerminalSearchLoading,
   setTerminalSearchResults,
+  type TerminalDirectoryItem,
 } from './terminalDirectorySlice'
+
+/**
+ * Canonical identity the sidebar rows a directory item under — mirrors
+ * buildSessionItems' runningSessionMap derivation in
+ * selectors/sidebarSelectors.ts: sessionRef first, then the codex durability
+ * id for codex terminals (getCodexDurabilitySessionId). Items with neither
+ * are rowed under the identity-less `<mode>:terminal:<terminalId>` fallback
+ * key, which is not a canonical identity.
+ */
+function directoryItemCanonicalIdentity(
+  item: TerminalDirectoryItem,
+): { provider: string; sessionId: string } | undefined {
+  const ref = item?.sessionRef
+  if (
+    typeof ref?.provider === 'string'
+    && typeof ref.sessionId === 'string'
+    && ref.sessionId.length > 0
+  ) {
+    return { provider: ref.provider, sessionId: ref.sessionId }
+  }
+  if (item?.mode === 'codex') {
+    const durabilitySessionId = item.codexDurability?.durableThreadId
+      ?? item.codexDurability?.candidate?.candidateThreadId
+    if (typeof durabilitySessionId === 'string' && durabilitySessionId.length > 0) {
+      return { provider: 'codex', sessionId: durabilitySessionId }
+    }
+  }
+  return undefined
+}
 
 type TerminalDirectorySurface = 'sidebar' | 'background' | 'overview'
 
@@ -83,20 +116,52 @@ export function fetchTerminalDirectoryWindow(args: FetchTerminalDirectoryWindowA
       })
       if (controller.signal.aborted) return
 
-      // Codex durability identity is a sidebar binding path: a running codex
-      // terminal with durability identity is rowed under
-      // codex:<durabilitySessionId> (getCodexDurabilitySessionId in
-      // selectors/sidebarSelectors.ts), never under the identity-less
-      // codex:terminal:<terminalId> close-tab alias. This thunk is the
-      // store-level choke point where refreshed directory data is applied,
-      // and the refresh fires on every terminals.changed broadcast (the Node
-      // server broadcasts terminals.changed immediately after
-      // terminal.codex.durability.updated), mounted or not — so the alias
-      // fold lives here, where a paneless post-close binding still reaches it.
+      // Close-tab activity migration runs at this store-level choke point —
+      // the sidebar rows running terminals straight from the applied window
+      // (buildSessionItems reads terminalDirectory.windows.sidebar.items;
+      // the directory never passes through
+      // reconcileTerminalSessionAssociation), and the refresh fires on every
+      // terminals.changed broadcast as well as on (re)connect, mounted or
+      // not. Two folds, both ratchet-only:
+      //
+      // 1. Canonical-to-canonical: the terminal.session.associated frame
+      //    carrying previousSessionId is a single transient broadcast, so a
+      //    client disconnected at rebind time only ever sees a codex fork
+      //    handoff as the SAME terminalId swapping canonical identity between
+      //    two applied pages. The previous window is the only record of the
+      //    superseded identity — fold its activity onto the new one.
+      // 2. Alias-to-canonical: a codex terminal closed while identity-less
+      //    had its touch recorded under codex:terminal:<terminalId>; once the
+      //    refreshed item carries durability identity the row rekeys to
+      //    codex:<durabilitySessionId>, so fold the alias across.
       const items = Array.isArray(response?.items) ? response.items : []
       const stateBeforeFold = getState()
+      const previousIdentityByTerminalId = new Map<string, { provider: string; sessionId: string }>()
+      for (const previous of stateBeforeFold.terminalDirectory?.windows?.[args.surface]?.items ?? []) {
+        if (typeof previous?.terminalId !== 'string') continue
+        const identity = directoryItemCanonicalIdentity(previous)
+        if (identity) previousIdentityByTerminalId.set(previous.terminalId, identity)
+      }
       for (const item of items) {
-        if (item?.mode !== 'codex' || typeof item?.terminalId !== 'string') continue
+        if (typeof item?.terminalId !== 'string') continue
+        const identity = directoryItemCanonicalIdentity(item)
+        if (identity) {
+          const previous = previousIdentityByTerminalId.get(item.terminalId)
+          if (
+            previous
+            && previous.provider === identity.provider
+            && previous.sessionId !== identity.sessionId
+          ) {
+            foldCanonicalSessionActivity({
+              dispatch,
+              state: stateBeforeFold,
+              provider: identity.provider,
+              previousSessionId: previous.sessionId,
+              sessionId: identity.sessionId,
+            })
+          }
+        }
+        if (item?.mode !== 'codex') continue
         const durabilitySessionId = item.codexDurability?.durableThreadId
           ?? item.codexDurability?.candidate?.candidateThreadId
         if (!durabilitySessionId) continue

--- a/src/store/terminalDirectoryThunks.ts
+++ b/src/store/terminalDirectoryThunks.ts
@@ -2,6 +2,7 @@ import {
   getTerminalDirectoryPage,
   searchTerminalView,
 } from '@/lib/api'
+import { foldTerminalAliasActivity } from '@/lib/terminal-session-association'
 import type { AppDispatch, RootState } from './store'
 import {
   clearTerminalSearch,
@@ -82,9 +83,35 @@ export function fetchTerminalDirectoryWindow(args: FetchTerminalDirectoryWindowA
       })
       if (controller.signal.aborted) return
 
+      // Codex durability identity is a sidebar binding path: a running codex
+      // terminal with durability identity is rowed under
+      // codex:<durabilitySessionId> (getCodexDurabilitySessionId in
+      // selectors/sidebarSelectors.ts), never under the identity-less
+      // codex:terminal:<terminalId> close-tab alias. This thunk is the
+      // store-level choke point where refreshed directory data is applied,
+      // and the refresh fires on every terminals.changed broadcast (the Node
+      // server broadcasts terminals.changed immediately after
+      // terminal.codex.durability.updated), mounted or not — so the alias
+      // fold lives here, where a paneless post-close binding still reaches it.
+      const items = Array.isArray(response?.items) ? response.items : []
+      const stateBeforeFold = getState()
+      for (const item of items) {
+        if (item?.mode !== 'codex' || typeof item?.terminalId !== 'string') continue
+        const durabilitySessionId = item.codexDurability?.durableThreadId
+          ?? item.codexDurability?.candidate?.candidateThreadId
+        if (!durabilitySessionId) continue
+        foldTerminalAliasActivity({
+          dispatch,
+          state: stateBeforeFold,
+          terminalId: item.terminalId,
+          provider: 'codex',
+          sessionId: durabilitySessionId,
+        })
+      }
+
       dispatch(setTerminalDirectoryWindowData({
         surface: args.surface,
-        items: Array.isArray(response?.items) ? response.items : [],
+        items,
         revision: response?.revision,
         nextCursor: response?.nextCursor ?? null,
         append: args.append,

--- a/test/integration/activity-sort.test.tsx
+++ b/test/integration/activity-sort.test.tsx
@@ -1,11 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
 import settingsReducer from '@/store/settingsSlice'
-import { SESSION_ACTIVITY_STORAGE_KEY } from '@/store/sessionActivitySlice'
+import sessionActivityReducer, { SESSION_ACTIVITY_STORAGE_KEY } from '@/store/sessionActivitySlice'
+import tabsReducer, { addTab, closeTab } from '@/store/tabsSlice'
+import panesReducer, { initLayout } from '@/store/panesSlice'
+import {
+  sessionActivityPersistMiddleware,
+  SESSION_ACTIVITY_PERSIST_DEBOUNCE_MS,
+  resetSessionActivityFlushListenersForTests,
+} from '@/store/sessionActivityPersistence'
 
 describe('Activity sort integration', () => {
   beforeEach(() => {
     localStorage.clear()
+    resetSessionActivityFlushListenersForTests()
     vi.useFakeTimers()
   })
 
@@ -32,4 +40,40 @@ describe('Activity sort integration', () => {
 
     expect(store.getState().sessionActivity.sessions['session-123']).toBe(timestamp)
   }, 10000)
+
+  it('persists the close-tab activity ratchet to localStorage after the debounce', async () => {
+    const claudeSessionId = '550e8400-e29b-41d4-a716-446655440000'
+    const store = configureStore({
+      reducer: {
+        tabs: tabsReducer,
+        panes: panesReducer,
+        sessionActivity: sessionActivityReducer,
+      },
+      middleware: (getDefault) => getDefault().concat(sessionActivityPersistMiddleware),
+    })
+
+    store.dispatch(addTab({ mode: 'claude' }))
+    const tabId = store.getState().tabs.tabs[0].id
+    store.dispatch(initLayout({
+      tabId,
+      content: {
+        kind: 'terminal',
+        mode: 'claude',
+        resumeSessionId: claudeSessionId,
+        sessionRef: { provider: 'claude', sessionId: claudeSessionId },
+      },
+    }))
+
+    const beforeClose = Date.now()
+    await store.dispatch(closeTab(tabId))
+
+    expect(store.getState().sessionActivity.sessions[`claude:${claudeSessionId}`])
+      .toBeGreaterThanOrEqual(beforeClose)
+    expect(localStorage.getItem(SESSION_ACTIVITY_STORAGE_KEY)).toBeNull()
+
+    vi.advanceTimersByTime(SESSION_ACTIVITY_PERSIST_DEBOUNCE_MS)
+
+    const persisted = JSON.parse(localStorage.getItem(SESSION_ACTIVITY_STORAGE_KEY) || '{}')
+    expect(persisted[`claude:${claudeSessionId}`]).toBeGreaterThanOrEqual(beforeClose)
+  })
 })

--- a/test/unit/client/components/Sidebar.test.tsx
+++ b/test/unit/client/components/Sidebar.test.tsx
@@ -1199,6 +1199,75 @@ describe('Sidebar Component - Session-Centric Display', () => {
       expect(buttons[1]).toHaveTextContent('Never active session')
     })
 
+    it('orders a locally busy pinned session ahead of a newer idle pinned session', async () => {
+      const now = Date.now()
+      const busySid = sessionId('busy-pinned')
+      const idleSid = sessionId('idle-pinned')
+      const terminalId = 'term-busy-tier'
+      const projects: ProjectGroup[] = [
+        {
+          projectPath: '/home/user/project',
+          sessions: [
+            {
+              sessionId: busySid,
+              provider: 'codex',
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 60000,
+              title: 'Busy pinned session',
+              cwd: '/home/user/project',
+            },
+            {
+              sessionId: idleSid,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 1000,
+              title: 'Idle pinned session',
+              cwd: '/home/user/project',
+            },
+          ],
+        },
+      ]
+
+      const tabs = [
+        // Explicit sessionRef is load-bearing for this fixture: production
+        // `extractSessionLocators` does not treat a codex `resumeSessionId`
+        // as a locator, so without it this tab produces no session ref,
+        // `hasTab` stays false, and tier sorting never applies to the row
+        // (proven by executed check: extractSessionLocators(codex terminal
+        // content with only resumeSessionId) returns []).
+        { id: 'tab-busy', terminalId, resumeSessionId: busySid, sessionRef: { provider: 'codex', sessionId: busySid }, mode: 'codex' },
+        { id: 'tab-idle', resumeSessionId: idleSid, mode: 'claude' },
+      ]
+
+      const store = createTestStore({
+        projects,
+        tabs,
+        sortMode: 'activity',
+        codexActivity: {
+          byTerminalId: {
+            [terminalId]: {
+              terminalId,
+              sessionId: 'session-codex',
+              phase: 'busy',
+              updatedAt: 10,
+            },
+          },
+        },
+      })
+      renderSidebar(store, [])
+
+      await act(async () => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const buttons = screen.getAllByRole('button').filter(
+        (btn) => btn.textContent?.includes('pinned session')
+      )
+
+      // Busy (older) must lead the pinned section; idle (newer) follows.
+      expect(buttons[0]).toHaveTextContent('Busy pinned session')
+      expect(buttons[1]).toHaveTextContent('Idle pinned session')
+    })
+
     it('shows green indicator for sessions with tabs, muted for others', async () => {
       const now = Date.now()
       const projects: ProjectGroup[] = [

--- a/test/unit/client/components/Sidebar.test.tsx
+++ b/test/unit/client/components/Sidebar.test.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import Sidebar from '@/components/Sidebar'
 import settingsReducer, { defaultSettings } from '@/store/settingsSlice'
-import tabsReducer from '@/store/tabsSlice'
+import tabsReducer, { closeTab } from '@/store/tabsSlice'
 import panesReducer from '@/store/panesSlice'
 import connectionReducer from '@/store/connectionSlice'
 import sessionsReducer, {
@@ -1266,6 +1266,79 @@ describe('Sidebar Component - Session-Centric Display', () => {
       // Busy (older) must lead the pinned section; idle (newer) follows.
       expect(buttons[0]).toHaveTextContent('Busy pinned session')
       expect(buttons[1]).toHaveTextContent('Idle pinned session')
+    })
+
+    it('floats a just-closed session to the top of the grey section', async () => {
+      const now = Date.now()
+      const closerSid = sessionId('closing-float')
+      const greyNewerSid = sessionId('grey-newer')
+      const greyOlderSid = sessionId('grey-older')
+      const projects: ProjectGroup[] = [
+        {
+          projectPath: '/home/user/project',
+          sessions: [
+            {
+              sessionId: closerSid,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 7200000,
+              title: 'Closing session',
+              cwd: '/home/user/project',
+            },
+            {
+              sessionId: greyNewerSid,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 1000,
+              title: 'Grey newer session',
+              cwd: '/home/user/project',
+            },
+            {
+              sessionId: greyOlderSid,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 5000,
+              title: 'Grey older session',
+              cwd: '/home/user/project',
+            },
+          ],
+        },
+      ]
+
+      const tabs = [{ id: 'tab-closing', resumeSessionId: closerSid, mode: 'claude' }]
+      const store = createTestStore({ projects, tabs, sortMode: 'activity' })
+      renderSidebar(store, [])
+
+      await act(async () => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const buttons = () => screen.getAllByRole('button').filter(
+        // endsWith would never match: every session row button's textContent
+        // ends with the appended relative-timestamp span (Sidebar.tsx), so
+        // match with `includes`, exactly like the existing ratchet-float test
+        // at Sidebar.test.tsx:1154 ff.
+        (btn) => btn.textContent?.includes('session')
+      )
+
+      // Pinned first, then grey newest-first.
+      expect(buttons()[0]).toHaveTextContent('Closing session')
+      expect(buttons()[1]).toHaveTextContent('Grey newer session')
+      expect(buttons()[2]).toHaveTextContent('Grey older session')
+
+      const beforeClose = Date.now()
+      await act(async () => {
+        await store.dispatch(closeTab('tab-closing') as any)
+        vi.advanceTimersByTime(100)
+      })
+
+      // The close ratcheted the session's activity timestamp...
+      expect(store.getState().sessionActivity.sessions[`claude:${closerSid}`])
+        .toBeGreaterThanOrEqual(beforeClose)
+      // ...so the stale session — sort order [newer, older, closer] without it —
+      // lands on top of the grey section instead of sinking below both.
+      expect(buttons()).toHaveLength(3)
+      expect(buttons()[0]).toHaveTextContent('Closing session')
+      expect(buttons()[0]).toHaveAttribute('data-has-tab', 'false')
+      expect(buttons()[1]).toHaveTextContent('Grey newer session')
+      expect(buttons()[2]).toHaveTextContent('Grey older session')
     })
 
     it('shows green indicator for sessions with tabs, muted for others', async () => {

--- a/test/unit/client/components/Sidebar.test.tsx
+++ b/test/unit/client/components/Sidebar.test.tsx
@@ -1341,6 +1341,68 @@ describe('Sidebar Component - Session-Centric Display', () => {
       expect(buttons()[2]).toHaveTextContent('Grey older session')
     })
 
+    it('floats a just-closed identity-less live-terminal row to the top of the grey section', async () => {
+      const now = Date.now()
+      const greyNewerSid = sessionId('grey-newer-live')
+      const projects: ProjectGroup[] = [
+        {
+          projectPath: '/home/user/project',
+          sessions: [
+            {
+              sessionId: greyNewerSid,
+              projectPath: '/home/user/project',
+              lastActivityAt: now - 1000,
+              title: 'Grey newer session',
+              cwd: '/home/user/project',
+            },
+          ],
+        },
+      ]
+      // Running agent terminal with no sessionRef: shows as an identity-less
+      // live-terminal fallback row keyed opencode:terminal:<terminalId>. Its
+      // last activity is older than the grey session's, so absent a close
+      // ratchet the row sinks below it once the tab closes.
+      const terminals: BackgroundTerminal[] = [{
+        terminalId: 'term-live-1',
+        title: 'Live terminal session',
+        createdAt: now - 7200000,
+        lastActivityAt: now - 7200000,
+        status: 'running',
+        hasClients: true,
+        mode: 'opencode',
+      }]
+      const tabs = [{ id: 'tab-live', terminalId: 'term-live-1', mode: 'opencode' }]
+      const store = createTestStore({ projects, terminals, tabs, sortMode: 'activity' })
+      renderSidebar(store, [])
+
+      await act(async () => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const buttons = () => screen.getAllByRole('button').filter(
+        (btn) => btn.textContent?.includes('session')
+      )
+
+      // Pinned (open here) first while its tab is open, grey after.
+      expect(buttons()[0]).toHaveTextContent('Live terminal session')
+      expect(buttons()[1]).toHaveTextContent('Grey newer session')
+
+      const beforeClose = Date.now()
+      await act(async () => {
+        await store.dispatch(closeTab('tab-live') as any)
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(store.getState().sessionActivity.sessions['opencode:terminal:term-live-1'])
+        .toBeGreaterThanOrEqual(beforeClose)
+      // The terminal keeps running, so the row stays; the close-touch ratchet
+      // floats it above the newer untouched grey session.
+      expect(buttons()).toHaveLength(2)
+      expect(buttons()[0]).toHaveTextContent('Live terminal session')
+      expect(buttons()[0]).toHaveAttribute('data-has-tab', 'false')
+      expect(buttons()[1]).toHaveTextContent('Grey newer session')
+    })
+
     it('shows green indicator for sessions with tabs, muted for others', async () => {
       const now = Date.now()
       const projects: ProjectGroup[] = [

--- a/test/unit/client/lib/session-utils.test.ts
+++ b/test/unit/client/lib/session-utils.test.ts
@@ -8,6 +8,7 @@ import {
   findTabIdForSession,
   getActiveSessionRefForTab,
   getSessionsForHello,
+  liveTerminalFallbackIdentity,
 } from '@/lib/session-utils'
 import type {
   FreshAgentPaneContent,
@@ -17,6 +18,7 @@ import type {
   TerminalPaneContent,
 } from '@/store/paneTypes'
 import type { RootState } from '@/store/store'
+import type { BackgroundTerminal } from '@/store/types'
 
 const VALID_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
 const OTHER_SESSION_ID = '6f1c2b3a-4d5e-4f70-8a9b-0c1d2e3f4a5b'
@@ -393,5 +395,72 @@ describe('extractSessionLocators', () => {
     expect(extractSessionLocators(terminalContent('claude', { resumeSessionId: VALID_SESSION_ID }))).toEqual([
       { provider: 'claude', sessionId: VALID_SESSION_ID },
     ])
+  })
+})
+
+describe('liveTerminalFallbackIdentity', () => {
+  function registryTerminal(overrides: Partial<BackgroundTerminal> = {}): BackgroundTerminal {
+    return {
+      terminalId: 'term-1',
+      title: 'Agent pane',
+      createdAt: 1,
+      lastActivityAt: 1,
+      status: 'running',
+      hasClients: true,
+      mode: 'opencode',
+      ...overrides,
+    }
+  }
+
+  it('keys a running identity-less agent terminal as <mode>:terminal:<terminalId>', () => {
+    expect(liveTerminalFallbackIdentity(registryTerminal())).toEqual({
+      provider: 'opencode',
+      key: 'opencode:terminal:term-1',
+    })
+  })
+
+  it('returns undefined for a missing registry terminal', () => {
+    expect(liveTerminalFallbackIdentity(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when the terminal is not running', () => {
+    expect(liveTerminalFallbackIdentity(registryTerminal({ status: 'exited' }))).toBeUndefined()
+  })
+
+  it('returns undefined for shell-mode terminals', () => {
+    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: 'shell' }))).toBeUndefined()
+    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: undefined }))).toBeUndefined()
+  })
+
+  it('returns undefined when the registry terminal carries a sessionRef', () => {
+    expect(liveTerminalFallbackIdentity(registryTerminal({
+      sessionRef: { provider: 'opencode', sessionId: 'session-1' },
+    }))).toBeUndefined()
+  })
+
+  it('returns undefined for codex terminals with durability identity (covered via codex:<durabilityId>)', () => {
+    const durable = {
+      schemaVersion: 1,
+      state: 'durable',
+      durableThreadId: 'durable-1',
+    } as const
+    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: 'codex', codexDurability: durable }))).toBeUndefined()
+    const candidateOnly = {
+      schemaVersion: 1,
+      state: 'identity_pending',
+      candidate: {
+        provider: 'codex',
+        candidateThreadId: 'cand-1',
+        rolloutPath: '/tmp/rollout.jsonl',
+        source: 'thread_start_response',
+        capturedAt: 1,
+      },
+    } as const
+    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: 'codex', codexDurability: candidateOnly }))).toBeUndefined()
+    // codex WITHOUT any durability identity still gets a terminal key
+    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: 'codex' }))).toEqual({
+      provider: 'codex',
+      key: 'codex:terminal:term-1',
+    })
   })
 })

--- a/test/unit/client/lib/session-utils.test.ts
+++ b/test/unit/client/lib/session-utils.test.ts
@@ -8,7 +8,7 @@ import {
   findTabIdForSession,
   getActiveSessionRefForTab,
   getSessionsForHello,
-  liveTerminalFallbackIdentity,
+  liveTerminalRowIdentity,
 } from '@/lib/session-utils'
 import type {
   FreshAgentPaneContent,
@@ -398,7 +398,7 @@ describe('extractSessionLocators', () => {
   })
 })
 
-describe('liveTerminalFallbackIdentity', () => {
+describe('liveTerminalRowIdentity', () => {
   function registryTerminal(overrides: Partial<BackgroundTerminal> = {}): BackgroundTerminal {
     return {
       terminalId: 'term-1',
@@ -412,39 +412,65 @@ describe('liveTerminalFallbackIdentity', () => {
     }
   }
 
+  function agentContent(
+    mode: TerminalPaneContent['mode'] = 'opencode',
+    options: Parameters<typeof terminalContent>[1] = {},
+  ): TerminalPaneContent {
+    return terminalContent(mode, { terminalId: 'term-1', ...options })
+  }
+
   it('keys a running identity-less agent terminal as <mode>:terminal:<terminalId>', () => {
-    expect(liveTerminalFallbackIdentity(registryTerminal())).toEqual({
+    expect(liveTerminalRowIdentity(agentContent(), registryTerminal())).toEqual({
       provider: 'opencode',
       key: 'opencode:terminal:term-1',
     })
   })
 
-  it('returns undefined for a missing registry terminal', () => {
-    expect(liveTerminalFallbackIdentity(undefined)).toBeUndefined()
+  it('falls back to the content-mode terminal key when the registry entry is missing', () => {
+    expect(liveTerminalRowIdentity(agentContent(), undefined)).toEqual({
+      provider: 'opencode',
+      key: 'opencode:terminal:term-1',
+    })
+    // Registry miss never keys shell content (shell terminals produce no row)
+    expect(liveTerminalRowIdentity(agentContent('shell'), undefined)).toBeUndefined()
   })
 
-  it('returns undefined when the terminal is not running', () => {
-    expect(liveTerminalFallbackIdentity(registryTerminal({ status: 'exited' }))).toBeUndefined()
+  it('returns undefined when the terminal is not running and carries no canonical identity', () => {
+    expect(liveTerminalRowIdentity(agentContent(), registryTerminal({ status: 'exited' }))).toBeUndefined()
   })
 
-  it('returns undefined for shell-mode terminals', () => {
-    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: 'shell' }))).toBeUndefined()
-    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: undefined }))).toBeUndefined()
+  it('returns undefined for shell-mode registry terminals', () => {
+    expect(liveTerminalRowIdentity(agentContent('shell'), registryTerminal({ mode: 'shell' }))).toBeUndefined()
+    expect(liveTerminalRowIdentity(agentContent('shell'), registryTerminal({ mode: undefined }))).toBeUndefined()
   })
 
-  it('returns undefined when the registry terminal carries a sessionRef', () => {
-    expect(liveTerminalFallbackIdentity(registryTerminal({
+  it('returns the canonical key when the registry terminal carries a sessionRef', () => {
+    expect(liveTerminalRowIdentity(agentContent(), registryTerminal({
       sessionRef: { provider: 'opencode', sessionId: 'session-1' },
-    }))).toBeUndefined()
+    }))).toEqual({
+      provider: 'opencode',
+      key: 'opencode:session-1',
+    })
+    // Canonical rows do not depend on terminal liveness
+    expect(liveTerminalRowIdentity(agentContent(), registryTerminal({
+      status: 'exited',
+      sessionRef: { provider: 'opencode', sessionId: 'session-1' },
+    }))).toEqual({
+      provider: 'opencode',
+      key: 'opencode:session-1',
+    })
   })
 
-  it('returns undefined for codex terminals with durability identity (covered via codex:<durabilityId>)', () => {
+  it('returns the codex canonical key for codex terminals with registry durability identity', () => {
     const durable = {
       schemaVersion: 1,
       state: 'durable',
       durableThreadId: 'durable-1',
     } as const
-    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: 'codex', codexDurability: durable }))).toBeUndefined()
+    expect(liveTerminalRowIdentity(agentContent('codex'), registryTerminal({
+      mode: 'codex',
+      codexDurability: durable,
+    }))).toEqual({ provider: 'codex', key: 'codex:durable-1' })
     const candidateOnly = {
       schemaVersion: 1,
       state: 'identity_pending',
@@ -456,11 +482,34 @@ describe('liveTerminalFallbackIdentity', () => {
         capturedAt: 1,
       },
     } as const
-    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: 'codex', codexDurability: candidateOnly }))).toBeUndefined()
+    expect(liveTerminalRowIdentity(agentContent('codex'), registryTerminal({
+      mode: 'codex',
+      codexDurability: candidateOnly,
+    }))).toEqual({ provider: 'codex', key: 'codex:cand-1' })
     // codex WITHOUT any durability identity still gets a terminal key
-    expect(liveTerminalFallbackIdentity(registryTerminal({ mode: 'codex' }))).toEqual({
+    expect(liveTerminalRowIdentity(agentContent('codex'), registryTerminal({ mode: 'codex' }))).toEqual({
       provider: 'codex',
       key: 'codex:terminal:term-1',
     })
+  })
+
+  it('returns nothing when the content already carries canonical identity (canonical loop covers it)', () => {
+    const withRef = agentContent('claude', {
+      sessionRef: { provider: 'claude', sessionId: VALID_SESSION_ID },
+    })
+    expect(liveTerminalRowIdentity(withRef, registryTerminal())).toBeUndefined()
+    expect(liveTerminalRowIdentity(withRef, undefined)).toBeUndefined()
+    const withDurability = {
+      ...agentContent('codex'),
+      codexDurability: { schemaVersion: 1, state: 'durable', durableThreadId: 'durable-own' } as const,
+    }
+    expect(liveTerminalRowIdentity(withDurability, undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for non-terminal contents and terminals without a terminalId', () => {
+    expect(liveTerminalRowIdentity(freshAgentContent(), registryTerminal())).toBeUndefined()
+    expect(liveTerminalRowIdentity(freshAgentContent(), undefined)).toBeUndefined()
+    expect(liveTerminalRowIdentity(terminalContent('opencode'), registryTerminal())).toBeUndefined()
+    expect(liveTerminalRowIdentity(terminalContent('opencode'), undefined)).toBeUndefined()
   })
 })

--- a/test/unit/client/lib/terminal-session-association.test.ts
+++ b/test/unit/client/lib/terminal-session-association.test.ts
@@ -310,6 +310,129 @@ describe('alias activity fold on later identity binding', () => {
   })
 })
 
+describe('canonical activity fold on accepted rebind (previousSessionId)', () => {
+  // Codex fork-handoff scenario: the tab was closed while the pane carried
+  // the PARENT identity, so the close-tab ratchet wrote the parent canonical
+  // key `codex:parent-1` (no terminal alias — liveTerminalRowIdentity yields
+  // none for identity-bearing content; pinned by the tabsSlice close-ratchet
+  // tests). When the detached terminal later commits the CHILD session and
+  // broadcasts previousSessionId, the sidebar rekeys the row to the child,
+  // so the parent key's timestamp must be folded across with the same
+  // ratchet-only mechanism as the terminal alias.
+
+  function codexPane(terminalId: string, sessionId: string) {
+    return {
+      kind: 'terminal',
+      terminalId,
+      createRequestId: 'req-1',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+      sessionRef: { provider: 'codex', sessionId },
+    }
+  }
+
+  function createRebindHarness(
+    sessions: Record<string, number>,
+    content: Record<string, unknown>,
+  ) {
+    const state = createState(content) as any
+    state.sessionActivity = { sessions: { ...sessions } }
+    const dispatch = vi.fn((action: any) => {
+      if (action?.type === updateSessionActivity.type) {
+        state.sessionActivity = sessionActivityReducer(state.sessionActivity, action)
+      }
+    })
+    return { state, dispatch, getState: () => state }
+  }
+
+  function broadcastForkRebind(harness: ReturnType<typeof createRebindHarness>) {
+    return reconcileTerminalSessionAssociation({
+      dispatch: harness.dispatch,
+      getState: harness.getState,
+      terminalId: 't-1',
+      sessionRef: { provider: 'codex', sessionId: 'child-1' },
+      previousSessionId: 'parent-1',
+    })
+  }
+
+  it('folds the parent canonical timestamp onto the child when a live pane accepts the rebind', () => {
+    const harness = createRebindHarness({ 'codex:parent-1': 1111 }, codexPane('t-1', 'parent-1'))
+    const result = broadcastForkRebind(harness)
+    expect(result).toBe('reconciled')
+    expect(harness.state.sessionActivity.sessions['codex:child-1']).toBe(1111)
+  })
+
+  it('still folds the parent timestamp when the tab closed before the rebind broadcast (orphan)', () => {
+    // THE finding scenario: the close happened while the pane carried the
+    // parent identity (parent key ratcheted, no terminal alias written) and
+    // the pane is gone now; the detached terminal's rebind broadcast must
+    // still fold, so the fold must not depend on a pane match.
+    const harness = createRebindHarness({ 'codex:parent-1': 1111 }, codexPane('t-other', 'parent-1'))
+    const result = broadcastForkRebind(harness)
+    expect(result).toBe('ignored')
+    expect(harness.state.sessionActivity.sessions['codex:child-1']).toBe(1111)
+  })
+
+  it('never lowers an already-newer child timestamp (ratchet non-regression)', () => {
+    const harness = createRebindHarness(
+      { 'codex:parent-1': 1111, 'codex:child-1': 9999 },
+      codexPane('t-1', 'parent-1'),
+    )
+    broadcastForkRebind(harness)
+    // The fold is attempted with the parent timestamp...
+    expect(harness.dispatch).toHaveBeenCalledWith(
+      updateSessionActivity({ sessionId: 'child-1', provider: 'codex', lastInputAt: 1111 }),
+    )
+    // ...and the real reducer keeps the max.
+    expect(harness.state.sessionActivity.sessions['codex:child-1']).toBe(9999)
+  })
+
+  it('writes nothing when the parent key holds no activity', () => {
+    const harness = createRebindHarness({}, codexPane('t-1', 'parent-1'))
+    broadcastForkRebind(harness)
+    expect(harness.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: updateSessionActivity.type }),
+    )
+    expect(harness.state.sessionActivity.sessions['codex:child-1']).toBeUndefined()
+  })
+
+  it('does not fold onto the child when the rebind itself is rejected (conflict)', () => {
+    // The pane carries a third identity, so previousSessionId does not
+    // authorize the swap — a rejected frame must not stamp the parent's
+    // activity onto a session this client never accepted.
+    const harness = createRebindHarness({ 'codex:parent-1': 1111 }, codexPane('t-1', 'some-other'))
+    const result = broadcastForkRebind(harness)
+    expect(result).toBe('conflict')
+    expect(harness.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: updateSessionActivity.type }),
+    )
+    expect(harness.state.sessionActivity.sessions['codex:child-1']).toBeUndefined()
+  })
+
+  it('does not move another session\'s activity on a plain association frame (no previousSessionId)', () => {
+    // Without the supersession token nothing authorizes a canonical swap:
+    // only the terminal alias may fold, never another session's key.
+    const harness = createRebindHarness({ 'codex:parent-1': 1111 }, {
+      kind: 'terminal',
+      terminalId: 't-1',
+      createRequestId: 'req-1',
+      status: 'running',
+      mode: 'codex',
+      shell: 'system',
+    })
+    const result = reconcileTerminalSessionAssociation({
+      dispatch: harness.dispatch,
+      getState: harness.getState,
+      terminalId: 't-1',
+      sessionRef: { provider: 'codex', sessionId: 'child-1' },
+    })
+    expect(result).toBe('reconciled')
+    expect(harness.state.sessionActivity.sessions['codex:child-1']).toBeUndefined()
+    expect(harness.state.sessionActivity.sessions['codex:parent-1']).toBe(1111)
+  })
+})
+
 // Codex durability alias folding now lives in the store-level directory
 // path: fetchTerminalDirectoryWindow folds every applied page (the
 // terminals.changed refresh runs mounted or not). See

--- a/test/unit/client/lib/terminal-session-association.test.ts
+++ b/test/unit/client/lib/terminal-session-association.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import {
-  foldTerminalAliasActivity,
-  reconcileTerminalSessionAssociation,
-} from '@/lib/terminal-session-association'
+import { reconcileTerminalSessionAssociation } from '@/lib/terminal-session-association'
 import { reconcileTerminalSessionRefByTerminalId } from '@/store/panesSlice'
 import { flushPersistedLayoutNow } from '@/store/persistControl'
 import { updateTab } from '@/store/tabsSlice'
@@ -294,37 +291,30 @@ describe('alias activity fold on later identity binding', () => {
     expect(harness.state.sessionActivity.sessions[CANONICAL_KEY]).toBeUndefined()
   })
 
-  it('codex durability binding migrates codex:terminal:<id> into codex:<durabilitySessionId>', () => {
-    // Codex durability identity is a binding path independent of sessionRef
-    // association (the sidebar rows a codex terminal with durability but no
-    // sessionRef under codex:<durabilitySessionId>), so the fold helper the
-    // terminal.codex.durability.updated handler calls is exercised directly.
-    const harness = createFoldHarness({ 'codex:terminal:t-9': 2222 })
-    foldTerminalAliasActivity({
-      dispatch: harness.dispatch,
-      state: harness.state,
-      terminalId: 't-9',
-      provider: 'codex',
-      sessionId: 'durable-1',
+  it('does not fold onto a session the association itself rejects (conflict)', () => {
+    // A stale/rejected association frame must not stamp alias activity onto
+    // the session it declines to bind: folding happens only when the
+    // association is accepted or harmlessly stale, never on the conflict
+    // path. (The pane below is already bound to a different claude session,
+    // so the s-1 frame is a conflict.)
+    const harness = createFoldHarness({ [ALIAS_KEY]: 1111 }, {
+      ...identityLessClaudePane(),
+      sessionRef: { provider: 'claude', sessionId: 's-bound' },
     })
-    expect(harness.state.sessionActivity.sessions['codex:durable-1']).toBe(2222)
-  })
-
-  it('codex durability binding writes nothing when no alias activity exists', () => {
-    const harness = createFoldHarness({})
-    foldTerminalAliasActivity({
-      dispatch: harness.dispatch,
-      state: harness.state,
-      terminalId: 't-9',
-      provider: 'codex',
-      sessionId: 'durable-1',
-    })
+    const result = bindClaudeSession(harness)
+    expect(result).toBe('conflict')
     expect(harness.dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: updateSessionActivity.type }),
     )
-    expect(harness.state.sessionActivity.sessions['codex:durable-1']).toBeUndefined()
+    expect(harness.state.sessionActivity.sessions[CANONICAL_KEY]).toBeUndefined()
   })
 })
+
+// Codex durability alias folding now lives in the store-level directory
+// path: fetchTerminalDirectoryWindow folds every applied page (the
+// terminals.changed refresh runs mounted or not). See
+// test/unit/client/store/terminalDirectoryThunks.test.ts,
+// 'codex durability alias fold on directory application'.
 
 describe('duplicate rebind broadcasts (idempotence regression guards)', () => {
   const boundPane = {

--- a/test/unit/client/lib/terminal-session-association.test.ts
+++ b/test/unit/client/lib/terminal-session-association.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
-import { reconcileTerminalSessionAssociation } from '@/lib/terminal-session-association'
+import {
+  foldTerminalAliasActivity,
+  reconcileTerminalSessionAssociation,
+} from '@/lib/terminal-session-association'
 import { reconcileTerminalSessionRefByTerminalId } from '@/store/panesSlice'
 import { flushPersistedLayoutNow } from '@/store/persistControl'
 import { updateTab } from '@/store/tabsSlice'
+import sessionActivityReducer, { updateSessionActivity } from '@/store/sessionActivitySlice'
 
 function createState(content: Record<string, unknown>, tabOverrides: Record<string, unknown> = {}) {
   return {
@@ -205,6 +209,120 @@ describe('server-authoritative rebind (previousSessionId)', () => {
       'opencode:ses_new': { sessionType: 'opencode', firstUserMessage: 'hello world' },
     })
     expect(dispatched.map((action) => action.type)).toContain(flushPersistedLayoutNow.type)
+  })
+})
+
+describe('alias activity fold on later identity binding', () => {
+  // An identity-less terminal touched by the close-tab ratchet is recorded
+  // under `<provider>:terminal:<terminalId>` (liveTerminalRowIdentity's
+  // identity-less live-terminal row key). When the still-running terminal
+  // later acquires canonical identity, the sidebar rekeys the row to
+  // `<provider>:<sessionId>` and reads activity only from there, so the
+  // alias timestamp must be folded across at the binding point.
+
+  const ALIAS_KEY = 'claude:terminal:t-1'
+  const CANONICAL_KEY = 'claude:s-1'
+
+  function identityLessClaudePane(terminalId = 't-1') {
+    return {
+      kind: 'terminal',
+      terminalId,
+      createRequestId: 'req-1',
+      status: 'running',
+      mode: 'claude',
+      shell: 'system',
+    }
+  }
+
+  function createFoldHarness(
+    sessions: Record<string, number>,
+    content: Record<string, unknown> = identityLessClaudePane(),
+  ) {
+    const state = createState(content) as any
+    state.sessionActivity = { sessions: { ...sessions } }
+    const dispatch = vi.fn((action: any) => {
+      if (action?.type === updateSessionActivity.type) {
+        state.sessionActivity = sessionActivityReducer(state.sessionActivity, action)
+      }
+    })
+    return { state, dispatch, getState: () => state }
+  }
+
+  function bindClaudeSession(harness: ReturnType<typeof createFoldHarness>) {
+    return reconcileTerminalSessionAssociation({
+      dispatch: harness.dispatch,
+      getState: harness.getState,
+      terminalId: 't-1',
+      sessionRef: { provider: 'claude', sessionId: 's-1' },
+    })
+  }
+
+  it('migrates the close-tab alias timestamp into the canonical key when identity binds', () => {
+    const harness = createFoldHarness({ [ALIAS_KEY]: 1111 })
+    const result = bindClaudeSession(harness)
+    expect(result).toBe('reconciled')
+    expect(harness.state.sessionActivity.sessions[CANONICAL_KEY]).toBe(1111)
+  })
+
+  it('still folds the alias when the closed tab left no pane to match (the actual orphan)', () => {
+    // The close happened earlier: the tab is gone, so no pane matches the
+    // terminal and the reconciliation itself is 'ignored'. The fold must not
+    // depend on a pane match -- this IS the orphan scenario.
+    const harness = createFoldHarness({ [ALIAS_KEY]: 1111 }, identityLessClaudePane('t-other'))
+    const result = bindClaudeSession(harness)
+    expect(result).toBe('ignored')
+    expect(harness.state.sessionActivity.sessions[CANONICAL_KEY]).toBe(1111)
+  })
+
+  it('never lowers an already-newer canonical timestamp (ratchet non-regression)', () => {
+    const harness = createFoldHarness({ [ALIAS_KEY]: 1111, [CANONICAL_KEY]: 9999 })
+    bindClaudeSession(harness)
+    // The fold is attempted with the alias timestamp...
+    expect(harness.dispatch).toHaveBeenCalledWith(
+      updateSessionActivity({ sessionId: 's-1', provider: 'claude', lastInputAt: 1111 }),
+    )
+    // ...and the real reducer keeps the max.
+    expect(harness.state.sessionActivity.sessions[CANONICAL_KEY]).toBe(9999)
+  })
+
+  it('writes nothing to the canonical key when no alias activity exists', () => {
+    const harness = createFoldHarness({})
+    bindClaudeSession(harness)
+    expect(harness.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: updateSessionActivity.type }),
+    )
+    expect(harness.state.sessionActivity.sessions[CANONICAL_KEY]).toBeUndefined()
+  })
+
+  it('codex durability binding migrates codex:terminal:<id> into codex:<durabilitySessionId>', () => {
+    // Codex durability identity is a binding path independent of sessionRef
+    // association (the sidebar rows a codex terminal with durability but no
+    // sessionRef under codex:<durabilitySessionId>), so the fold helper the
+    // terminal.codex.durability.updated handler calls is exercised directly.
+    const harness = createFoldHarness({ 'codex:terminal:t-9': 2222 })
+    foldTerminalAliasActivity({
+      dispatch: harness.dispatch,
+      state: harness.state,
+      terminalId: 't-9',
+      provider: 'codex',
+      sessionId: 'durable-1',
+    })
+    expect(harness.state.sessionActivity.sessions['codex:durable-1']).toBe(2222)
+  })
+
+  it('codex durability binding writes nothing when no alias activity exists', () => {
+    const harness = createFoldHarness({})
+    foldTerminalAliasActivity({
+      dispatch: harness.dispatch,
+      state: harness.state,
+      terminalId: 't-9',
+      provider: 'codex',
+      sessionId: 'durable-1',
+    })
+    expect(harness.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: updateSessionActivity.type }),
+    )
+    expect(harness.state.sessionActivity.sessions['codex:durable-1']).toBeUndefined()
   })
 })
 

--- a/test/unit/client/store/selectors/sidebarSelectors.test.ts
+++ b/test/unit/client/store/selectors/sidebarSelectors.test.ts
@@ -1193,6 +1193,121 @@ describe('sidebarSelectors', () => {
       })
     })
 
+    describe('pinned status tiers', () => {
+      const pinned = (id: string, timestamp: number, extra: Partial<SidebarSessionItem> = {}) =>
+        createSessionItem({ id, sessionId: id, timestamp, hasTab: true, ...extra })
+
+      it('orders pinned rows into four tiers: busy here, plain open here, remote busy, remote open', () => {
+        // Legacy time order would be remote-open > remote-busy > plain-open > busy-here.
+        const items = [
+          pinned('remote-open', 4000),
+          pinned('remote-busy', 3000),
+          pinned('plain-open', 2000),
+          pinned('busy-here', 1000),
+        ]
+
+        const sorted = sortSessionItems(items, 'activity', {
+          pinnedStatus: {
+            busySessionKeys: new Set(['claude:busy-here']),
+            remoteActivity: { 'claude:remote-busy': 'busy', 'claude:remote-open': 'open' },
+          },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['busy-here', 'plain-open', 'remote-busy', 'remote-open'])
+      })
+
+      it('treats local-busy as tier 1 even when the session is also busy remotely', () => {
+        const items = [pinned('both', 1000), pinned('plain', 2000)]
+
+        const sorted = sortSessionItems(items, 'activity', {
+          pinnedStatus: {
+            busySessionKeys: new Set(['claude:both']),
+            remoteActivity: { 'claude:both': 'busy' },
+          },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['both', 'plain'])
+      })
+
+      it('keeps (ratchetedActivity ?? timestamp) ordering within a tier in activity mode', () => {
+        const items = [
+          pinned('old-ratcheted', 5000, { ratchetedActivity: 4000 }),
+          pinned('new-untouched', 3000),
+        ]
+
+        const sorted = sortSessionItems(items, 'activity', { pinnedStatus: {} })
+
+        expect(sorted.map((i) => i.id)).toEqual(['old-ratcheted', 'new-untouched'])
+      })
+
+      it('applies the same tiers in recency-pinned mode with timestamp ordering within a tier', () => {
+        const items = [
+          pinned('remote-open', 4000),
+          pinned('busy-here', 1000),
+          pinned('plain', 3000),
+        ]
+
+        const sorted = sortSessionItems(items, 'recency-pinned', {
+          pinnedStatus: {
+            busySessionKeys: new Set(['claude:busy-here']),
+            remoteActivity: { 'claude:remote-open': 'open' },
+          },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['busy-here', 'plain', 'remote-open'])
+      })
+
+      it('flattens tiers when disableTabPinning is set (active search)', () => {
+        const items = [
+          pinned('remote-open', 4000),
+          pinned('busy-here', 1000),
+        ]
+
+        const sorted = sortSessionItems(items, 'activity', {
+          disableTabPinning: true,
+          pinnedStatus: {
+            busySessionKeys: new Set(['claude:busy-here']),
+            remoteActivity: { 'claude:remote-open': 'open' },
+          },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['remote-open', 'busy-here'])
+      })
+
+      it('applies tiers within the archived partition (archived still last)', () => {
+        const items = [
+          createSessionItem({ id: 'arch-plain', sessionId: 'arch-plain', timestamp: 2000, hasTab: true, archived: true }),
+          createSessionItem({ id: 'arch-busy', sessionId: 'arch-busy', timestamp: 1000, hasTab: true, archived: true }),
+          createSessionItem({ id: 'live', sessionId: 'live', timestamp: 500, hasTab: false }),
+        ]
+
+        const sorted = sortSessionItems(items, 'activity', {
+          pinnedStatus: { busySessionKeys: new Set(['claude:arch-busy']) },
+        })
+
+        expect(sorted.map((i) => i.id)).toEqual(['live', 'arch-busy', 'arch-plain'])
+      })
+
+      it('ignores pinnedStatus in recency and project modes', () => {
+        const pinnedStatus = { busySessionKeys: new Set(['claude:busy-here']) }
+
+        const recency = sortSessionItems([pinned('busy-here', 1000), pinned('plain', 2000)], 'recency', { pinnedStatus })
+        expect(recency.map((i) => i.id)).toEqual(['plain', 'busy-here'])
+
+        const project = sortSessionItems([
+          createSessionItem({ id: 'busy-here', sessionId: 'busy-here', timestamp: 1000, hasTab: true, projectPath: '/b' }),
+          createSessionItem({ id: 'plain', sessionId: 'plain', timestamp: 2000, hasTab: true, projectPath: '/a' }),
+        ], 'project', { pinnedStatus })
+        expect(project.map((i) => i.id)).toEqual(['plain', 'busy-here'])
+      })
+
+      it('leaves legacy pinned ordering untouched when pinnedStatus is omitted', () => {
+        const sorted = sortSessionItems([pinned('older', 1000), pinned('newer', 2000)], 'activity')
+
+        expect(sorted.map((i) => i.id)).toEqual(['newer', 'older'])
+      })
+    })
+
     describe('project mode', () => {
       it('sorts by project path alphabetically', () => {
         const items = [

--- a/test/unit/client/store/selectors/sidebarSelectors.test.ts
+++ b/test/unit/client/store/selectors/sidebarSelectors.test.ts
@@ -1021,6 +1021,44 @@ describe('sidebarSelectors', () => {
         'server-archived',
       ])
     })
+
+    it('orders pinned sessions by status tier when pinnedStatus is provided, flat under applied search', () => {
+      const busy = createFallbackTab('tab-busy', 'busy-s', 'Busy Session', '/tmp/a', 'codex')
+      const idle = createFallbackTab('tab-idle', 'idle-s', 'Idle Session', '/tmp/b', 'claude')
+      const projects = [
+        {
+          projectPath: '/tmp',
+          sessions: [
+            { sessionId: 'busy-s', provider: 'codex', projectPath: '/tmp', lastActivityAt: 1000, title: 'Busy Session', cwd: '/tmp' },
+            { sessionId: 'idle-s', provider: 'claude', projectPath: '/tmp', lastActivityAt: 9000, title: 'Idle Session', cwd: '/tmp' },
+          ],
+        },
+      ] as any
+      const makeState = (extra: { appliedQuery?: string; appliedSearchTier?: 'title' } = {}) =>
+        createSelectorState({
+          projects,
+          tabs: [busy.tab, idle.tab],
+          panes: {
+            layouts: { 'tab-busy': busy.layout, 'tab-idle': idle.layout },
+            activePane: {},
+            paneTitles: {},
+          },
+          sortMode: 'activity',
+          ...extra,
+        })
+      const selectSortedItems = makeSelectSortedSessionItems()
+      const pinnedStatus = { busySessionKeys: new Set(['codex:busy-s']), remoteActivity: {} }
+
+      // Omitted pinnedStatus: legacy pinned time order (newest first).
+      expect(selectSortedItems(makeState(), [], '').map((i) => i.sessionId)).toEqual(['idle-s', 'busy-s'])
+      // Provided pinnedStatus: busy session leads the pinned section.
+      expect(selectSortedItems(makeState(), [], '', pinnedStatus).map((i) => i.sessionId)).toEqual(['busy-s', 'idle-s'])
+      // Applied server search flattens pinning; tiers go with it (decision B).
+      expect(
+        selectSortedItems(makeState({ appliedQuery: 'Session', appliedSearchTier: 'title' }), [], '', pinnedStatus)
+          .map((i) => i.sessionId),
+      ).toEqual(['idle-s', 'busy-s'])
+    })
   })
 
   describe('sortSessionItems', () => {

--- a/test/unit/client/store/tabsSlice.test.ts
+++ b/test/unit/client/store/tabsSlice.test.ts
@@ -771,9 +771,12 @@ describe('tabsSlice', () => {
       expect(sessions['codex:terminal:term-cx-1']).toBeUndefined()
     })
 
-    it('skips the terminal key when the registry terminal carries a sessionRef', async () => {
-      // Canonical identity lives in the registry, not the pane content here;
-      // the alias terminal key would be junk (its row never exists).
+    it('ratchets the registry canonical key when the sessionRef exists only in the registry', async () => {
+      // Canonical identity lives in the registry, not the pane content: the
+      // content yields no locator, so the canonical loop ratchets nothing.
+      // The sidebar rows this terminal under claude:<sessionId>; the ratchet
+      // must target that canonical key, not a terminal alias (which would be
+      // junk — no row ever reads it).
       const store = createRegistryRatchetStore([{
         terminalId: 'term-ref-1',
         title: 'Claude pane',
@@ -791,9 +794,62 @@ describe('tabsSlice', () => {
         content: { kind: 'terminal', mode: 'claude', terminalId: 'term-ref-1' },
       }))
 
+      const beforeClose = Date.now()
       await store.dispatch(closeTab(tabId))
 
-      expect(store.getState().sessionActivity.sessions).toEqual({})
+      const sessions = store.getState().sessionActivity.sessions
+      expect(sessions[`claude:${VALID_CLAUDE_SESSION_ID}`]).toBeGreaterThanOrEqual(beforeClose)
+      expect(sessions['claude:terminal:term-ref-1']).toBeUndefined()
+    })
+
+    it('ratchets the registry codex canonical key when durability identity exists only in the registry', async () => {
+      // Same registry-only-identity gap as the sessionRef case: the content
+      // carries no codexDurability, so the canonical loop yields nothing, but
+      // the sidebar rows the terminal under codex:<durabilitySessionId>.
+      const codexDurability = { schemaVersion: 1, state: 'durable', durableThreadId: 'durable-cx-2' } as const
+      const store = createRegistryRatchetStore([{
+        terminalId: 'term-cx-2',
+        title: 'Codex pane',
+        createdAt: 1,
+        lastActivityAt: 1,
+        status: 'running',
+        hasClients: true,
+        mode: 'codex',
+        codexDurability,
+      }])
+      store.dispatch(addTab({ mode: 'codex' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({
+        tabId,
+        content: { kind: 'terminal', mode: 'codex', terminalId: 'term-cx-2' },
+      }))
+
+      const beforeClose = Date.now()
+      await store.dispatch(closeTab(tabId))
+
+      const sessions = store.getState().sessionActivity.sessions
+      expect(sessions['codex:durable-cx-2']).toBeGreaterThanOrEqual(beforeClose)
+      expect(sessions['codex:terminal:term-cx-2']).toBeUndefined()
+    })
+
+    it('falls back to the pane-mode terminal key when the registry entry is missing', async () => {
+      // terminalDirectory.windows.sidebar.items loads asynchronously, can
+      // fail or be stale, and is capped: closing before the entry arrives
+      // must still ratchet the key the still-running terminal's fallback row
+      // will read once it registers.
+      const store = createRegistryRatchetStore([])
+      store.dispatch(addTab({ mode: 'opencode' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({
+        tabId,
+        content: { kind: 'terminal', mode: 'opencode', terminalId: 'term-miss-1' },
+      }))
+
+      const beforeClose = Date.now()
+      await store.dispatch(closeTab(tabId))
+
+      expect(store.getState().sessionActivity.sessions['opencode:terminal:term-miss-1'])
+        .toBeGreaterThanOrEqual(beforeClose)
     })
   })
 

--- a/test/unit/client/store/tabsSlice.test.ts
+++ b/test/unit/client/store/tabsSlice.test.ts
@@ -15,7 +15,8 @@ import panesReducer, { initLayout, splitPane } from '../../../../src/store/panes
 import sessionActivityReducer from '../../../../src/store/sessionActivitySlice'
 import connectionReducer from '../../../../src/store/connectionSlice'
 import extensionsReducer from '../../../../src/store/extensionsSlice'
-import type { Tab } from '../../../../src/store/types'
+import terminalDirectoryReducer from '../../../../src/store/terminalDirectorySlice'
+import type { BackgroundTerminal, Tab } from '../../../../src/store/types'
 
 const VALID_CLAUDE_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000'
 
@@ -672,6 +673,127 @@ describe('tabsSlice', () => {
 
       expect(store.getState().sessionActivity.sessions[`claude:${VALID_CLAUDE_SESSION_ID}`])
         .toBeGreaterThanOrEqual(beforeClose)
+    })
+
+    function createRegistryRatchetStore(
+      terminals: BackgroundTerminal[],
+      sessions: Record<string, number> = {},
+    ) {
+      return configureStore({
+        reducer: {
+          tabs: tabsReducer,
+          panes: panesReducer,
+          sessionActivity: sessionActivityReducer,
+          terminalDirectory: terminalDirectoryReducer,
+        },
+        preloadedState: {
+          sessionActivity: { sessions },
+          terminalDirectory: {
+            windows: { sidebar: { items: terminals, nextCursor: null } },
+            searches: {},
+          },
+        },
+      })
+    }
+
+    it('ratchets the fallback row key of every running identity-less registry terminal in the layout', async () => {
+      // Running agent terminals without sessionRef surface in the sidebar as
+      // fallback rows keyed `<mode>:terminal:<terminalId>`; the row persists
+      // after tab close because the terminal keeps running.
+      const store = createRegistryRatchetStore([
+        {
+          terminalId: 'term-op-1',
+          title: 'OpenCode one',
+          createdAt: 1,
+          lastActivityAt: 1,
+          status: 'running',
+          hasClients: true,
+          mode: 'opencode',
+        },
+        {
+          terminalId: 'term-op-2',
+          title: 'OpenCode two',
+          createdAt: 1,
+          lastActivityAt: 1,
+          status: 'running',
+          hasClients: true,
+          mode: 'opencode',
+        },
+      ])
+      store.dispatch(addTab({ mode: 'opencode' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({
+        tabId,
+        content: { kind: 'terminal', mode: 'opencode', terminalId: 'term-op-1' },
+      }))
+      const leafId = (store.getState().panes.layouts[tabId] as any).id
+      store.dispatch(splitPane({
+        tabId,
+        paneId: leafId,
+        direction: 'horizontal',
+        newContent: { kind: 'terminal', mode: 'opencode', terminalId: 'term-op-2' },
+      }))
+
+      const beforeClose = Date.now()
+      await store.dispatch(closeTab(tabId))
+
+      const sessions = store.getState().sessionActivity.sessions
+      expect(sessions['opencode:terminal:term-op-1']).toBeGreaterThanOrEqual(beforeClose)
+      expect(sessions['opencode:terminal:term-op-2']).toBeGreaterThanOrEqual(beforeClose)
+    })
+
+    it('skips the terminal key when a codex registry terminal has durability identity', async () => {
+      // That row is keyed codex:<durabilitySessionId> and is already ratcheted
+      // by the canonical refs loop (pane-content codex durability locator).
+      const codexDurability = { schemaVersion: 1, state: 'durable', durableThreadId: 'durable-cx-1' } as const
+      const store = createRegistryRatchetStore([{
+        terminalId: 'term-cx-1',
+        title: 'Codex pane',
+        createdAt: 1,
+        lastActivityAt: 1,
+        status: 'running',
+        hasClients: true,
+        mode: 'codex',
+        codexDurability,
+      }])
+      store.dispatch(addTab({ mode: 'codex' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({
+        tabId,
+        content: { kind: 'terminal', mode: 'codex', terminalId: 'term-cx-1', codexDurability },
+      }))
+
+      const beforeClose = Date.now()
+      await store.dispatch(closeTab(tabId))
+
+      const sessions = store.getState().sessionActivity.sessions
+      expect(sessions['codex:durable-cx-1']).toBeGreaterThanOrEqual(beforeClose)
+      expect(sessions['codex:terminal:term-cx-1']).toBeUndefined()
+    })
+
+    it('skips the terminal key when the registry terminal carries a sessionRef', async () => {
+      // Canonical identity lives in the registry, not the pane content here;
+      // the alias terminal key would be junk (its row never exists).
+      const store = createRegistryRatchetStore([{
+        terminalId: 'term-ref-1',
+        title: 'Claude pane',
+        createdAt: 1,
+        lastActivityAt: 1,
+        status: 'running',
+        hasClients: true,
+        mode: 'claude',
+        sessionRef: { provider: 'claude', sessionId: VALID_CLAUDE_SESSION_ID },
+      }])
+      store.dispatch(addTab({ mode: 'claude' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({
+        tabId,
+        content: { kind: 'terminal', mode: 'claude', terminalId: 'term-ref-1' },
+      }))
+
+      await store.dispatch(closeTab(tabId))
+
+      expect(store.getState().sessionActivity.sessions).toEqual({})
     })
   })
 

--- a/test/unit/client/store/tabsSlice.test.ts
+++ b/test/unit/client/store/tabsSlice.test.ts
@@ -11,7 +11,8 @@ import tabsReducer, {
   openSessionTab,
   TabsState,
 } from '../../../../src/store/tabsSlice'
-import panesReducer, { initLayout } from '../../../../src/store/panesSlice'
+import panesReducer, { initLayout, splitPane } from '../../../../src/store/panesSlice'
+import sessionActivityReducer from '../../../../src/store/sessionActivitySlice'
 import connectionReducer from '../../../../src/store/connectionSlice'
 import extensionsReducer from '../../../../src/store/extensionsSlice'
 import type { Tab } from '../../../../src/store/types'
@@ -574,6 +575,103 @@ describe('tabsSlice', () => {
 
       // Layout should be removed
       expect(store.getState().panes.layouts[tabId]).toBeUndefined()
+    })
+  })
+
+  describe('closeTab session activity ratchet', () => {
+    const SECOND_CLAUDE_ID = '550e8400-e29b-41d4-a716-446655440001'
+
+    function createRatchetStore(sessions: Record<string, number> = {}) {
+      return configureStore({
+        reducer: {
+          tabs: tabsReducer,
+          panes: panesReducer,
+          sessionActivity: sessionActivityReducer,
+        },
+        preloadedState: { sessionActivity: { sessions } },
+      })
+    }
+
+    it('ratchets activity for every session ref of the closing tab', async () => {
+      const store = createRatchetStore()
+      store.dispatch(addTab({ mode: 'claude' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({
+        tabId,
+        content: {
+          kind: 'terminal',
+          mode: 'claude',
+          resumeSessionId: VALID_CLAUDE_SESSION_ID,
+          sessionRef: { provider: 'claude', sessionId: VALID_CLAUDE_SESSION_ID },
+        },
+      }))
+      const leafId = (store.getState().panes.layouts[tabId] as any).id
+      store.dispatch(splitPane({
+        tabId,
+        paneId: leafId,
+        direction: 'horizontal',
+        newContent: {
+          kind: 'terminal',
+          mode: 'claude',
+          resumeSessionId: SECOND_CLAUDE_ID,
+          sessionRef: { provider: 'claude', sessionId: SECOND_CLAUDE_ID },
+        },
+      }))
+
+      const beforeClose = Date.now()
+      await store.dispatch(closeTab(tabId))
+
+      const sessions = store.getState().sessionActivity.sessions
+      expect(sessions[`claude:${VALID_CLAUDE_SESSION_ID}`]).toBeGreaterThanOrEqual(beforeClose)
+      expect(sessions[`claude:${SECOND_CLAUDE_ID}`]).toBeGreaterThanOrEqual(beforeClose)
+    })
+
+    it('records no activity when closing a sessionless shell tab', async () => {
+      const store = createRatchetStore()
+      store.dispatch(addTab({ mode: 'shell' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({ tabId, content: { kind: 'terminal', mode: 'shell' } }))
+
+      await store.dispatch(closeTab(tabId))
+
+      expect(store.getState().sessionActivity.sessions).toEqual({})
+    })
+
+    it('never downgrades a newer existing ratchet value', async () => {
+      const future = Date.now() + 60_000
+      const store = createRatchetStore({ [`claude:${VALID_CLAUDE_SESSION_ID}`]: future })
+      store.dispatch(addTab({ mode: 'claude' }))
+      const tabId = store.getState().tabs.tabs[0].id
+      store.dispatch(initLayout({
+        tabId,
+        content: { kind: 'terminal', mode: 'claude', resumeSessionId: VALID_CLAUDE_SESSION_ID },
+      }))
+
+      await store.dispatch(closeTab(tabId))
+
+      expect(store.getState().sessionActivity.sessions[`claude:${VALID_CLAUDE_SESSION_ID}`]).toBe(future)
+    })
+
+    it('ratchets layout-less tabs via tab-level fallback identity', async () => {
+      const store = createRatchetStore()
+      store.dispatch(hydrateTabs({
+        tabs: [{
+          id: 'layout-less',
+          createRequestId: 'layout-less',
+          title: 'Layout-less',
+          status: 'running',
+          mode: 'claude',
+          resumeSessionId: VALID_CLAUDE_SESSION_ID,
+          createdAt: 1,
+        } as any],
+        activeTabId: 'layout-less',
+      }))
+
+      const beforeClose = Date.now()
+      await store.dispatch(closeTab('layout-less'))
+
+      expect(store.getState().sessionActivity.sessions[`claude:${VALID_CLAUDE_SESSION_ID}`])
+        .toBeGreaterThanOrEqual(beforeClose)
     })
   })
 

--- a/test/unit/client/store/terminalDirectoryThunks.test.ts
+++ b/test/unit/client/store/terminalDirectoryThunks.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
 import terminalDirectoryReducer from '@/store/terminalDirectorySlice'
+import sessionActivityReducer from '@/store/sessionActivitySlice'
 import {
   _resetTerminalDirectoryThunkControllers,
   fetchTerminalDirectoryWindow,
@@ -184,5 +185,138 @@ describe('terminalDirectoryThunks', () => {
     expect(signals[0].aborted).toBe(true)
     expect(signals[1].aborted).toBe(false)
     await expect(firstDispatch).resolves.toBeUndefined()
+  })
+})
+
+describe('codex durability alias fold on directory application', () => {
+  // A codex terminal closed while identity-less had its close-tab touch
+  // recorded under codex:terminal:<terminalId> (liveTerminalRowIdentity's
+  // fallback row key). When the still-running terminal later gains codex
+  // durability identity, the sidebar rekeys the row to
+  // codex:<durabilitySessionId> (mirroring getCodexDurabilitySessionId in
+  // selectors/sidebarSelectors.ts). On the Node server every
+  // terminal.codex.durability.updated broadcast is followed by
+  // terminals.changed, which refreshes the directory regardless of whether
+  // any pane is still mounted -- so the applied directory page is the
+  // store-level binding point that must fold the alias across.
+
+  const CANDIDATE = {
+    provider: 'codex',
+    candidateThreadId: 'cand-1',
+    rolloutPath: '/tmp/rollout-cand-1.jsonl',
+    source: 'thread_start_response',
+    capturedAt: 1,
+  } as const
+
+  function codexItem(codexDurability: Record<string, unknown>) {
+    return {
+      terminalId: 'term-cx-1',
+      title: 'Codex',
+      createdAt: 1,
+      lastActivityAt: 10,
+      status: 'running',
+      hasClients: false,
+      mode: 'codex',
+      codexDurability,
+    }
+  }
+
+  function createStoreWithActivity(sessions: Record<string, number>) {
+    return configureStore({
+      reducer: {
+        terminalDirectory: terminalDirectoryReducer,
+        sessionActivity: sessionActivityReducer,
+      },
+      preloadedState: {
+        sessionActivity: { sessions },
+      },
+    })
+  }
+
+  it('folds the alias timestamp into codex:<durabilitySessionId> when the applied page carries durable identity', async () => {
+    getTerminalDirectoryPage.mockResolvedValue({
+      items: [codexItem({ schemaVersion: 1, state: 'durable', durableThreadId: 'durable-1' })],
+      nextCursor: null,
+      revision: 11,
+    })
+
+    const store = createStoreWithActivity({ 'codex:terminal:term-cx-1': 1111 })
+    await store.dispatch(fetchTerminalDirectoryWindow({
+      surface: 'sidebar',
+      priority: 'visible',
+    }) as any)
+
+    expect(store.getState().sessionActivity.sessions['codex:durable-1']).toBe(1111)
+  })
+
+  it('folds candidate-only durability identity the same way (identity_pending rekeys the row too)', async () => {
+    getTerminalDirectoryPage.mockResolvedValue({
+      items: [codexItem({ schemaVersion: 1, state: 'identity_pending', candidate: CANDIDATE })],
+      nextCursor: null,
+      revision: 12,
+    })
+
+    const store = createStoreWithActivity({ 'codex:terminal:term-cx-1': 2222 })
+    await store.dispatch(fetchTerminalDirectoryWindow({
+      surface: 'sidebar',
+      priority: 'visible',
+    }) as any)
+
+    expect(store.getState().sessionActivity.sessions['codex:cand-1']).toBe(2222)
+  })
+
+  it('never lowers an already-newer canonical timestamp (ratchet non-regression)', async () => {
+    getTerminalDirectoryPage.mockResolvedValue({
+      items: [codexItem({ schemaVersion: 1, state: 'durable', durableThreadId: 'durable-1' })],
+      nextCursor: null,
+      revision: 13,
+    })
+
+    const store = createStoreWithActivity({
+      'codex:terminal:term-cx-1': 1111,
+      'codex:durable-1': 9999,
+    })
+    await store.dispatch(fetchTerminalDirectoryWindow({
+      surface: 'sidebar',
+      priority: 'visible',
+    }) as any)
+
+    expect(store.getState().sessionActivity.sessions['codex:durable-1']).toBe(9999)
+  })
+
+  it('writes nothing when no alias activity exists for the terminal', async () => {
+    getTerminalDirectoryPage.mockResolvedValue({
+      items: [codexItem({ schemaVersion: 1, state: 'durable', durableThreadId: 'durable-1' })],
+      nextCursor: null,
+      revision: 14,
+    })
+
+    const store = createStoreWithActivity({})
+    await store.dispatch(fetchTerminalDirectoryWindow({
+      surface: 'sidebar',
+      priority: 'visible',
+    }) as any)
+
+    expect(store.getState().sessionActivity.sessions['codex:durable-1']).toBeUndefined()
+    expect(Object.keys(store.getState().sessionActivity.sessions)).toHaveLength(0)
+  })
+
+  it('writes nothing when the applied item carries no durability identity', async () => {
+    getTerminalDirectoryPage.mockResolvedValue({
+      items: [codexItem({ schemaVersion: 1, state: 'identity_pending' })],
+      nextCursor: null,
+      revision: 15,
+    })
+
+    const store = createStoreWithActivity({ 'codex:terminal:term-cx-1': 3333 })
+    await store.dispatch(fetchTerminalDirectoryWindow({
+      surface: 'sidebar',
+      priority: 'visible',
+    }) as any)
+
+    // The identity-less fallback row is still the one shown; the alias must
+    // not be folded onto a session that does not exist.
+    expect(store.getState().sessionActivity.sessions['codex:terminal:term-cx-1']).toBe(3333)
+    expect(Object.keys(store.getState().sessionActivity.sessions)).toHaveLength(1)
   })
 })

--- a/test/unit/client/store/terminalDirectoryThunks.test.ts
+++ b/test/unit/client/store/terminalDirectoryThunks.test.ts
@@ -320,3 +320,150 @@ describe('codex durability alias fold on directory application', () => {
     expect(Object.keys(store.getState().sessionActivity.sessions)).toHaveLength(1)
   })
 })
+
+describe('canonical rebind fold on directory refresh (snapshot swap)', () => {
+  // The sidebar rows a running terminal under the directory item's own
+  // sessionRef (buildSessionItems' runningSessionMap reads
+  // state.terminalDirectory.windows.sidebar.items directly — the directory is
+  // applied here and never passes through reconcileTerminalSessionAssociation).
+  // The terminal.session.associated frame carrying previousSessionId is a
+  // single transient broadcast: a client disconnected at rebind time (fresh
+  // page load, second device) only ever sees the parent->child swap as two
+  // consecutive directory snapshots for the same terminalId. The previous
+  // window is the client's only record of the superseded identity, so the
+  // canonical previous->new fold must run here too, ratchet-only.
+
+  function codexSessionItem(terminalId: string, sessionId: string) {
+    return {
+      terminalId,
+      title: 'Codex',
+      createdAt: 1,
+      lastActivityAt: 10,
+      status: 'running',
+      hasClients: false,
+      mode: 'codex',
+      sessionRef: { provider: 'codex', sessionId },
+    }
+  }
+
+  function createStoreWithActivity(sessions: Record<string, number>) {
+    return configureStore({
+      reducer: {
+        terminalDirectory: terminalDirectoryReducer,
+        sessionActivity: sessionActivityReducer,
+      },
+      preloadedState: {
+        sessionActivity: { sessions },
+      },
+    })
+  }
+
+  async function fetchSidebarPage(store: ReturnType<typeof createStoreWithActivity>) {
+    await store.dispatch(fetchTerminalDirectoryWindow({
+      surface: 'sidebar',
+      priority: 'visible',
+    }) as any)
+  }
+
+  it('folds the superseded canonical timestamp onto the new identity when a refresh swaps the same terminal\'s sessionRef', async () => {
+    getTerminalDirectoryPage
+      .mockResolvedValueOnce({
+        items: [codexSessionItem('term-cx-9', 'parent-1')],
+        nextCursor: null,
+        revision: 20,
+      })
+      .mockResolvedValueOnce({
+        items: [codexSessionItem('term-cx-9', 'child-1')],
+        nextCursor: null,
+        revision: 21,
+      })
+
+    const store = createStoreWithActivity({ 'codex:parent-1': 4444 })
+    await fetchSidebarPage(store)
+    expect(store.getState().sessionActivity.sessions['codex:child-1']).toBeUndefined()
+
+    await fetchSidebarPage(store)
+    expect(store.getState().sessionActivity.sessions['codex:child-1']).toBe(4444)
+    // The old key stays (ratchet-only, pruned by existing retention).
+    expect(store.getState().sessionActivity.sessions['codex:parent-1']).toBe(4444)
+  })
+
+  it('never lowers an already-newer new-identity timestamp (ratchet non-regression)', async () => {
+    getTerminalDirectoryPage
+      .mockResolvedValueOnce({
+        items: [codexSessionItem('term-cx-9', 'parent-1')],
+        nextCursor: null,
+        revision: 20,
+      })
+      .mockResolvedValueOnce({
+        items: [codexSessionItem('term-cx-9', 'child-1')],
+        nextCursor: null,
+        revision: 21,
+      })
+
+    const store = createStoreWithActivity({ 'codex:parent-1': 4444, 'codex:child-1': 9999 })
+    await fetchSidebarPage(store)
+    await fetchSidebarPage(store)
+
+    expect(store.getState().sessionActivity.sessions['codex:child-1']).toBe(9999)
+  })
+
+  it('writes nothing when the refreshed identity is unchanged', async () => {
+    getTerminalDirectoryPage.mockResolvedValue({
+      items: [codexSessionItem('term-cx-9', 'parent-1')],
+      nextCursor: null,
+      revision: 20,
+    })
+
+    const store = createStoreWithActivity({ 'codex:parent-1': 4444 })
+    await fetchSidebarPage(store)
+    await fetchSidebarPage(store)
+
+    // No canonical->canonical fold happened: the map is untouched.
+    expect(store.getState().sessionActivity.sessions).toEqual({ 'codex:parent-1': 4444 })
+  })
+
+  it('writes nothing when the previous window never carried the terminal (first sighting)', async () => {
+    getTerminalDirectoryPage.mockResolvedValue({
+      items: [codexSessionItem('term-cx-9', 'child-1')],
+      nextCursor: null,
+      revision: 20,
+    })
+
+    const store = createStoreWithActivity({ 'codex:parent-1': 4444 })
+    await fetchSidebarPage(store)
+
+    // There is no evidence the terminal ever stood for parent-1 on this
+    // client, so nothing may move.
+    expect(store.getState().sessionActivity.sessions).toEqual({ 'codex:parent-1': 4444 })
+  })
+
+  it('does not fold across providers (a provider change is not a rebind)', async () => {
+    getTerminalDirectoryPage
+      .mockResolvedValueOnce({
+        items: [{
+          terminalId: 'term-x-1',
+          title: 'Claude',
+          createdAt: 1,
+          lastActivityAt: 10,
+          status: 'running',
+          hasClients: false,
+          mode: 'claude',
+          sessionRef: { provider: 'claude', sessionId: 'claude-1' },
+        }],
+        nextCursor: null,
+        revision: 20,
+      })
+      .mockResolvedValueOnce({
+        items: [codexSessionItem('term-x-1', 'child-1')],
+        nextCursor: null,
+        revision: 21,
+      })
+
+    const store = createStoreWithActivity({ 'claude:claude-1': 4444 })
+    await fetchSidebarPage(store)
+    await fetchSidebarPage(store)
+
+    expect(store.getState().sessionActivity.sessions).toEqual({ 'claude:claude-1': 4444 })
+  })
+})


### PR DESCRIPTION
## Summary

Two related sidebar changes (the-usual-beta run; reviewed plan in `docs/plans/2026-08-22-sidebar-pinned-status-sort.md`, full review trail in the run logs):

1. **Pinned status-tier ordering.** Sessions open in tabs on this device now sort in four tiers — busy here first, then open-here idle (the persistent green icon bucket), then busy on other devices (blue ring), then open on other devices (green ring) — with existing time-based ordering inside each tier. Applies to the `activity` and `recency-pinned` sort modes; search flattening, `recency`/`project` modes, and archived-last behavior are unchanged. With no status data available the sort degenerates byte-for-byte to the previous order.

2. **Close-tab activity ratchet.** Closing a tab counts as a touch: the session's locally-stored activity timestamp ratchets to now, so the just-closed session floats to the top of the grey (non-pinned) section under the default activity sort. Covers canonical sessions, identity-less live-terminal sidebar rows, registry-only identities, directory-window load gaps, terminals that bind an identity after close (both binding paths), and canonical session rebinds (Codex fork handoffs, including directory-level identity swaps for disconnected clients). All folds are ratchet-only (max-wins persistence).

## Test plan

- Per-task red/green TDD evidence + task reviews for all 3 plan tasks; whole-branch review PASS/APPROVED.
- `npm run lint`: 0 errors (12 pre-existing warnings in untouched files).
- `npm run check` (typecheck + coordinated full suite, cloud): green at HEAD 42ed14e88 and again at the post-repair final HEAD 803a050f7.
- Independent Fresh Eyes: plan converged in 2 rounds; complete delta converged in 2 rounds plus one 5-round focused repair episode (5 repair commits, each re-reviewed). No unresolved substantiated findings.

Out-of-scope residuals (recorded, non-blocking): placeholder-only rows vanish at close (nothing to float); a reload during a mid-flight Codex fork handoff can lose the touch across the reload; a legacy shell-mode pane closed during a directory outage gets no touch.