### PR TITLE
test(host-stats): pin the Limits tile's cgroup-scoped pids pair at the service layer

### DIFF
--- a/crates/freshell-server/src/host_stats.rs
+++ b/crates/freshell-server/src/host_stats.rs
@@ -1721,6 +1721,46 @@ mod tests {
         );
     }
 
+    /// f0ef threaded case at the tile-facing layer: procmini carries 7
+    /// numeric top-level dirs (non-leader threads invisible to a /proc walk)
+    /// while the cgroup counts 42 tasks — the service must surface the
+    /// cgroup-scoped pair, never the process-count heuristic. (Node mirror:
+    /// test/unit/server/host-stats/service-fixture.test.ts.)
+    #[test]
+    fn host_stats_limits_section_binds_committed_threaded_fixture() {
+        let interest = HostStatsInterestRegistry::default();
+        let collector = test_collector(procmini_fixture(), sys_fixture(), &interest);
+        let limits = collector.ctx.read_limits_section();
+        assert!(limits.available);
+        assert_eq!(limits.pids_used, Some(42));
+        assert_eq!(limits.pids_max, Some(10854));
+        assert_eq!(readers::read_pid_count(&procmini_fixture()), Some(7));
+    }
+
+    /// f0ef namespace-divergence case: outside a PID namespace a top-level
+    /// /proc walk also sees UNRELATED cgroups' processes; the correctly
+    /// scoped pids.current is unaffected by the noise.
+    #[test]
+    fn host_stats_limits_section_ignores_unrelated_proc_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proc_root = tmp.path().join("proc");
+        write_rel(
+            &proc_root,
+            "self/cgroup",
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/freshell-rust.service\n",
+        );
+        for pid in 9000..9030u32 {
+            std::fs::create_dir_all(proc_root.join(pid.to_string())).unwrap();
+        }
+        assert_eq!(readers::read_pid_count(&proc_root), Some(30));
+        let interest = HostStatsInterestRegistry::default();
+        let collector = test_collector(proc_root, sys_fixture(), &interest);
+        let limits = collector.ctx.read_limits_section();
+        assert!(limits.available);
+        assert_eq!(limits.pids_used, Some(42));
+        assert_eq!(limits.pids_max, Some(10854));
+    }
+
     #[test]
     fn host_stats_pids_constraint_binds_highest_utilization_node() {
         // Leaf 90/100 (0.9) beats ancestor 500/1000 (0.5).

--- a/test/unit/server/host-stats/service-fixture.test.ts
+++ b/test/unit/server/host-stats/service-fixture.test.ts
@@ -1,0 +1,98 @@
+/**
+ * f0ef pinning coverage: the Limits tile surfaces the cgroup-scope pids pair.
+ *
+ * Unlike service.test.ts, this file does NOT mock the readers module: the real
+ * readers run against the committed test/fixtures/host-stats tree, pinning the
+ * readLimitsSection wiring itself (service.ts "pids constraint" branch):
+ *   - threaded case: procmini carries 7 numeric top-level dirs (non-leader
+ *     threads have no top-level /proc dir) while the cgroup counts 42 tasks;
+ *     the tile must show the cgroup-scoped 42, never the /proc walk's 7.
+ *   - namespace-divergence case: outside a PID namespace a top-level /proc
+ *     walk also sees UNRELATED cgroups' processes; a synthetic 30-dir overlay
+ *     inflates the legacy count while the cgroup-scoped pids.current is
+ *     unaffected.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { HostStatsService } from '../../../../server/host-stats/service.js'
+import { readPidCount } from '../../../../server/host-stats/readers.js'
+
+// Silence structured logging (same child-logger shape as service.test.ts).
+vi.mock('../../../../server/logger.js', () => {
+  const child = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn(), fatal: vi.fn(), trace: vi.fn() }
+  return { logger: { child: () => child }, __childLogger: child }
+})
+
+// Same fake-monitor pattern as service.test.ts (event-loop section contract
+// is out of scope here; the real monitor would still work).
+vi.mock('node:perf_hooks', () => ({
+  monitorEventLoopDelay: vi.fn(() => ({
+    enable: vi.fn(), disable: vi.fn(), reset: vi.fn(), percentile: vi.fn(() => 3_200_000),
+  })),
+}))
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, '../../../fixtures/host-stats')
+const PROMINI = path.join(FIXTURES, 'procmini') // 7 numeric dirs + self/cgroup
+const SYS = path.join(FIXTURES, 'sys') // …/fs/cgroup/…/freshell-rust.service/{pids.current=42, pids.max=10854}
+
+let services: HostStatsService[] = []
+let tmpDirs: string[] = []
+
+function makeWiredService(procRoot: string): HostStatsService {
+  const service = new HostStatsService({ procRoot, sysRoot: SYS, fastMs: 2000, slowMs: 5000 })
+  services.push(service)
+  return service
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  for (const service of services) service.stop()
+  services = []
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true })
+  tmpDirs = []
+  vi.useRealTimers()
+})
+
+describe('limits tile: cgroup-scoped pids pair through the real readers', () => {
+  it('surfaces pids.current=42 from the committed threaded fixture, not the 7-dir /proc count', () => {
+    // Threaded divergence the kata names: group accounting counts TIDs (42),
+    // top-level /proc iteration sees only thread leaders (7).
+    expect(readPidCount(PROMINI)).toBe(7)
+    const service = makeWiredService(PROMINI)
+    service.start()
+    vi.advanceTimersByTime(5000) // first slow tick populates limits
+    expect(service.getSnapshot().live.limits).toEqual({
+      available: true,
+      fdsUsed: null,
+      fdsMax: null,
+      pidsUsed: 42,
+      pidsMax: 10854,
+      timeWait: null,
+      ephemeralPorts: null,
+    })
+  })
+
+  it('stays cgroup-scoped when unrelated processes inflate the /proc walk (30 dirs)', () => {
+    // Namespace-divergence the kata names: outside a PID namespace the legacy
+    // count includes OTHER cgroups' processes; pids.current does not.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'freshell-f0ef-pids-'))
+    tmpDirs.push(tmp)
+    const tmpProc = path.join(tmp, 'proc')
+    fs.mkdirSync(path.join(tmpProc, 'self'), { recursive: true })
+    fs.copyFileSync(path.join(PROMINI, 'self', 'cgroup'), path.join(tmpProc, 'self', 'cgroup'))
+    for (let pid = 9000; pid < 9030; pid += 1) fs.mkdirSync(path.join(tmpProc, String(pid)))
+    expect(readPidCount(tmpProc)).toBe(30)
+    const service = makeWiredService(tmpProc)
+    service.start()
+    vi.advanceTimersByTime(5000)
+    expect(service.getSnapshot().live.limits.pidsUsed).toBe(42)
+    expect(service.getSnapshot().live.limits.pidsMax).toBe(10854)
+  })
+})


### PR DESCRIPTION
## What

Test-only pinning coverage for the host-stats Limits tile's pids pair, on both stacks:

- `test/unit/server/host-stats/service-fixture.test.ts` (new): drives the REAL reader stack through `HostStatsService` against the committed threaded fixture (7 numeric top-level `/proc` dirs vs `pids.current` 42) and a synthetic unrelated-processes overlay (30 dirs), asserting the tile-facing number is always the cgroup-scoped pair (42/10854), never the legacy heuristic.
- `crates/freshell-server/src/host_stats.rs`: two mirror tests at the pinned anchor in `mod tests` asserting the same properties for `read_limits_section`.

## Why

The production fix (read `pids.current` from the same cgroup node as `pids.max`, legacy heuristic only as fallback) landed in #731. What was missing: the Node service tests mock the entire readers module, so a wiring regression (dropped constraint call, or swapped `procRoot`/`cgroupRoot` — the frozen argument orders differ) would pass the suite while shipping the heuristic to the tile. These tests pin the wiring. Both were proven non-decorative by mutation probe during TDD (disarmed wiring → failures showing legacy values `7`/`30` Node, `Some(7)`/`Some(30)` Rust; restored → pass with `42`/`10854`).

Production code, fixtures, and the wire shape (`pidsUsed`/`pidsMax` nullable ints) are unchanged. Disjoint from the concurrently-landed cgroup-namespace-root work (darkforge/6rbc, merged adjacent to this); post-rebase focused suites verified green on the reconciled tree (host-stats vitest 106/106; `cargo test -p freshell-server host_stats` 28/28; `-p freshell-platform host_stats_readers` 4/4).

## Verification

- Focused suites above, plus Task-2 `cargo fmt --all -- --check` and `cargo clippy -p freshell-server --all-targets -- -D warnings` green on this content.
- Darkforge full QA gate accepted at this exact commit (`441e0abe9`): server suite nonzero with exactly the three ledgered pre-existing `codex-adapter` identities (`preexisting_ok`); zero new failures.

Surfaced by an independent review round during the sidebar-status-sort run (#710 review cycle).
