### PR TITLE
fix(host-stats): read cgroup-v2 limits at the cgroup-namespace-visible root

### DIFF
--- a/crates/freshell-platform/src/host_stats_readers.rs
+++ b/crates/freshell-platform/src/host_stats_readers.rs
@@ -79,24 +79,51 @@ fn safe_read_dir(dir_path: &Path) -> Option<Vec<String>> {
     )
 }
 
-/// Resolve THIS process's cgroup leaf from `<proc_root>/self/cgroup`. The
-/// cgroup fs root has NO limit files by design, so callers must always
-/// resolve the leaf and never read the fs root.
+/// Resolve THIS process's cgroup leaf from `<proc_root>/self/cgroup`.
+///
+/// cgroup v2 namespace contract: a PRIVATE cgroup namespace (Docker's
+/// default on cgroup-v2 hosts) rewrites this process's v2 membership to
+/// `0::/`, and the namespace-visible cgroupfs mount exposes the container's
+/// OWN cgroup at the filesystem root — its memory.current/memory.max/
+/// pids.max live AT `<cgroup_root>` itself. Those limit files only exist at
+/// the root of a namespace-rooted mount: the REAL cgroup2 root of a
+/// non-namespaced host has none of them, so reading at the fs root degrades
+/// to the same `None` fallback as before there. Three v2 shapes therefore
+/// resolve to the fs root (empty path): membership `0::/`, a membership path
+/// that does not exist under `<cgroup_root>`, and a `../`-relative membership
+/// (out-of-namespace per `cgroup_namespaces(7)` — reads at the closest
+/// visible ancestor, never above `<cgroup_root>`). cgroup v1 is unchanged:
+/// v1 has no namespace membership rewrite and the v1 fs root DOES carry
+/// (garbage-sentinel) limit files, so v1 never reads the fs root.
 enum CgroupLeaf {
     V1(String),
+    /// The path may be empty: the cgroup-namespace-visible fs root.
     V2(String),
 }
 
