### PR TITLE
test: re-home stale codex/claude model references after #732 catalog update

### DIFF
--- a/test/e2e-browser/specs/fresh-agent-control-rust.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent-control-rust.spec.ts
@@ -1859,18 +1859,18 @@ test.describe('fresh-agent control surfaces — codex lane (rust)', () => {
 
       // Change model + effort BETWEEN sends through the real settings UI:
       // gear popover → Model row ("Change…") → the two-column model dialog →
-      // pick GPT-5.4 Flash, stage its `low` thinking level, commit.
+      // pick GPT-5.6 Sol, stage its `low` thinking level, commit.
       await page.getByRole('button', { name: 'Agent settings' }).click()
       const popover = page.getByRole('dialog', { name: 'Agent settings' })
       await expect(popover).toBeVisible({ timeout: 10_000 })
       await popover.getByRole('button', { name: /Change/ }).click()
       const dialog = page.getByRole('dialog', { name: 'Model and thinking level' })
       await expect(dialog).toBeVisible({ timeout: 10_000 })
-      await dialog.getByRole('option', { name: 'GPT-5.4 Flash' }).click()
-      const levelsList = dialog.getByRole('listbox', { name: 'Thinking levels for GPT-5.4 Flash' })
+      await dialog.getByRole('option', { name: 'GPT-5.6 Sol' }).click()
+      const levelsList = dialog.getByRole('listbox', { name: 'Thinking levels for GPT-5.6 Sol' })
       await expect(levelsList).toBeVisible()
       await levelsList.getByRole('option', { name: 'low', exact: true }).click()
-      await dialog.getByRole('button', { name: 'Use GPT-5.4 Flash · low' }).click()
+      await dialog.getByRole('button', { name: 'Use GPT-5.6 Sol · low' }).click()
       await expect(dialog).toHaveCount(0)
       // The commit leaves the settings popover open behind the dialog; close it.
       await page.keyboard.press('Escape')
@@ -1880,7 +1880,7 @@ test.describe('fresh-agent control surfaces — codex lane (rust)', () => {
           const content = (await paneLeaf(lane.harness, lane.tabId))?.content
           return content ? `${content.model ?? ''}|${content.effort ?? ''}` : ''
         })
-        .toBe('gpt-5.4-flash|low')
+        .toBe('gpt-5.6-sol|low')
 
       // Turn 2 must now carry the changed knobs (canonical's codex.rs merges
       // msg.settings over the session baseline before turn/start).
@@ -1890,15 +1890,15 @@ test.describe('fresh-agent control surfaces — codex lane (rust)', () => {
       // CODEX_HOME (<home>/.codex/fake-turns/<threadId>.json). Each recorded
       // turn carries its captured turn/start params additively under `start` —
       // turn 2 carries the per-send selection while turn 1 kept the defaults
-      // (gpt-5.5 / the default 'max' effort, wire-mapped 'xhigh' by
+      // (gpt-6-astra / the default 'max' effort, wire-mapped 'xhigh' by
       // to_codex_reasoning_effort).
       const turnsPath = path.join(lane.info.homeDir, '.codex', 'fake-turns', `${threadId}.json`)
       await expect(async () => {
         const turns = JSON.parse(await fs.readFile(turnsPath, 'utf8')) as any[]
         expect(turns, 'exactly the two recorded turns').toHaveLength(2)
-        expect(turns[1]?.start?.model).toBe('gpt-5.4-flash')
+        expect(turns[1]?.start?.model).toBe('gpt-5.6-sol')
         expect(turns[1]?.start?.effort).toBe('low')
-        expect(turns[0]?.start?.model).toBe('gpt-5.5')
+        expect(turns[0]?.start?.model).toBe('gpt-6-astra')
         expect(turns[0]?.start?.effort).toBe('xhigh')
         expect(turns[0]?.start?.model).not.toBe(turns[1]?.start?.model)
         expect(turns[0]?.start?.effort).not.toBe(turns[1]?.start?.effort)

--- a/test/e2e-browser/specs/fresh-agent-model-dialog-parity.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent-model-dialog-parity.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '../helpers/fixtures.js'
 async function installPane(page: Page, provider: 'claude' | 'codex') {
   const sessionType = provider === 'claude' ? 'freshclaude' : 'freshcodex'
   const sessionId = 'd4430000-0000-4444-8444-000000000001'
-  const model = provider === 'claude' ? 'opus[1m]' : 'gpt-5.5'
+  const model = provider === 'claude' ? 'opus[1m]' : 'gpt-6-astra'
   await page.route('**/api/fresh-agent/threads/**', (route) => route.fulfill({
     json: {
       sessionType, provider, sessionId, threadId: sessionId,
@@ -67,11 +67,11 @@ test('Codex cancels a staged model change and preserves its current thinking lev
   const chip = page.getByRole('button', { name: /^Model:.*change model$/ })
   await chip.click()
   const dialog = page.getByRole('dialog', { name: 'Model and thinking level' })
-  await expect(dialog.getByRole('button', { name: 'Use GPT-5.5 · low' })).toBeVisible()
-  await dialog.getByRole('option', { name: /GPT-5.4 Flash/ }).click()
+  await expect(dialog.getByRole('button', { name: 'Use GPT-6 Astra · low' })).toBeVisible()
+  await dialog.getByRole('option', { name: /GPT-5.6 Sol/ }).click()
   await dialog.getByRole('button', { name: 'Cancel', exact: true }).click()
   await chip.click()
-  await dialog.getByRole('button', { name: 'Use GPT-5.5 · low' }).click()
+  await dialog.getByRole('button', { name: 'Use GPT-6 Astra · low' }).click()
   await page.getByRole('button', { name: 'Agent settings', exact: true }).click()
   const permissions = page.getByRole('combobox', { name: 'Permission mode' })
   await permissions.selectOption('untrusted')

--- a/test/unit/server/fresh-agent/codex-adapter.test.ts
+++ b/test/unit/server/fresh-agent/codex-adapter.test.ts
@@ -1015,7 +1015,7 @@ describe('Codex fresh-agent adapter', () => {
     await adapter.send?.('thread-new-1', {
       requestId: 'send-model-1',
       text: 'Use the small model',
-      settings: { model: 'gpt-5.4-flash' },
+      settings: { model: 'gpt-5.6-sol' },
     })
 
     const snapshot = await adapter.getSnapshot?.({
@@ -1025,8 +1025,8 @@ describe('Codex fresh-agent adapter', () => {
     }, 7) as any
     expect(snapshot.turns).toHaveLength(3)
     expect(snapshot.turns[0]).not.toHaveProperty('model')
-    expect(snapshot.turns[1]).toMatchObject({ role: 'user', model: 'gpt-5.4-flash' })
-    expect(snapshot.turns[2]).toMatchObject({ role: 'assistant', model: 'gpt-5.4-flash' })
+    expect(snapshot.turns[1]).toMatchObject({ role: 'user', model: 'gpt-5.6-sol' })
+    expect(snapshot.turns[2]).toMatchObject({ role: 'assistant', model: 'gpt-5.6-sol' })
   })
 
   it('subscribes to Codex lifecycle notifications and projects matching thread updates', async () => {
@@ -1428,7 +1428,7 @@ describe('Codex fresh-agent adapter', () => {
       permissionMode: 'on-request',
       sandbox: 'workspace-write',
       effort: 'max',
-      model: 'gpt-5.5',
+      model: 'gpt-5.6-sol',
     })
 
     await adapter.send?.('thread-new-1', {
@@ -1446,7 +1446,7 @@ describe('Codex fresh-agent adapter', () => {
       cwd: '/repo',
       approvalPolicy: 'on-request',
       sandboxPolicy: { type: 'workspaceWrite' },
-      model: 'gpt-5.5',
+      model: 'gpt-5.6-sol',
       effort: 'xhigh',
     })
     expect(runtime.interruptTurn).toHaveBeenCalledWith({
@@ -1505,18 +1505,21 @@ describe('Codex fresh-agent adapter', () => {
     await expect(adapter.create({
       requestId: 'req-1',
       sessionType: 'freshcodex',
-      model: 'gpt-5.4-flash',
-      effort: 'xhigh',
+      // 'none' is a real level on the 5.6 models but gpt-6-astra does not offer it,
+      // so it must clamp to astra's declared default ('max').
+      model: 'gpt-6-astra',
+      effort: 'none',
     })).resolves.toEqual({ sessionId: 'thread-new-1', sessionRef: { provider: 'codex', sessionId: 'thread-new-1' } })
 
     await adapter.send?.('thread-new-1', { text: 'reply ok' })
 
     expect(runtime.startThread).toHaveBeenCalledWith(expect.objectContaining({
-      model: 'gpt-5.4-flash',
+      model: 'gpt-6-astra',
     }))
     expect(runtime.startTurn).toHaveBeenCalledWith(expect.objectContaining({
-      model: 'gpt-5.4-flash',
-      effort: 'high',
+      model: 'gpt-6-astra',
+      // 'none' clamped to astra's default ('max'), wire-mapped to codex's top level 'xhigh'.
+      effort: 'xhigh',
     }))
   })
 


### PR DESCRIPTION
## What

PR #732 (de8bcc3e0) updated the freshcodex catalog to {gpt-6-astra (default), gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.3-codex-spark}, retiring gpt-5.5 / gpt-5.4-flash. Unknown models now clamp to the default on both the TS normalize path and the Rust port (crates/freshell-codex/src/model.rs). Three unit tests + two e2e specs that pinned retired models went RED on merged main (base-gate at 7b86de3c1: `test/unit/server/fresh-agent/codex-adapter.test.ts` 3/49).

Root system issue: PR CI gates only on clippy / contract / typecheck-client / rust-test — it does NOT run the Node vitest suites, so this class of drift landed silently.

## Changes

- `test/unit/server/fresh-agent/codex-adapter.test.ts`:
  - Per-turn relabel + turn-shape tests now use `gpt-5.6-sol` (a catalog member, preserving the flow-through semantics).
  - The effort-normalization test now uses `gpt-6-astra` + effort `'none'` (a level astra does not offer) so the per-model clamp is still exercised: resolves to astra's declared default `'max'`, wire-mapped to codex's `'xhigh'`.
- `test/e2e-browser/specs/fresh-agent-control-rust.spec.ts`: model dialog drives GPT-5.6 Sol/low; turn payload assertions updated (turn 1 untouched defaults = gpt-6-astra / xhigh).
- `test/e2e-browser/specs/fresh-agent-model-dialog-parity.spec.ts`: codex pane model is the catalog default gpt-6-astra; staged-then-cancelled option is GPT-5.6 Sol.

## What I left alone

Fixtures that echo arbitrary model strings without normalizing (fake sidecars, session-history display paths, config-store user values, model-id display-name formatters) — they're load-bearing against behavior that is unchanged, and editing them would be cosmetic noise.

## Verification

- Adapter unit file: 49/49 local.
- Coordinated broad cloud suite (`npm test`, FRESHELL_VITEST_BACKEND=cloud) on this branch: exit 0.
- Cloud e2e, affected specs: `fresh-agent-model-dialog-parity.spec.ts` (chromium) — green; `fresh-agent-control-rust.spec.ts` (rust-chromium) — green.
- `npm run typecheck` clean.