### PR TITLE
fix(claude): map 5th-gen models to 1M window + elevate on observed prompts (kata 9c92)

### DIFF
--- a/crates/freshell-sessions/src/parse/claude.rs
+++ b/crates/freshell-sessions/src/parse/claude.rs
@@ -28,6 +28,13 @@ fn claude_model_context_window(model: Option<&str>) -> i64 {
     let normalized = model.to_lowercase();
     let normalized = normalized.trim();
     match normalized {
+        // kata 9c92: 5th-gen claude sessions run the 1M "context-1m" window (Claude
+        // Code's `opus[1m]`-style models; canonical JSONL ids carry no suffix).
+        // Verified on local corpora: opus-5 prompts up to 579,832 served without
+        // prompt-too-long (and sonnet-5 237K, fable-5 353K, opus-4-8 227K — all beyond
+        // any 200K window's 95% autocompact cliff), so these sessions could only have
+        // been served on the 1M beta.
+        "claude-opus-5" | "claude-sonnet-5" | "claude-fable-5" | "claude-opus-4-8" => 1_000_000,
         "claude-opus-4-20250514"
         | "claude-sonnet-4-20250514"
         | "claude-3-7-sonnet-latest"
@@ -42,6 +49,26 @@ fn claude_model_context_window(model: Option<&str>) -> i64 {
         | "claude-3-haiku-20240307" => 200_000,
         _ => CLAUDE_DEFAULT_CONTEXT_WINDOW,
     }
+}
+
+/// Window tiers the JSONL can never carry: the transcript records the canonical model
+/// id but not the session's effective window. A prompt that was SERVED above the
+/// mapped window proves the real window is larger (a true 200K session compacts at
+/// 95% ≈ 190K and can never exceed it), so elevate to the smallest tier that covers
+/// the observed maximum prompt — never below the table value. Parity mirror of
+/// `elevateClaudeContextWindow` in server/coding-cli/providers/claude.ts.
+const CLAUDE_CONTEXT_WINDOW_TIERS: [i64; 2] = [200_000, 1_000_000];
+
+fn elevate_claude_context_window(mapped_window: i64, max_prompt_tokens: i64) -> i64 {
+    if max_prompt_tokens <= mapped_window {
+        return mapped_window;
+    }
+    for tier in CLAUDE_CONTEXT_WINDOW_TIERS {
+        if tier >= max_prompt_tokens {
+            return mapped_window.max(tier);
+        }
+    }
+    max_prompt_tokens
 }
 
 /// `resolveClaudeCompactPercentThreshold` — reads `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`.
@@ -268,6 +295,7 @@ pub fn parse_session_content(content: &str, options: &ParseSessionOptions) -> Pa
     let mut user_message_count: i64 = 0;
     let mut usage_seen: HashSet<String> = HashSet::new();
     let mut latest_usage: Option<LatestUsage> = None;
+    let mut max_prompt_tokens: i64 = 0;
 
     for line in &lines {
         let obj: Value = match serde_json::from_str(line) {
@@ -476,6 +504,12 @@ pub fn parse_session_content(content: &str, options: &ParseSessionOptions) -> Pa
                         output_tokens: output as i64,
                         cached_tokens: (cache_read + cache_creation) as i64,
                     });
+                    // kata 9c92: largest SERVED prompt (deduped) drives window
+                    // elevation when the mapped window is provably too small.
+                    let prompt = input + cache_read + cache_creation;
+                    if prompt as i64 > max_prompt_tokens {
+                        max_prompt_tokens = prompt as i64;
+                    }
                 }
             }
         }