-fn resolve_cgroup_leaf(proc_root: &Path, v1_controller: &str) -> Option<CgroupLeaf> {
+fn resolve_cgroup_leaf(
+    proc_root: &Path,
+    v1_controller: &str,
+    cgroup_root: &Path,
+) -> Option<CgroupLeaf> {
     let text = safe_read(&proc_root.join("self").join("cgroup"))?;
     let lines: Vec<&str> = non_empty_lines(&text).collect();
     // v2 unified hierarchy: a single "0::/path" line.
     for line in &lines {
         if let Some(rest) = line.strip_prefix("0::") {
             let leaf = rest.trim_start_matches('/');
-            if leaf.is_empty() {
-                // process sits at the cgroup2 root: no limit files there
-                return None;
+            // '' is a cgroup-namespace root; a membership path absent from
+            // the mounted cgroupfs is the same namespace shape seen through
+            // /proc; a '../'-relative membership (out-of-namespace) must
+            // never resolve ABOVE the injected root. All three read at the
+            // fs root — the closest visible ancestor; on a real
+            // non-namespaced host the root has no limit files, so the
+            // readers' None fallbacks fire exactly as before.
+            if leaf.is_empty()
+                || leaf.split('/').any(|segment| segment == "..")
+                || !cgroup_root.join(leaf).is_dir()
+            {
+                return Some(CgroupLeaf::V2(String::new()));
             }
             return Some(CgroupLeaf::V2(leaf.to_string()));
         }
@@ -279,15 +306,16 @@ pub struct CgroupMemory {
 /// reads its memory files. v2: `0::/path` -> `<cgroup_root>/path/
 /// memory.current` + `memory.max` ('max' -> `None` limit). v1: `memory`
 /// controller line -> `<cgroup_root>/memory/path/usage_in_bytes` +
-/// `limit_in_bytes` (garbage limit >= 2^60 -> `None`). The cgroup fs root has
-/// NO limit files by design, so the leaf is always resolved; the fs root is
-/// never read.
+/// `limit_in_bytes` (garbage limit >= 2^60 -> `None`). A v2 membership of
+/// `0::/` (cgroup-namespace root, Docker's default) or one whose path is not
+/// mounted resolves to the cgroupfs fs root itself; on a non-namespaced host
+/// that root has no limit files, so `None` falls through as before.
 ///
 /// NOTE (frozen contract): parameter order here is (cgroup_root, proc_root)
 /// — the opposite of [`read_pids_limit`]. Callers: read the signatures, do
 /// not assume.
 pub fn read_cgroup_memory(cgroup_root: &Path, proc_root: &Path) -> Option<CgroupMemory> {
-    let leaf = resolve_cgroup_leaf(proc_root, "memory")?;
+    let leaf = resolve_cgroup_leaf(proc_root, "memory", cgroup_root)?;
     match leaf {
         CgroupLeaf::V2(leaf) => {
             let dir = cgroup_root.join(leaf);
@@ -670,13 +698,14 @@ pub fn read_pid_count(proc_root: &Path) -> Option<u64> {
 /// fall back), else cgroup v1 `pids.max`, else
 /// `/proc/sys/kernel/threads-max`. `/proc/sys/kernel/pid_max` is a PID-number
 /// wrap boundary, NOT a creatable-process cap, and is deliberately never used
-/// (validated R3M2).
+/// (validated R3M2). v2 leaf resolution is namespace-aware: see
+/// [`resolve_cgroup_leaf`].
 ///
 /// NOTE (frozen contract): parameter order here is (proc_root, cgroup_root)
 /// — the opposite of [`read_cgroup_memory`]. Callers: read the signatures,
 /// do not assume.
 pub fn read_pids_limit(proc_root: &Path, cgroup_root: &Path) -> Option<u64> {
-    if let Some(leaf) = resolve_cgroup_leaf(proc_root, "pids") {
+    if let Some(leaf) = resolve_cgroup_leaf(proc_root, "pids", cgroup_root) {
         let dir = match &leaf {
             CgroupLeaf::V2(leaf) => cgroup_root.join(leaf),
             CgroupLeaf::V1(leaf) => cgroup_root.join("pids").join(leaf),
@@ -715,15 +744,24 @@ pub struct PidsConstraint {
 /// system-wide `read_pid_count`/`read_pids_limit` pair). Deepest node wins
 /// ties (deterministic).
 ///
-/// The cgroup fs root has NO limit files by design; [`resolve_cgroup_leaf`]
-/// already yields `None` for a process sitting at the cgroup2 root.
+/// The v2 chain INCLUDES the fs-root node: under a private cgroup namespace
+/// (Docker's default on v2) [`resolve_cgroup_leaf`] yields an empty path and
+/// that root IS the container's cgroup, with real limit files; on a
+/// non-namespaced host the root carries no pids files, so the depth-0 node is
+/// simply skipped. The v1 walk is unchanged (v1 has no namespace membership
+/// rewrite).
 ///
 /// NOTE (frozen contract): parameter order here is (proc_root, cgroup_root)
 /// — the opposite of [`read_cgroup_memory`]. Callers: read the signatures,
 /// do not assume.
 pub fn read_pids_constraint(proc_root: &Path, cgroup_root: &Path) -> Option<PidsConstraint> {
-    let leaf = resolve_cgroup_leaf(proc_root, "pids")?;
-    // Deepest-first chain; the fs-root segment is never read (no limit files).
+    let leaf = resolve_cgroup_leaf(proc_root, "pids", cgroup_root)?;
+    // Deepest-first chain. For v2 the chain INCLUDES the fs-root node (depth
+    // 0 -> empty node path -> `<cgroup_root>` itself): under a private cgroup
+    // namespace that root IS the container's cgroup (with limit files); on a
+    // non-namespaced host the root carries no pids files and the depth-0
+    // node is simply skipped. The v1 walk is unchanged (v1 has no namespace
+    // membership rewrite).
     let segments: Vec<&str> = match &leaf {
         CgroupLeaf::V2(path) | CgroupLeaf::V1(path) => path
             .split('/')
@@ -732,7 +770,11 @@ pub fn read_pids_constraint(proc_root: &Path, cgroup_root: &Path) -> Option<Pids
     };
     let mut best: Option<PidsConstraint> = None;
     let mut best_ratio = -1.0_f64;
-    for depth in (1..=segments.len()).rev() {
+    let min_depth = match &leaf {
+        CgroupLeaf::V2(_) => 0,
+        CgroupLeaf::V1(_) => 1,
+    };
+    for depth in (min_depth..=segments.len()).rev() {
         let node_path = segments[..depth].join("/");
         let dir = match &leaf {
             CgroupLeaf::V2(_) => cgroup_root.join(&node_path),

--- a/crates/freshell-server/src/host_stats.rs
+++ b/crates/freshell-server/src/host_stats.rs
@@ -1624,8 +1624,8 @@ mod tests {
             .expect("v2 leaf resolves");
         assert_eq!(leaf.limit_bytes, None);
         assert_eq!(leaf.current_bytes, 17000000000);
-        // The cgroup fs root has NO limit files by design: a cgroup root that
-        // lacks the leaf tree must NOT fall back to reading the fs root.
+        // The fs-root fallback still finds nothing: a cgroup root that
+        // lacks the leaf tree AND has no top-level limit files yields None.
         let empty = tempfile::tempdir().unwrap();
         assert!(readers::read_cgroup_memory(empty.path(), &procmini_fixture()).is_none());
         // self/cgroup absent -> None (never a panic).
@@ -1706,7 +1706,8 @@ mod tests {
                 max: 678924
             })
         );
-        // A process at the cgroup2 root has no leaf -> None (no fs-root reads).
+        // '0::/' (namespace root) reads the fs root; the committed cgroup
+        // tree has no top-level pids files, so no node qualifies.
         let tmp2 = tempfile::tempdir().unwrap();
         write_rel(&tmp2.path().join("proc"), "self/cgroup", "0::/\n");
         assert_eq!(
@@ -1808,6 +1809,118 @@ mod tests {
             Some(readers::PidsConstraint {
                 current: 900,
                 max: 1000
+            })
+        );
+    }
+
+    #[test]
+    fn host_stats_cgroup_v2_namespace_root_reads() {
+        // 0::/ + namespace-private cgroupfs mount (Docker default on v2
+        // hosts): the container's limit files live AT the fs root.
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        write_rel(&proc_root, "self/cgroup", "0::/\n");
+        write_rel(&proc_root, "sys/kernel/threads-max", "999999\n");
+        write_rel(&cgroup_root, "memory.current", "1073741824\n");
+        write_rel(&cgroup_root, "memory.max", "4294967296\n");
+        write_rel(&cgroup_root, "pids.max", "512\n");
+        write_rel(&cgroup_root, "pids.current", "400\n");
+        assert_eq!(
+            readers::read_cgroup_memory(&cgroup_root, &proc_root),
+            Some(readers::CgroupMemory {
+                limit_bytes: Some(4294967296),
+                current_bytes: 1073741824,
+            })
+        );
+        assert_eq!(
+            readers::read_pids_limit(&proc_root, &cgroup_root),
+            Some(512)
+        );
+        assert_eq!(
+            readers::read_pids_constraint(&proc_root, &cgroup_root),
+            Some(readers::PidsConstraint {
+                current: 400,
+                max: 512,
+            })
+        );
+
+        // 0::/ at the REAL (non-namespaced) host root: no limit files exist
+        // there, so every reader keeps its existing fallback.
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        std::fs::create_dir_all(&cgroup_root).unwrap();
+        write_rel(&proc_root, "self/cgroup", "0::/\n");
+        write_rel(&proc_root, "sys/kernel/threads-max", "4242\n");
+        assert!(readers::read_cgroup_memory(&cgroup_root, &proc_root).is_none());
+        assert!(readers::read_pids_constraint(&proc_root, &cgroup_root).is_none());
+        assert_eq!(
+            readers::read_pids_limit(&proc_root, &cgroup_root),
+            Some(4242)
+        );
+
+        // Membership names a host path that is not mounted under the
+        // cgroupfs mount: read the namespace-visible fs root instead.
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        write_rel(&proc_root, "self/cgroup", "0::/docker/deadbeefcafe\n");
+        write_rel(&cgroup_root, "memory.current", "268435456\n");
+        write_rel(&cgroup_root, "memory.max", "536870912\n");
+        write_rel(&cgroup_root, "pids.max", "256\n");
+        write_rel(&cgroup_root, "pids.current", "10\n");
+        assert_eq!(
+            readers::read_cgroup_memory(&cgroup_root, &proc_root),
+            Some(readers::CgroupMemory {
+                limit_bytes: Some(536870912),
+                current_bytes: 268435456,
+            })
+        );
+        assert_eq!(
+            readers::read_pids_limit(&proc_root, &cgroup_root),
+            Some(256)
+        );
+        assert_eq!(
+            readers::read_pids_constraint(&proc_root, &cgroup_root),
+            Some(readers::PidsConstraint {
+                current: 10,
+                max: 256
+            })
+        );
+
+        // '../'-relative membership (cgroup_namespaces(7): out-of-namespace):
+        // a sibling dir ABOVE the injected root carries different limits; the
+        // resolver must bind the namespace root, never the escape.
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        let cgroup_root = tmp.path().join("cgroup");
+        let escape = tmp.path().join("escape");
+        write_rel(&proc_root, "self/cgroup", "0::/../escape\n");
+        write_rel(&cgroup_root, "memory.current", "1073741824\n");
+        write_rel(&cgroup_root, "memory.max", "4294967296\n");
+        write_rel(&cgroup_root, "pids.max", "512\n");
+        write_rel(&cgroup_root, "pids.current", "400\n");
+        write_rel(&escape, "memory.current", "1\n");
+        write_rel(&escape, "memory.max", "2\n");
+        write_rel(&escape, "pids.max", "999\n");
+        write_rel(&escape, "pids.current", "1\n");
+        assert_eq!(
+            readers::read_cgroup_memory(&cgroup_root, &proc_root),
+            Some(readers::CgroupMemory {
+                limit_bytes: Some(4294967296),
+                current_bytes: 1073741824,
+            })
+        );
+        assert_eq!(
+            readers::read_pids_limit(&proc_root, &cgroup_root),
+            Some(512)
+        );
+        assert_eq!(
+            readers::read_pids_constraint(&proc_root, &cgroup_root),
+            Some(readers::PidsConstraint {
+                current: 400,
+                max: 512,
             })
         );
     }

--- a/server/host-stats/readers.ts
+++ b/server/host-stats/readers.ts
@@ -83,12 +83,40 @@ function safeReaddir(dirPath: string): string[] | null {
 }
 
 /**
- * Resolve THIS process's cgroup leaf from <procRoot>/self/cgroup. The cgroup fs root has NO
- * limit files by design, so callers must always resolve the leaf and never read the fs root.
+ * Directory probe; false instead of throwing. Used by resolveCgroupLeaf to
+ * detect a v2 membership whose path is not present under the mounted
+ * cgroupfs (a mount rooted at the container's own cgroup).
+ */
+function safeIsDir(dirPath: string): boolean {
+  try {
+    return fs.statSync(dirPath).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve THIS process's cgroup leaf from <procRoot>/self/cgroup.
+ *
+ * cgroup v2 namespace contract: a PRIVATE cgroup namespace (Docker's default
+ * on cgroup-v2 hosts) rewrites this process's v2 membership to '0::/', and
+ * the namespace-visible cgroupfs mount exposes the container's OWN cgroup at
+ * the filesystem root — its memory.current/memory.max/pids.max/pids.current
+ * live AT <cgroupRoot> itself. Those limit files exist only at the root of a
+ * namespace-rooted mount: the REAL cgroup2 root of a non-namespaced host has
+ * none of them (only statistics/pressure files), so reads resolved to the fs
+ * root degrade to the same null/threads-max fallbacks as before there. Three
+ * v2 shapes therefore resolve to the fs root (path ''): membership '0::/',
+ * a membership path that does not exist under <cgroupRoot> (a mount rooted
+ * at the container's cgroup while /proc still reports the host path), and a
+ * '../'-relative membership (out-of-namespace — reads at the closest visible
+ * ancestor, never above <cgroupRoot>). cgroup v1 is unchanged: v1 has no
+ * namespace membership rewrite and the v1 fs root DOES carry
+ * (garbage-sentinel) limit files, so v1 never resolves to the fs root.
  */
 type CgroupLeaf = { version: 'v1' | 'v2'; path: string } | null
 
-function resolveCgroupLeaf(procRoot: string, v1Controller: string): CgroupLeaf {
+function resolveCgroupLeaf(procRoot: string, v1Controller: string, cgroupRoot: string): CgroupLeaf {
   const text = safeRead(path.join(procRoot, 'self', 'cgroup'))
   if (text === null) return null
   const lines = splitLines(text)
@@ -96,7 +124,16 @@ function resolveCgroupLeaf(procRoot: string, v1Controller: string): CgroupLeaf {
   const v2 = lines.find((line) => line.startsWith('0::'))
   if (v2) {
     const leaf = v2.slice('0::'.length).replace(/^\/+/, '')
-    if (leaf === '') return null // process sits at the cgroup2 root: no limit files there
+    // '' is a cgroup-namespace root; a membership path absent from the mounted
+    // cgroupfs is the same namespace shape seen through /proc; a '../'-relative
+    // membership is the kernel's encoding for a cgroup outside the visible
+    // namespace (cgroup_namespaces(7)) and must never resolve ABOVE the
+    // injected root. All three read at the fs root — the closest visible
+    // ancestor; on a real non-namespaced host the root has no limit files, so
+    // the readers' null fallbacks fire exactly as before.
+    if (leaf === '' || leaf.split('/').includes('..') || !safeIsDir(path.join(cgroupRoot, leaf))) {
+      return { version: 'v2', path: '' }
+    }
     return { version: 'v2', path: leaf }
   }
   // v1: "<hierarchy>:<controller[,controller...]>:/path"
@@ -197,8 +234,10 @@ export function readMeminfo(
  * Resolves THIS process's cgroup leaf from <procRoot>/self/cgroup and reads its memory files.
  * v2: '0::/path' -> <cgroupRoot>/path/memory.current + memory.max ('max' -> null limit).
  * v1: 'memory' controller line -> <cgroupRoot>/memory/path/usage_in_bytes + limit_in_bytes
- * (garbage limit >= 2^60 -> null). The cgroup fs root has NO limit files by design, so the
- * leaf is always resolved; never read the fs root. None/unreadable -> null.
+ * (garbage limit >= 2^60 -> null). A v2 membership of '0::/' (cgroup-namespace root,
+ * Docker's default) or one whose path is not mounted resolves to the cgroupfs fs root
+ * itself; on a non-namespaced host that root has no limit files, so null falls through
+ * as before. None/unreadable -> null.
  *
  * NOTE (frozen contract): parameter order here is (cgroupRoot, procRoot) — the opposite of
  * readPidsLimit(procRoot, cgroupRoot). Callers: read the signatures, do not assume.
@@ -208,7 +247,7 @@ export function readCgroupMemory(
   procRoot: string = PROC_ROOT,
 ): { limitBytes: number | null; currentBytes: number } | null {
   try {
-    const leaf = resolveCgroupLeaf(procRoot, 'memory')
+    const leaf = resolveCgroupLeaf(procRoot, 'memory', cgroupRoot)
     if (!leaf) return null
     if (leaf.version === 'v2') {
       const dir = path.join(cgroupRoot, leaf.path)
@@ -429,14 +468,15 @@ export function readPidCount(procRoot: string = PROC_ROOT): number | null {
  * The BINDING process cap: cgroup v2 leaf pids.max ('max' -> unlimited -> fall back), else
  * cgroup v1 pids.max, else '/proc/sys/kernel/threads-max'.
  * '/proc/sys/kernel/pid_max' is a PID-number wrap boundary, NOT a creatable-process cap, and
- * is deliberately never used (validated R3M2).
+ * is deliberately never used (validated R3M2). v2 leaf resolution is namespace-aware: see
+ * resolveCgroupLeaf.
  *
  * NOTE (frozen contract): parameter order here is (procRoot, cgroupRoot) — the opposite of
  * readCgroupMemory(cgroupRoot, procRoot). Callers: read the signatures, do not assume.
  */
 export function readPidsLimit(procRoot: string = PROC_ROOT, cgroupRoot: string = CGROUP_ROOT): number | null {
   try {
-    const leaf = resolveCgroupLeaf(procRoot, 'pids')
+    const leaf = resolveCgroupLeaf(procRoot, 'pids', cgroupRoot)
     if (leaf) {
       const dir = leaf.version === 'v2' ? path.join(cgroupRoot, leaf.path) : path.join(cgroupRoot, 'pids', leaf.path)
       const text = safeRead(path.join(dir, 'pids.max'))
@@ -467,8 +507,11 @@ export type PidsConstraint = { current: number; max: number }
  * reading. No qualified node -> null (callers fall back to the system-wide
  * readPidCount/readPidsLimit pair). Deepest node wins ties (deterministic).
  *
- * The cgroup fs root has NO limit files by design; resolveCgroupLeaf already
- * yields null for a process sitting at the cgroup2 root.
+ * The v2 chain INCLUDES the fs-root node: under a private cgroup namespace
+ * (Docker's default on v2) resolveCgroupLeaf yields path '' and that root IS
+ * the container's cgroup, with real limit files; on a non-namespaced host the
+ * root carries no pids files, so the depth-0 node is simply skipped. The v1
+ * walk is unchanged (v1 has no namespace membership rewrite).
  *
  * NOTE (frozen contract): parameter order here is (procRoot, cgroupRoot) — the
  * opposite of readCgroupMemory(cgroupRoot, procRoot). Callers: read the
@@ -479,13 +522,15 @@ export function readPidsConstraint(
   cgroupRoot: string = CGROUP_ROOT,
 ): PidsConstraint | null {
   try {
-    const leaf = resolveCgroupLeaf(procRoot, 'pids')
+    const leaf = resolveCgroupLeaf(procRoot, 'pids', cgroupRoot)
     if (!leaf) return null
-    // Deepest-first chain; the fs-root segment is never read (no limit files).
+    // Deepest-first chain; v2 walks one node past the leaf chain to the fs
+    // root (namespace-visible cgroup), v1 stops at depth 1 as before.
     const segments = leaf.path.split('/').filter((segment) => segment.length > 0)
+    const minDepth = leaf.version === 'v2' ? 0 : 1
     let best: PidsConstraint | null = null
     let bestRatio = -1
-    for (let depth = segments.length; depth >= 1; depth--) {
+    for (let depth = segments.length; depth >= minDepth; depth--) {
       const nodePath = segments.slice(0, depth).join('/')
       const dir =
         leaf.version === 'v2' ? path.join(cgroupRoot, nodePath) : path.join(cgroupRoot, 'pids', nodePath)

--- a/test/unit/server/host-stats/readers.test.ts
+++ b/test/unit/server/host-stats/readers.test.ts
@@ -15,6 +15,9 @@
  *  - small cgroup variant trees (v2 finite limit, v2 pids 'max' fallback,
  *    v1 controllers, pid_max-only) are written into os.tmpdir() at setup,
  *    keeping the committed tree exactly as the plan enumerates.
+ *  - cgroup-v2 namespace variants (membership '0::/' with limit files AT the
+ *    fs root, a membership path absent from the mounted cgroupfs, and a
+ *    '../'-relative membership) are written into os.tmpdir() at setup.
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import fs from 'node:fs'
@@ -83,6 +86,11 @@ let pidsNoCurrentCgroup: string
 let pidsRootCgroupProc: string
 let v1ChainProc: string
 let v1ChainCgroup: string
+let nsV2Proc: string
+let nsV2Cgroup: string
+let nsMissingProc: string
+let nsRootCgroup: string
+let nsEscapeProc: string
 
 function writeFile(root: string, rel: string, content: string): void {
   const full = path.join(root, rel)
@@ -207,10 +215,13 @@ beforeAll(() => {
   writeFile(pidsNoCurrentCgroup, 'slices/c.service/pids.max', 'max\n')
   writeFile(pidsNoCurrentCgroup, 'slices/pids.max', '500\n')
 
-  // Process sits AT the cgroup2 root ('0::/'): no limit files exist there
-  // and resolveCgroupLeaf yields null -> no binding constraint.
+  // Process membership reported as the namespace root ('0::/'); the committed
+  // cgroup tree has no top-level limit files, so even after the
+  // namespace-aware fs-root read there is no binding constraint — the
+  // fallbacks behave exactly as on a real non-namespaced host root.
   pidsRootCgroupProc = path.join(tmp, 'pids-root-cgroup', 'proc')
   writeFile(pidsRootCgroupProc, 'self/cgroup', '0::/\n')
+  writeFile(pidsRootCgroupProc, 'sys/kernel/threads-max', '4242\n')
 
   // v1 pids controller chain: leaf pair finite but low utilization,
   // ancestor pair higher -> the ancestor must win.
@@ -221,6 +232,41 @@ beforeAll(() => {
   writeFile(v1ChainCgroup, 'pids/limited.slice/svc.service/pids.current', '50\n')
   writeFile(v1ChainCgroup, 'pids/limited.slice/pids.max', '1000\n')
   writeFile(v1ChainCgroup, 'pids/limited.slice/pids.current', '900\n')
+
+  // cgroup-v2 NAMESPACE (Docker's default private cgroupns on v2 hosts):
+  // the kernel reports this process's membership as '0::/' and the
+  // namespace-private cgroupfs mount exposes the container's own cgroup —
+  // WITH limit files — at the filesystem root.
+  nsV2Proc = path.join(tmp, 'ns-v2', 'proc')
+  nsV2Cgroup = path.join(tmp, 'ns-v2', 'cgroup')
+  writeFile(nsV2Proc, 'self/cgroup', '0::/\n')
+  writeFile(nsV2Proc, 'sys/kernel/threads-max', '999999\n')
+  writeFile(nsV2Cgroup, 'memory.current', '1073741824\n')
+  writeFile(nsV2Cgroup, 'memory.max', '4294967296\n')
+  writeFile(nsV2Cgroup, 'pids.max', '512\n')
+  writeFile(nsV2Cgroup, 'pids.current', '400\n')
+
+  // Membership names a host path that does NOT exist under the mounted
+  // cgroupfs (mount rooted at the container's cgroup while /proc still
+  // reports the host path): the namespace-visible fs root carries the files.
+  nsMissingProc = path.join(tmp, 'ns-missing', 'proc')
+  nsRootCgroup = path.join(tmp, 'ns-missing', 'cgroup')
+  writeFile(nsMissingProc, 'self/cgroup', '0::/docker/deadbeefcafe\n')
+  writeFile(nsRootCgroup, 'memory.current', '268435456\n')
+  writeFile(nsRootCgroup, 'memory.max', '536870912\n')
+  writeFile(nsRootCgroup, 'pids.max', '256\n')
+  writeFile(nsRootCgroup, 'pids.current', '10\n')
+
+  // '../'-relative membership (cgroup_namespaces(7): a process seen from
+  // outside its cgroup namespace). The sibling 'escape' dir carries
+  // DIFFERENT limit values and sits ABOVE the injected cgroup root; the
+  // resolver must bind the namespace root (nsV2Cgroup), never the escape.
+  nsEscapeProc = path.join(tmp, 'ns-escape', 'proc')
+  writeFile(nsEscapeProc, 'self/cgroup', '0::/../escape\n')
+  writeFile(path.join(tmp, 'ns-v2'), 'escape/memory.current', '1\n')
+  writeFile(path.join(tmp, 'ns-v2'), 'escape/memory.max', '2\n')
+  writeFile(path.join(tmp, 'ns-v2'), 'escape/pids.max', '999\n')
+  writeFile(path.join(tmp, 'ns-v2'), 'escape/pids.current', '1\n')
 })
 
 afterAll(() => {
@@ -301,10 +347,35 @@ describe('readCgroupMemory', () => {
     expect(readCgroupMemory(CGROUP, emptyCgroupRoot)).toBeNull()
   })
 
-  it('returns null when the leaf files are absent (fs root has no limit files by design)', () => {
-    // cgroupRoot exists but the leaf tree does not -> must NOT fall back to
-    // reading the cgroup fs root.
+  it('returns null when neither the leaf nor the fs root has limit files', () => {
+    // cgroupRoot exists but holds no limit files at any depth the namespace
+    // contract can see (leaf tree absent, fs root empty).
     expect(readCgroupMemory(emptyCgroupRoot, PROMINI)).toBeNull()
+  })
+
+  it('reads limit files at the fs root when v2 membership is the namespace root (0::/)', () => {
+    expect(readCgroupMemory(nsV2Cgroup, nsV2Proc)).toEqual({
+      limitBytes: 4294967296,
+      currentBytes: 1073741824,
+    })
+  })
+
+  it('falls back to the fs root when the v2 membership path is not mounted', () => {
+    expect(readCgroupMemory(nsRootCgroup, nsMissingProc)).toEqual({
+      limitBytes: 536870912,
+      currentBytes: 268435456,
+    })
+  })
+
+  it('returns null for 0::/ when the (non-namespaced) fs root has no limit files', () => {
+    expect(readCgroupMemory(emptyCgroupRoot, pidsRootCgroupProc)).toBeNull()
+  })
+
+  it('treats ../-relative v2 membership as the fs root, never above the injected root', () => {
+    expect(readCgroupMemory(nsV2Cgroup, nsEscapeProc)).toEqual({
+      limitBytes: 4294967296,
+      currentBytes: 1073741824,
+    })
   })
 })
 
@@ -470,6 +541,22 @@ describe('readPidsLimit', () => {
   it('never uses /proc/sys/kernel/pid_max (wrap boundary, not a process cap)', () => {
     expect(readPidsLimit(pidMaxOnlyProc, CGROUP)).toBeNull()
   })
+
+  it('reads pids.max at the fs root when v2 membership is the namespace root (0::/)', () => {
+    expect(readPidsLimit(nsV2Proc, nsV2Cgroup)).toBe(512)
+  })
+
+  it('falls back to the fs root when the v2 membership path is not mounted', () => {
+    expect(readPidsLimit(nsMissingProc, nsRootCgroup)).toBe(256)
+  })
+
+  it('reads fs-root pids.max for ../-relative v2 membership (never the escape above the root)', () => {
+    expect(readPidsLimit(nsEscapeProc, nsV2Cgroup)).toBe(512)
+  })
+
+  it('keeps the threads-max fallback for 0::/ at a real (non-namespaced) fs root', () => {
+    expect(readPidsLimit(pidsRootCgroupProc, emptyCgroupRoot)).toBe(4242)
+  })
 })
 
 describe('readPidsConstraint', () => {
@@ -514,12 +601,27 @@ describe('readPidsConstraint', () => {
     expect(readPidsConstraint(v1ChainProc, v1ChainCgroup)).toEqual({ current: 900, max: 1000 })
   })
 
-  it('returns null at the cgroup2 root (no limit files exist there)', () => {
+  it('returns null for 0::/ when the fs root has no pids limit files', () => {
+    // Namespace-root membership resolves to the fs root; the committed cgroup
+    // tree has no top-level pids.max, exactly like a real non-namespaced
+    // host root -> no binding constraint.
     expect(readPidsConstraint(pidsRootCgroupProc, CGROUP)).toBeNull()
   })
 
   it('returns null when there is no cgroup data', () => {
     expect(readPidsConstraint(missing, CGROUP)).toBeNull()
+  })
+
+  it('binds the fs-root node when v2 membership is the namespace root (0::/)', () => {
+    expect(readPidsConstraint(nsV2Proc, nsV2Cgroup)).toEqual({ current: 400, max: 512 })
+  })
+
+  it('binds the fs-root node when the v2 membership path is not mounted', () => {
+    expect(readPidsConstraint(nsMissingProc, nsRootCgroup)).toEqual({ current: 10, max: 256 })
+  })
+
+  it('treats ../-relative v2 membership as the fs root, never above the injected root', () => {
+    expect(readPidsConstraint(nsEscapeProc, nsV2Cgroup)).toEqual({ current: 400, max: 512 })
   })
 })
 


### PR DESCRIPTION
## Summary

Darkforge job 6rbc — host-pressure pane fix for Docker's default cgroup-v2 private namespace.

The host-stats readers (Node `server/host-stats/readers.ts` + Rust mirror `crates/freshell-platform/src/host_stats_readers.rs`) discarded a cgroup-v2 membership of `0::/`, assuming the cgroupfs root never carries limit files. Under a private cgroup namespace (Docker's default on v2) the kernel rewrites membership to `0::/` and the namespaced mount exposes the container's own cgroup at the filesystem root — so Freshell in a default container fell back to HOST memory/pids limits and could report ALL GOOD right before the container hit its real cap.

Both mirrors now resolve three v2 shapes to the namespace-visible fs root: `0::/`, a membership path absent from the mounted cgroupfs, and a `../`-relative (out-of-namespace) membership, which never resolves above the injected root. On a real non-namespaced host the true cgroup2 root has no resource-control files (kernel design), so fallbacks are unchanged — pinned by tests. cgroup v1 behavior is untouched; public reader signatures are frozen.

## Evidence

- Full QA gate (`darkforge qa`) accepted at this exact commit: 5422 passed; the only 3 failures are the recorded pre-existing `codex-adapter.test.ts` baseline identities.
- Plan Fresh Eyes: PASSED (round 2). Delta Fresh Eyes: PASSED (round 1), zero findings.
- New tests pin: namespaced `0::/` memory/pids reads, unmounted-path fallback, `../`-relative decoy never escaping the root, and non-namespaced fallback preservation.

## Notes

- The pane label remains "VM limit" for cgroup-sourced limits (now including Docker containers); relabeling is deferred to a possible follow-up.
- Authored autonomously by Darkforge job 6rbc; full plan is appended to the landing commit message.
