### PR TITLE
fix(freshagent): glom chip shows first line only; root-cause and fix duplicate command at bottom

### DIFF
--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -1147,7 +1147,7 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
           title={glomTarget.text}
         >
           <ChevronUp className="h-3 w-3 shrink-0" aria-hidden="true" />
-          <span className="min-w-0 flex-1 truncate">{glomTarget.text}</span>
+          <span className="min-w-0 flex-1 truncate">{glomTarget.text.split('\n')[0]}</span>
         </button>
       ) : null}
       <FreshAgentTurnContextMenu

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -142,10 +142,30 @@ function getTurnKey(turn: FreshAgentTurn): string {
   return getFreshAgentDisplayTurnKey(turn)
 }
 
+/**
+ * Bidirectional text match between the local echo (raw user input) and the
+ * server-normalised turn text. The server may add content (system context,
+ * metadata) or remove content (strip quoting, trim whitespace), so we check
+ * both directions: the turn text contains the echo text, or the echo text
+ * contains the turn text.
+ */
+function echoTextMatchesTurn(echoText: string, needle: string, turnText: string): boolean {
+  if (turnText.includes(needle)) return true
+  const trimmedTurnText = turnText.trim()
+  return trimmedTurnText.length > 0 && echoText.includes(trimmedTurnText)
+}
+
 type LocalEcho = {
   text: string
   requestId: string
   submittedTurnId?: string
+  /** Turn keys captured at send time — used by the echo-landed check to
+   * distinguish the new server turn from pre-existing turns. Unlike the
+   * previous-snapshot turns, these never include the just-sent turn, so
+   * the text-match guard cannot permanently block the echo from clearing
+   * if the first snapshot's text match fails (e.g. the server normalises
+   * the text by stripping quoting). */
+  previousTurnKeys?: readonly string[]
 }
 
 function sameLocalEcho(a: LocalEcho | null | undefined, b: LocalEcho | null | undefined): boolean {
@@ -172,14 +192,12 @@ function localEchoLanded(
   pending?: PendingSendMetadata,
   options: {
     allowTextMatch?: boolean
-    previousTurns?: readonly FreshAgentTurn[]
+    previousTurnKeys?: Set<string> | null
   } = {},
 ): boolean {
   const needle = echo.text.slice(0, 80)
   const submittedTurnId = echo.submittedTurnId ?? pending?.submittedTurnId
-  const previousTurnKeys = options.previousTurns
-    ? new Set(options.previousTurns.map(getTurnKey))
-    : null
+  const previousTurnKeys = options.previousTurnKeys ?? null
   const canMatchText = Boolean(needle) && (
     options.allowTextMatch === true
     || pending?.legacyAccepted === true
@@ -193,7 +211,7 @@ function localEchoLanded(
       || (
         canMatchText
         && (!previousTurnKeys || !previousTurnKeys.has(getTurnKey(turn)))
-        && freshAgentTurnText(turn).includes(needle)
+        && echoTextMatchesTurn(echo.text, needle, freshAgentTurnText(turn))
       )
     )
   ))
@@ -844,11 +862,18 @@ export function FreshAgentView({
   const setLocalEcho = useCallback((next: LocalEcho | null) => {
     setLocalEchoState(next)
     const current = paneContentRef.current
-    if (sameLocalEcho(current.pendingLocalEcho, next)) return
+    // Strip runtime-only fields (previousTurnKeys) before persisting —
+    // the persisted echo only needs the wire-identity fields. On remount
+    // the echo is restored without previousTurnKeys, which correctly
+    // disables the text-match guard (no send-time turns to compare against).
+    const persisted = next
+      ? { requestId: next.requestId, text: next.text, ...(next.submittedTurnId ? { submittedTurnId: next.submittedTurnId } : {}) }
+      : undefined
+    if (sameLocalEcho(current.pendingLocalEcho, persisted)) return
     dispatch(mergePaneContent({
       tabId,
       paneId,
-      updates: { pendingLocalEcho: next ?? undefined },
+      updates: { pendingLocalEcho: persisted },
     }))
   }, [dispatch, paneId, tabId])
   useEffect(() => {
@@ -2078,7 +2103,7 @@ export function FreshAgentView({
         && agentSessionStatusVersionRef.current === requestAgentSessionStatusVersion
         && localEchoLanded(displaySnapshot.turns, outgoing, pendingSendMetadataRef.current.get(outgoing.requestId), {
           allowTextMatch: true,
-          previousTurns: outgoing.previousTurns,
+          previousTurnKeys: new Set((outgoing.previousTurns ?? []).map(getTurnKey)),
         })
       ) {
         // Reconnect may miss every stream/status event. A current idle snapshot
@@ -2094,7 +2119,7 @@ export function FreshAgentView({
       const landedEcho = echo
         ? localEchoLanded(displaySnapshot.turns, echo, echoPendingMetadata, {
             allowTextMatch: snapshotAccepted,
-            previousTurns: previousSnapshot?.turns,
+            previousTurnKeys: echo.previousTurnKeys ? new Set(echo.previousTurnKeys) : null,
           })
         : false
       // Task 16: 'accepted but not landed' -- the raw input predicate of the
@@ -2543,7 +2568,11 @@ export function FreshAgentView({
         firstMessage: text,
       }))
     }
-    const nextLocalEcho: LocalEcho = { text, requestId }
+    const nextLocalEcho: LocalEcho = {
+      text,
+      requestId,
+      previousTurnKeys: (snapshotRef.current?.turns ?? []).map(getTurnKey),
+    }
     sendFreshAgentSendFrame(requestId, text, routeCwd)
     setLocalEchoState(nextLocalEcho)
     dispatch(mergePaneContent({

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -1466,6 +1466,40 @@ describe('FreshAgentTranscript', () => {
       const chip = screen.getByRole('button', { name: /Jump to your message/ })
       expect(chip).toHaveTextContent('First user message here')
     })
+
+    it('shows only the first line of a multi-line user message, with the full text as tooltip', () => {
+      const MULTILINE = [
+        {
+          id: 'u1',
+          role: 'user' as const,
+          summary: 'First line of command\nSecond line of command\nThird line',
+          items: [{
+            id: 'i1',
+            kind: 'text' as const,
+            text: 'First line of command\nSecond line of command\nThird line',
+          }],
+        },
+        {
+          id: 'a1',
+          role: 'assistant' as const,
+          summary: 'reply',
+          items: [{ id: 'i2', kind: 'text' as const, text: 'A'.repeat(200) }],
+        },
+      ]
+      const { container } = render(<FreshAgentTranscript turns={MULTILINE} />)
+      const scroller = container.querySelector('[data-context="fresh-agent-transcript"]') as HTMLDivElement
+      mockScroll(scroller, 400, 1000, 200)
+      const userTurns = container.querySelectorAll('[data-turn-role="user"]')
+      mockRect(scroller, 0)
+      mockRect(userTurns[0], -100)
+      fireEvent.scroll(scroller)
+
+      const chip = screen.getByRole('button', { name: /Jump to your message/ })
+      expect(chip).toHaveTextContent('First line of command')
+      expect(chip).not.toHaveTextContent('Second line of command')
+      expect(chip).toHaveAttribute('title', 'First line of command\nSecond line of command\nThird line')
+      expect(chip).toHaveAttribute('aria-label', 'Jump to your message: First line of command\nSecond line of command\nThird line')
+    })
   })
 
   describe('turn actions', () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -5309,6 +5309,104 @@ describe('FreshAgentView', () => {
     expect(sentFreshAgentMessages('freshAgent.send').at(-1)?.requestId).toBe(requestId)
   })
 
+  it('clears local echo when the server normalizes the submitted text (e.g. strips quoting)', async () => {
+    const store = createStore()
+    let wsHandler: ((message: any) => void) | undefined
+    wsMock.onMessage.mockImplementation((handler) => {
+      wsHandler = handler
+      return () => {}
+    })
+    apiMock.getFreshAgentThreadSnapshot
+      .mockResolvedValueOnce({
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        threadId: 'ses_echo_normalized',
+        revision: 1,
+        status: 'idle',
+        capabilities: { send: true, interrupt: true, fork: true },
+        turns: [],
+      })
+      .mockResolvedValueOnce({
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        threadId: 'ses_echo_normalized',
+        revision: 2,
+        status: 'running',
+        capabilities: { send: false, interrupt: true, fork: true },
+        turns: [
+          {
+            id: 'turn-real-user',
+            turnId: 'turn-real-user',
+            role: 'user',
+            summary: 'Do the thing',
+            items: [{ id: 'item-real-user', kind: 'text', text: 'Do the thing' }],
+          },
+          {
+            id: 'turn-real-assistant',
+            turnId: 'turn-real-assistant',
+            role: 'assistant',
+            summary: 'Working',
+            items: [{ id: 'item-real-assistant', kind: 'text', text: 'Working' }],
+          },
+        ],
+      })
+    store.dispatch(initLayout({
+      tabId: 'tab-1',
+      paneId: 'pane-1',
+      content: {
+        kind: 'fresh-agent',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        createRequestId: 'req-echo-normalized',
+        sessionId: 'ses_echo_normalized',
+        sessionRef: { provider: 'opencode', sessionId: 'ses_echo_normalized' },
+        resumeSessionId: 'ses_echo_normalized',
+        status: 'idle',
+      },
+    }))
+
+    render(
+      <Provider store={store}>
+        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Chat message input' })).not.toBeDisabled()
+    })
+    // User wraps in quotes; the opencode normalizer strips them server-side
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message input' }), {
+      target: { value: '"Do the thing"' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    // The local echo shows the raw text (with quotes)
+    expect(screen.getByText('"Do the thing"')).toBeInTheDocument()
+
+    act(() => {
+      wsHandler?.({
+        type: 'freshAgent.event',
+        sessionId: 'ses_echo_normalized',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        event: {
+          type: 'freshAgent.session.snapshot',
+          sessionId: 'ses_echo_normalized',
+          status: 'running',
+          latestTurnId: 'turn-real-assistant',
+          revision: 2,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Working')).toBeInTheDocument()
+    })
+    // The echo should be cleared — only the server's normalized turn should be visible
+    expect(screen.getAllByText('Do the thing')).toHaveLength(1)
+    expect(screen.queryByText('"Do the thing"')).not.toBeInTheDocument()
+    expect(getFreshAgentPaneContent(store).pendingLocalEcho).toBeUndefined()
+  })
+
   it('keeps local echo when an older snapshot response is ignored after send acceptance', async () => {
     const store = createStore()
     let wsHandler: ((message: any) => void) | undefined


### PR DESCRIPTION
## Summary

Two fresh-agent pane fixes:

### 1. Glom chip shows only first line
The glom chip (pinned last user message at the top of a fresh agent pane) now shows only the first line of a multi-line message, with the full text as the tooltip (`title`/`aria-label` already carry the full text).

### 2. Root cause: command repeated at bottom of history
When a user sends a message, a **local echo** (optimistic placeholder) renders at the bottom of the transcript for instant feedback while the server processes the turn. It clears once the server's actual turn arrives in a snapshot.

**Root cause:** The `localEchoLanded` text-match check was unidirectional — it only checked `turnText.includes(echoText)`. When the server normalises the user's text (e.g. opencode's `stripOpencodeRunArgumentQuoting` strips surrounding quotes), the turn text is shorter than the echo text, so the match failed. Worse, the `previousTurnKeys` guard (built from `previousSnapshot.turns`) permanently blocked text matching on all subsequent snapshots — the turn was now "previous" — leaving the echo visible alongside the real turn for the entire running phase.

**Fix (two parts):**
1. **Bidirectional text match** (`echoTextMatchesTurn`): also check if `echoText.includes(turnText.trim())`, so server-side normalisation that *removes* content (quote stripping, whitespace trimming) still clears the echo.
2. **Send-time turn keys:** store the turn keys at send time on `LocalEcho.previousTurnKeys` and use those for the guard instead of `previousSnapshot.turns`. The new server turn is never in the send-time set, so the guard can never permanently block it. The persisted `pendingLocalEcho` strips this field (on remount the guard is correctly disabled).

## Test plan
- [x] New unit test: glom chip shows first line of multi-line message with full text tooltip
- [x] New unit test: local echo clears when server normalises text (quote stripping)
- [x] All 1158 existing fresh-agent + pane + store unit tests pass
- [x] Typecheck clean
- [x] Lint clean (only pre-existing warnings)