### PR TITLE
test(codex-fixture): persist witness logs before sending RPC responses

### DIFF
--- a/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
+++ b/test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs
@@ -792,12 +792,19 @@ wss.on('connection', (socket) => {
       await writeBytes(process.stdout, floodStdoutBytes)
       await writeBytes(process.stderr, floodStderrBytes)
       const result = override?.result ?? successResult(method, message.params)
+      // Durable witnesses land BEFORE the RPC response (kata rb5h). socket.send copies
+      // the frame into the kernel synchronously, so on a loaded multi-core host a client
+      // on another core can observe the response and assert the witness files while THIS
+      // process is preempted inside a send→append window — that exact interleaving twice
+      // emptied scenario 2's thread-op log on cloud shards even though the append here is
+      // appendFileSync. Persisting first gives tests a real happens-before: a resolved
+      // response implies the witness entry is already on disk.
+      appendThreadOperation(method, message.params, result)
+      maybeWriteRolloutForMethod(method, message.params)
       socket.send(JSON.stringify({
         id: message.id,
         result,
       }))
-      appendThreadOperation(method, message.params, result)
-      maybeWriteRolloutForMethod(method, message.params)
       if (method === 'thread/compact/start') {
         // The compact RPC result is empty; the lifecycle rides notifications.
         await emitCompactNotificationSequence(message.params?.threadId)


### PR DESCRIPTION
## Problem

kata rb5h: `sidecar-reattach` scenario 2 flaked twice on cloud shards with an EMPTY thread-op log despite the resume RPC resolving. The fixture wrote its op-log/rollout witnesses AFTER `socket.send()`; ws copies frames into the kernel synchronously, so on a loaded multi-core shard the test process (another core) could observe the resolved response and assert the witness files while THIS process was preempted inside the send→append window. `appendFileSync` did not help — preemption happens between statements, not inside syscalls.

## Fix

Persist witnesses FIRST (write-ahead-log order): a resolved response now implies the witness entry is already durable on disk, making the scenario assertions race-free by construction. The reorder is behavior-preserving for all correct consumers (same observable file content, strictly earlier persistence).