@@ -498,7 +532,10 @@ pub fn parse_session_content(content: &str, options: &ParseSessionOptions) -> Pa
     let token_usage = latest_usage.map(|u| {
         let context_tokens_from_usage = u.input_tokens + u.output_tokens + u.cached_tokens;
         let context_tokens = options.context_tokens.unwrap_or(context_tokens_from_usage);
-        let model_context_window = claude_model_context_window(model.as_deref());
+        let model_context_window = elevate_claude_context_window(
+            claude_model_context_window(model.as_deref()),
+            max_prompt_tokens,
+        );
         let compact_threshold_tokens = options.compact_threshold_tokens.unwrap_or_else(|| {
             ((model_context_window * resolve_claude_compact_percent_threshold()) as f64 / 100.0)
                 .round() as i64

--- a/crates/freshell-sessions/tests/claude_fixture_parity.rs
+++ b/crates/freshell-sessions/tests/claude_fixture_parity.rs
@@ -249,3 +249,51 @@ fn malformed_line_never_panics_across_all_committed_fixtures() {
         assert!(meta.message_count >= 0, "{name} produced a meta");
     }
 }
+
+#[test]
+fn fifth_gen_claude_models_map_to_1m_window() {
+    // kata 9c92: 5th-gen claude sessions run the 1M "context-1m" window.
+    // prompt = 50000 + 45000 + 5000 = 100000 ≤ 1M → no elevation.
+    let meta = parse_str(concat!(
+        "{\"type\":\"assistant\",\"uuid\":\"uuid-opus5-1m\",\"message\":",
+        "{\"role\":\"assistant\",\"model\":\"claude-opus-5\",\"usage\":",
+        "{\"input_tokens\":50000,\"output_tokens\":4000,",
+        "\"cache_read_input_tokens\":45000,\"cache_creation_input_tokens\":5000}}}\n",
+    ));
+    let usage = meta.token_usage.expect("token_usage");
+    assert_eq!(usage.model_context_window, Some(1_000_000));
+    assert_eq!(usage.compact_threshold_tokens, Some(950_000));
+    // context = 50000 + 4000 + 45000 + 5000 = 104000; round(104000/950000*100) = 11
+    assert_eq!(usage.compact_percent, Some(11));
+}
+
+#[test]
+fn elevation_lifts_window_when_prompt_exceeds_mapped_window() {
+    // kata 9c92: a 200K-mapped model with a served prompt of 388178 — only possible
+    // on a larger real window (a true 200K session compacts at 190K). Elevation → 1M.
+    let meta = parse_str(concat!(
+        "{\"type\":\"assistant\",\"uuid\":\"uuid-elevated\",\"message\":",
+        "{\"role\":\"assistant\",\"model\":\"claude-sonnet-4-20250514\",\"usage\":",
+        "{\"input_tokens\":2,\"output_tokens\":8,",
+        "\"cache_read_input_tokens\":384514,\"cache_creation_input_tokens\":3662}}}\n",
+    ));
+    let usage = meta.token_usage.expect("token_usage");
+    assert_eq!(usage.model_context_window, Some(1_000_000));
+    assert_eq!(usage.compact_threshold_tokens, Some(950_000));
+    // context = 2 + 8 + 384514 + 3662 = 388186; round(388186/950000*100) = 41
+    assert_eq!(usage.compact_percent, Some(41));
+}
+
+#[test]
+fn no_elevation_when_prompt_within_mapped_window() {
+    // kata 9c92: 200K model, prompt 190K (at the 95% cliff) — no elevation.
+    let meta = parse_str(concat!(
+        "{\"type\":\"assistant\",\"uuid\":\"uuid-cliff\",\"message\":",
+        "{\"role\":\"assistant\",\"model\":\"claude-sonnet-4-20250514\",\"usage\":",
+        "{\"input_tokens\":190000,\"output_tokens\":5,",
+        "\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n",
+    ));
+    let usage = meta.token_usage.expect("token_usage");
+    assert_eq!(usage.model_context_window, Some(200_000));
+    assert_eq!(usage.compact_threshold_tokens, Some(190_000));
+}

--- a/server/coding-cli/providers/claude.ts
+++ b/server/coding-cli/providers/claude.ts
@@ -35,6 +35,15 @@ const CLAUDE_DEBUG_AUTOCOMPACT_TAIL_BYTES = 128 * 1024
 const CLAUDE_DEBUG_AUTOCOMPACT_MAX_READ_BYTES = 4 * 1024 * 1024
 
 const CLAUDE_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  // kata 9c92: 5th-gen claude sessions run the 1M "context-1m" window (Claude Code's
+  // `opus[1m]`-style models; canonical JSONL ids carry no suffix). Verified on local
+  // corpora: opus-5 prompts up to 579,832 served without prompt-too-long (and
+  // sonnet-5 237K, fable-5 353K, opus-4-8 227K — all beyond any 200K window's 95%
+  // autocompact cliff), so these sessions could only have been served on the 1M beta.
+  'claude-opus-5': 1_000_000,
+  'claude-sonnet-5': 1_000_000,
+  'claude-fable-5': 1_000_000,
+  'claude-opus-4-8': 1_000_000,
   'claude-opus-4-20250514': 200_000,
   'claude-sonnet-4-20250514': 200_000,
   'claude-3-7-sonnet-latest': 200_000,
@@ -47,6 +56,22 @@ const CLAUDE_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'claude-3-opus-20240229': 200_000,
   'claude-3-sonnet-20240229': 200_000,
   'claude-3-haiku-20240307': 200_000,
+}
+
+// Window tiers the JSONL can never carry: the transcript records the canonical model id
+// but not the session's effective window. A prompt that was SERVED above the mapped
+// window proves the real window is larger (a true 200K session compacts at 95% ≈ 190K
+// and can never exceed it), so elevate to the smallest tier that covers the observed
+// maximum prompt — never below the table value. This keeps immature 1M sessions honest
+// without overstating immature 200K sessions.
+const CLAUDE_CONTEXT_WINDOW_TIERS: readonly number[] = [200_000, 1_000_000]
+
+function elevateClaudeContextWindow(mappedWindow: number, maxPromptTokens: number): number {
+  if (maxPromptTokens <= mappedWindow) return mappedWindow
+  for (const tier of CLAUDE_CONTEXT_WINDOW_TIERS) {
+    if (tier >= maxPromptTokens) return Math.max(mappedWindow, tier)
+  }
+  return maxPromptTokens
 }
 
 type ClaudeDebugAutocompactSnapshot = {
@@ -339,6 +364,7 @@ export function parseSessionContent(content: string, options: ParseSessionOption
   let model: string | undefined
   let userMessageCount = 0
   const usageSeen = new Set<string>()
+  let maxPromptTokens = 0
   let latestUsage:
     | {
       inputTokens: number
@@ -461,13 +487,17 @@ export function parseSessionContent(content: string, options: ParseSessionOption
       const dedupeKey = assistantUsageDedupKey(obj, line)
       if (!usageSeen.has(dedupeKey)) {
         usageSeen.add(dedupeKey)
+        const inputTokens = toFiniteNumber(usage.input_tokens) ?? 0
+        const cacheReadTokens = toFiniteNumber(usage.cache_read_input_tokens) ?? 0
+        const cacheCreationTokens = toFiniteNumber(usage.cache_creation_input_tokens) ?? 0
         latestUsage = {
-          inputTokens: toFiniteNumber(usage.input_tokens) ?? 0,
+          inputTokens,
           outputTokens: toFiniteNumber(usage.output_tokens) ?? 0,
-          cachedTokens:
-            (toFiniteNumber(usage.cache_read_input_tokens) ?? 0) +
-            (toFiniteNumber(usage.cache_creation_input_tokens) ?? 0),
+          cachedTokens: cacheReadTokens + cacheCreationTokens,
         }
+        // kata 9c92: track the largest SERVED prompt so an unknown/oversized real
+        // window can be self-healed by elevation (see elevateClaudeContextWindow).
+        maxPromptTokens = Math.max(maxPromptTokens, inputTokens + cacheReadTokens + cacheCreationTokens)
       }
     }
   }
@@ -485,7 +515,7 @@ export function parseSessionContent(content: string, options: ParseSessionOption
   if (latestUsage) {
     const contextTokensFromUsage = latestUsage.inputTokens + latestUsage.outputTokens + latestUsage.cachedTokens
     const contextTokens = options.contextTokens ?? contextTokensFromUsage
-    const modelContextWindow = resolveClaudeContextWindow(model)
+    const modelContextWindow = elevateClaudeContextWindow(resolveClaudeContextWindow(model), maxPromptTokens)
     const compactThresholdTokens =
       options.compactThresholdTokens ??
       Math.round((modelContextWindow * resolveClaudeCompactPercentThreshold()) / 100)

--- a/test/unit/server/coding-cli/claude-provider.test.ts
+++ b/test/unit/server/coding-cli/claude-provider.test.ts
@@ -323,6 +323,86 @@ describe('parseSessionContent() - token usage snapshots', () => {
     expect(meta.tokenUsage?.compactPercent).toBe(100)
   })
 
+  it('maps 5th-gen claude models to the 1M context window (kata 9c92)', () => {
+    const content = [
+      JSON.stringify({
+        type: 'assistant',
+        uuid: 'uuid-opus5-1m',
+        message: {
+          role: 'assistant',
+          model: 'claude-opus-5',
+          usage: {
+            input_tokens: 50_000,
+            output_tokens: 4_000,
+            cache_read_input_tokens: 45_000,
+            cache_creation_input_tokens: 5_000,
+          },
+        },
+      }),
+    ].join('\n')
+
+    const meta = parseSessionContent(content)
+
+    expect(meta.tokenUsage?.modelContextWindow).toBe(1_000_000)
+    expect(meta.tokenUsage?.compactThresholdTokens).toBe(950_000)
+    // contextTokens = 50000 + 4000 + 45000 + 5000 = 104000; 104000/950000 ≈ 11
+    expect(meta.tokenUsage?.compactPercent).toBe(Math.round((104_000 / 950_000) * 100))
+  })
+
+  it('elevates the effective window when a served prompt exceeds the mapped window (kata 9c92)', () => {
+    // A 200K-mapped model (claude-sonnet-4-20250514) with a prompt of 388,178 —
+    // only possible if the real window is larger (a true 200K session compacts
+    // at 95% ≈ 190K and can never serve 388K). Elevation lifts to 1M.
+    const content = [
+      JSON.stringify({
+        type: 'assistant',
+        uuid: 'uuid-elevated',
+        message: {
+          role: 'assistant',
+          model: 'claude-sonnet-4-20250514',
+          usage: {
+            input_tokens: 2,
+            output_tokens: 8,
+            cache_read_input_tokens: 384_514,
+            cache_creation_input_tokens: 3_662,
+          },
+        },
+      }),
+    ].join('\n')
+
+    const meta = parseSessionContent(content)
+
+    expect(meta.tokenUsage?.modelContextWindow).toBe(1_000_000)
+    expect(meta.tokenUsage?.compactThresholdTokens).toBe(950_000)
+    // contextTokens = 2 + 8 + 384514 + 3662 = 388186; 388186/950000 ≈ 41
+    expect(meta.tokenUsage?.compactPercent).toBe(Math.round((388_186 / 950_000) * 100))
+  })
+
+  it('does not elevate when the prompt stays within the mapped window', () => {
+    // Same 200K model, prompt 190K (right at the 95% cliff) — no elevation.
+    const content = [
+      JSON.stringify({
+        type: 'assistant',
+        uuid: 'uuid-cliff',
+        message: {
+          role: 'assistant',
+          model: 'claude-sonnet-4-20250514',
+          usage: {
+            input_tokens: 190_000,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      }),
+    ].join('\n')
+
+    const meta = parseSessionContent(content)
+
+    expect(meta.tokenUsage?.modelContextWindow).toBe(200_000)
+    expect(meta.tokenUsage?.compactThresholdTokens).toBe(190_000)
+  })
+
   it('supports compact-threshold overrides sourced outside session JSON (e.g. debug logs)', () => {
     const content = [
       JSON.stringify({


### PR DESCRIPTION
## Problem

The fresh-agent status strip showed wrong token percentages (up to 212% clamped to 100%) for 5th-gen claude sessions (opus-5, sonnet-5, fable-5, opus-4-8) because the model→context-window tables in both the Node and Rust parsers predated these models and mapped them to the 200K default. The user's Claude Code runs `opus[1m]` (1M context); local corpora confirm prompts up to 579,832 served — only possible on the 1M window.

## Fix (parity-mirrored across both parsers)

1. **Table rows** for `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, `claude-opus-4-8` → 1,000,000 (evidence: 580K+ served prompts; Claude Code's own catalog labels these 'Claude Opus 5 (1M context)').

2. **Elevation floor**: track the max served prompt (deduped) per session; if it exceeds the mapped window, elevate to the smallest tier [200K, 1M] that covers it (or to the raw max beyond all tiers). A true 200K session compacts at 95% ≈ 190K and can never serve beyond that, so elevation never misfires on a 200K session. This self-heals unknown models / future generations without table maintenance.

## Verification

- Node unit tests: 82/82 (3 new cases: 5th-gen mapping, elevation, no-elevation guard).
- Rust parity tests: 16/16 (3 new inline cases mirroring the Node tests).
- `npm run typecheck` clean; `cargo clippy -p freshell-sessions --tests` clean.
- Simulated against 122 local claude sessions: 50 offenders (max 212%) under old math → 0 offenders under new math.