### PR TITLE
fix(fresh-agent): unify transcript turn right-clicks into the global fresh-agent context menu

### DIFF
--- a/src/components/context-menu/ContextMenuProvider.tsx
+++ b/src/components/context-menu/ContextMenuProvider.tsx
@@ -62,7 +62,7 @@ import type { ContextTarget } from './context-menu-types'
 import { ContextMenu } from './ContextMenu'
 import { ContextIds } from './context-menu-constants'
 import { buildMenuItems } from './menu-defs'
-import { copyDataset, isFreshAgentSpecializedRegion, isTextInputLike, parseContextTarget } from './context-menu-utils'
+import { copyDataset, isTextInputLike, parseContextTarget } from './context-menu-utils'
 import {
   copyFreshAgentCodeBlock,
   copyFreshAgentToolInput,
@@ -146,11 +146,12 @@ function findContextElement(start: HTMLElement | null): HTMLElement | null {
 }
 
 /**
- * Fresh-agent transcript turn articles (sole producer: FreshAgentTranscript)
- * own their contextmenu gesture entirely — the transcript always installs a
- * turn handler per pointer kind (turn menu on fine pointers, action sheet on
- * coarse). The provider's capture-phase document listener would otherwise
- * beat that bubble-phase handler and stack its pane menu at the same point.
+ * True when the target sits inside a fresh-agent transcript turn article
+ * (sole producer: FreshAgentTranscript). Because the transcript installs a
+ * per-article contextmenu handler only for its touch action sheet, the
+ * provider's capture-phase listener uses this predicate for the remaining
+ * gesture-scoped carve-out: while a touch gesture is in flight on a turn, the
+ * sheet owns it and no provider menu may open.
  */
 function isFreshAgentTurnTarget(el: HTMLElement | null): boolean {
   return !!el?.closest?.('article[data-turn-role]')
@@ -1120,31 +1121,26 @@ export function ContextMenuProvider({
 
     const handleContextMenu = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null
-      // Turn articles own their contextmenu gesture (see predicate comment) —
-      // no openMenu, and we cancel the event on the early return: for an
-      // article-targeted event the transcript's bubble-phase handler cancels
-      // it too (a harmless double cancel — opening the transcript's menu does
-      // not depend on defaultPrevented), while a late sheet-targeted event has
-      // no transcript handler at all, so the provider must cancel it here or
-      // the browser shows its native context menu over the sheet. While a
-      // touch gesture is in flight (the Android-race case-B condition below),
-      // resolve ownership against the gesture's ORIGINAL target, not e.target:
-      // a late native contextmenu retargeted onto the transcript's action
-      // sheet would otherwise bypass this check and stack the provider menu on
-      // top. For non-turn gestures the recorded target fails the predicate
-      // identically to e.target, so their behavior is unchanged.
+      // One menu system owns every fresh-agent right-click: fine-pointer
+      // turns, specialized sub-regions, and pane background all flow through
+      // the fresh-agent menu builder below (it selects region- and turn-aware
+      // items). The transcript's bubble-phase article handler installs no
+      // handler at all on fine pointers. The carve-out that remains is
+      // gesture-scoped: while a touch gesture is in flight on a turn article,
+      // the transcript's long-press action sheet owns the whole turn, and we
+      // must not stack a menu on it. We still cancel the event on the early
+      // return: for an article-targeted event the transcript's bubble-phase
+      // handler cancels it too (a harmless double cancel), while a late
+      // sheet-targeted event has no transcript handler at all — without a
+      // cancel here the browser shows its native context menu over the sheet.
+      // Since a late native contextmenu can arrive retargeted onto the
+      // just-opened sheet (Android-race case B below), ownership resolves
+      // against the gesture's ORIGINAL target, not e.target. For non-turn
+      // gestures the recorded target fails the predicate identically to
+      // e.target, so their behavior is unchanged.
       const gestureInFlight = touchStartPos !== null || longPressTimer !== null
       const ownershipTarget = gestureInFlight ? touchGestureTarget : target
-      // Fine-pointer (no touch gesture in flight) right-clicks into the turn's
-      // specialized sub-regions (markdown code blocks, tool input/output,
-      // diffs) fall through to the normal fresh-agent menu below so their
-      // context-sensitive items ("Copy code block", "Copy output", ...) stay
-      // available — the transcript article yields this gesture to us. A touch
-      // gesture in flight (early or late Android contextmenu) keeps the
-      // carve-out: the transcript's action sheet owns the whole turn on
-      // coarse pointers, which never install specialized-region menus.
-      if (isFreshAgentTurnTarget(ownershipTarget)
-        && !(isFreshAgentSpecializedRegion(ownershipTarget) && !gestureInFlight)) {
+      if (gestureInFlight && isFreshAgentTurnTarget(ownershipTarget)) {
         if (e.cancelable) e.preventDefault()
         return
       }

--- a/src/components/context-menu/context-menu-utils.ts
+++ b/src/components/context-menu/context-menu-utils.ts
@@ -55,21 +55,6 @@ export function isTextInputLike(el: HTMLElement | null): boolean {
   return false
 }
 
-/**
- * Fresh-agent transcript turns: specialized sub-regions (markdown code
- * blocks, tool input/output rows, diff views) keep the PROVIDER's
- * context-sensitive menu on fine pointers instead of the whole-turn menu.
- * Both `ContextMenuProvider`'s turn carve-out and `FreshAgentTranscript`'s
- * article onContextMenu key off this predicate.
- *
- * KEEP IN SYNC: the selector list must mirror the fresh-agent sub-region
- * `closest()` selectors in menu-defs.ts ("Detect sub-region from click
- * target") EXACTLY — edit both together.
- */
-export function isFreshAgentSpecializedRegion(el: HTMLElement | null): boolean {
-  return !!el?.closest?.('.prose pre code, [data-tool-input], [data-tool-output], [data-diff]')
-}
-
 export function parseContextTarget(contextId: ContextId, data: ContextDataset): ContextTarget | null {
   switch (contextId) {
     case ContextIds.Global:

--- a/src/components/context-menu/menu-defs.ts
+++ b/src/components/context-menu/menu-defs.ts
@@ -16,7 +16,8 @@ import type { PaneNode, PaneContent } from '@/store/paneTypes'
 import { buildPaneRefreshTarget, findPaneContent } from '@/lib/pane-utils'
 import { collectSessionRefsFromNode } from '@/lib/session-utils'
 import type { TerminalActions, EditorActions, BrowserActions } from '@/lib/pane-action-registry'
-import { getFreshAgentPaneActions } from '@/lib/pane-action-registry'
+import { getFreshAgentPaneActions, getFreshAgentTurnItemsBuilder } from '@/lib/pane-action-registry'
+import type { ActionSheetItem } from '@/components/fresh-agent/FreshAgentActionSheet'
 import { buildResumeCommand, isResumeCommandProvider, type ResumeCommandProvider } from '@/lib/coding-cli-utils'
 import {
   resolveReopenPaneSessionTarget,
@@ -743,13 +744,17 @@ export function buildMenuItems(target: ContextTarget, ctx: MenuBuildContext): Me
     const selection = window.getSelection()
     const hasSelection = !!(selection && selection.toString().trim())
 
-    // Detect sub-region from click target using closest()
-    // KEEP IN SYNC: these selectors must mirror isFreshAgentSpecializedRegion
-    // in context-menu-utils.ts EXACTLY — edit both together.
+    // One menu, region-aware items: the specialized sub-region partition
+    // (markdown code blocks, tool input/output rows, diff views) selects WHICH
+    // rows this menu shows — it no longer decides which menu renders. Plain
+    // turn regions (inside a turn article but outside every specialized
+    // sub-region) prepend the pane-registered per-turn actions; specialized
+    // sub-regions keep their context-sensitive rows and gain no turn rows.
     const codeBlock = clickTarget?.closest?.('.prose pre code') as HTMLElement | null
     const toolInput = clickTarget?.closest?.('[data-tool-input]') as HTMLElement | null
     const toolOutput = clickTarget?.closest?.('[data-tool-output]') as HTMLElement | null
     const diffView = clickTarget?.closest?.('[data-diff]') as HTMLElement | null
+    const isSpecializedRegion = !!(codeBlock || toolInput || toolOutput || diffView)
 
     const items: MenuItem[] = [
       {
@@ -877,8 +882,37 @@ export function buildMenuItems(target: ContextTarget, ctx: MenuBuildContext): Me
       )
     }
 
+    // Plain-text region of a turn article: prepend the per-turn rows the pane
+    // registered (single item builder, buildTurnActionItems — the same builder
+    // the touch action sheet consumes). Specialized sub-regions above stay
+    // turn-row-free, exactly as the PR-#735 partition decided; it now selects
+    // items within this one menu instead of handing the gesture between menus.
+    const turnArticle = clickTarget?.closest?.('article[data-turn-role]') as HTMLElement | null
+    const turnArticleIndex = turnArticle?.getAttribute('data-turn-index')
+    if (target.paneId && turnArticle && !isSpecializedRegion && turnArticleIndex != null) {
+      const index = Number(turnArticleIndex)
+      const turnItems = Number.isNaN(index)
+        ? null
+        : getFreshAgentTurnItemsBuilder(target.paneId)?.(index)
+      if (turnItems && turnItems.length > 0) {
+        return [...turnActionItemsToMenuItems(turnItems), { type: 'separator', id: 'fc-turn-sep' }, ...items]
+      }
+    }
+
     return items
   }
 
   return []
+}
+
+/** Adapt the shared turn-action sheet vocabulary onto the context-menu row shape. */
+function turnActionItemsToMenuItems(items: ActionSheetItem[]): MenuItem[] {
+  return items.map((item) => ({
+    type: 'item',
+    id: `fc-turn-${item.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+    label: item.label,
+    disabled: item.disabled,
+    danger: item.destructive,
+    onSelect: () => item.run(),
+  }))
 }

--- a/src/components/fresh-agent/FreshAgentTranscript.tsx
+++ b/src/components/fresh-agent/FreshAgentTranscript.tsx
@@ -15,12 +15,10 @@ import {
 import {
   buildTurnActionItems,
   FreshAgentTurnActions,
-  FreshAgentTurnContextMenu,
   turnPlainText,
-  type FreshAgentTurnContextMenuState,
 } from './FreshAgentTurnActions'
 import { FreshAgentActionSheet } from './FreshAgentActionSheet'
-import { isFreshAgentSpecializedRegion } from '@/components/context-menu/context-menu-utils'
+import { registerFreshAgentTurnItems } from '@/lib/pane-action-registry'
 import { buildLongPressHandlers, useCoarsePointer } from '@/lib/pointer'
 import { getFreshAgentDisplayTurnKey, turnSummaryIsAuthored } from '@shared/fresh-agent-turns'
 
@@ -724,7 +722,6 @@ type TurnActionProps = {
   canRollback?: boolean
   rollbackBusy?: boolean
   onRollbackToTurn?: (turnId: string) => void
-  onTurnContextMenu?: (event: React.MouseEvent, turn: FreshAgentTurn) => void
   /** Coarse-pointer path: open the bottom action sheet for this turn. */
   onOpenActions?: (turn: FreshAgentTurn) => void
 }
@@ -806,6 +803,9 @@ function FreshAgentTurnArticle({
         continuation && 'mt-1.5',
       )}
       data-turn-role={turn.role}
+      // Load-bearing beyond the glom chip: the global ContextMenuProvider's
+      // fresh-agent menu reads this index at right-click time and resolves
+      // the action turn through the pane-registered builder below.
       data-turn-index={index}
       data-turn-continuation={continuation ? 'true' : 'false'}
       // Ownership marker for the global ContextMenuProvider: present exactly
@@ -816,31 +816,20 @@ function FreshAgentTurnArticle({
       data-longpress-owned={longPress ? 'true' : undefined}
       aria-label={`${turnLabel} transcript turn`}
       onContextMenu={(event) => {
-        // The global ContextMenuProvider's document listener is capture-phase,
-        // so stopPropagation could never beat it — the real protection today is
-        // the provider's early-return carve-out for article[data-turn-role]
-        // targets. stopPropagation is kept as cheap, correct event hygiene.
-        if (actions.onOpenActions) {
-          event.preventDefault()
-          event.stopPropagation()
-          // The sheet opens mid-touch via this native-contextmenu route (no
-          // long-press timer involved): mark the overlay open so the gesture's
-          // touchend suppresses the synthesized compat click.
-          longPress?.notifyOverlayOpened?.()
-          actions.onOpenActions(actionTurn)
-          return
-        }
-        if (!actions.onTurnContextMenu) return
-        // Fine-pointer right-click into a specialized sub-region (markdown
-        // code block, tool input/output, diff): yield WITHOUT cancelling the
-        // event or opening the turn menu — the provider's capture-phase
-        // handler already opened its context-sensitive fresh-agent menu for
-        // this gesture (on coarse pointers the sheet branch above owns the
-        // whole turn and never yields).
-        if (isFreshAgentSpecializedRegion(event.target as HTMLElement | null)) return
+        // Coarse pointers only: open the bottom action sheet. On fine
+        // pointers this article installs no behavior at all — the global
+        // ContextMenuProvider's capture-phase document listener owns every
+        // fresh-agent right-click and already opened its unified menu for
+        // this gesture (turn action rows ride in via the pane-registered
+        // builder, so the transcript needs no menu of its own).
+        if (!actions.onOpenActions) return
         event.preventDefault()
         event.stopPropagation()
-        actions.onTurnContextMenu(event, actionTurn)
+        // The sheet opens mid-touch via this native-contextmenu route (no
+        // long-press timer involved): mark the overlay open so the gesture's
+        // touchend suppresses the synthesized compat click.
+        longPress?.notifyOverlayOpened?.()
+        actions.onOpenActions(actionTurn)
       }}
       {...(longPress?.handlers ?? {})}
     >
@@ -916,6 +905,11 @@ export type FreshAgentTranscriptHandle = {
 
 export type FreshAgentTranscriptProps = {
   turns: FreshAgentTurn[]
+  /** Owning pane. When present, the transcript registers a pane-scoped
+   * turn-items builder so the global ContextMenuProvider's fresh-agent menu
+   * can show per-turn rows for plain-text turn regions. Omitted in
+   * isolation/tests: no context-menu turn rows are registered. */
+  paneId?: string
   canFork?: boolean
   agentLabel?: string
   showModel?: boolean
@@ -943,6 +937,7 @@ export type FreshAgentTranscriptProps = {
 
 export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, FreshAgentTranscriptProps>(function FreshAgentTranscript({
   turns,
+  paneId,
   canFork = false,
   agentLabel,
   showModel = false,
@@ -963,7 +958,6 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const [atBottom, setAtBottom] = useState(true)
   const [newMessages, setNewMessages] = useState(0)
-  const [contextMenu, setContextMenu] = useState<FreshAgentTurnContextMenuState>(null)
   const [sheetTurn, setSheetTurn] = useState<FreshAgentTurn | null>(null)
   const [glomTarget, setGlomTarget] = useState<{ index: number; text: string } | null>(null)
   const coarsePointer = useCoarsePointer()
@@ -1045,10 +1039,6 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
     el?.scrollIntoView?.({ block: 'start' })
   }, [glomTarget])
 
-  const handleTurnContextMenu = useCallback((event: React.MouseEvent, turn: FreshAgentTurn) => {
-    setContextMenu({ x: event.clientX, y: event.clientY, turn })
-  }, [])
-
   const handleOpenActions = useCallback((turn: FreshAgentTurn) => {
     setSheetTurn(turn)
   }, [])
@@ -1060,9 +1050,31 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
     canRollback,
     rollbackBusy,
     onRollbackToTurn,
-    onTurnContextMenu: coarsePointer ? undefined : handleTurnContextMenu,
     onOpenActions: coarsePointer ? handleOpenActions : undefined,
-  }), [canFork, canRollback, coarsePointer, handleOpenActions, handleTurnContextMenu, onForkFromTurn, onRewindToTurn, onRollbackToTurn, rollbackBusy])
+  }), [canFork, canRollback, coarsePointer, handleOpenActions, onForkFromTurn, onRewindToTurn, onRollbackToTurn, rollbackBusy])
+
+  // Desktop right-click surface: the global ContextMenuProvider owns every
+  // fresh-agent contextmenu gesture and asks this pane's registered builder
+  // for the per-turn rows. Registering HERE (not in the pane view) keeps the
+  // article-index → action-turn resolution next to the merged-line layout it
+  // depends on (lineEndIndex), so a merged activity line still forks/undoes/
+  // rewinds its LAST contributing turn. Same items as the touch action sheet:
+  // buildTurnActionItems is the single builder for both surfaces.
+  useEffect(() => {
+    if (!paneId) return
+    return registerFreshAgentTurnItems(paneId, (articleIndex) => {
+      const turn = displayTurns[lineEndIndex.get(articleIndex) ?? articleIndex]
+      if (!turn) return null
+      return buildTurnActionItems(turn, {
+        canFork,
+        canRollback,
+        rollbackBusy,
+        onForkFromTurn,
+        onRollbackToTurn,
+        onRewindToTurn,
+      })
+    })
+  }, [paneId, displayTurns, lineEndIndex, canFork, canRollback, rollbackBusy, onForkFromTurn, onRollbackToTurn, onRewindToTurn])
 
   useImperativeHandle(ref, () => ({
     scrollByLine: (direction) => {
@@ -1200,16 +1212,6 @@ export const FreshAgentTranscript = forwardRef<FreshAgentTranscriptHandle, Fresh
           <span className="min-w-0 flex-1 truncate">{glomTarget.text.split('\n')[0]}</span>
         </button>
       ) : null}
-      <FreshAgentTurnContextMenu
-        state={contextMenu}
-        canFork={canFork}
-        canRollback={canRollback}
-        rollbackBusy={rollbackBusy}
-        onForkFromTurn={onForkFromTurn}
-        onRollbackToTurn={onRollbackToTurn}
-        onRewindToTurn={onRewindToTurn}
-        onClose={() => setContextMenu(null)}
-      />
       {sheetTurn ? (
         <FreshAgentActionSheet
           title={turnPlainText(sheetTurn).slice(0, 80) || getTurnLabel(sheetTurn, agentLabel)}

--- a/src/components/fresh-agent/FreshAgentTurnActions.tsx
+++ b/src/components/fresh-agent/FreshAgentTurnActions.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Check, Copy, GitFork, History, MoreHorizontal, Undo2 } from 'lucide-react'
 import { copyText } from '@/lib/clipboard'
 import type { FreshAgentTurn } from '@shared/fresh-agent-contract'
 import { stripSystemReminders } from './FreshAgentItemCard'
 import type { ActionSheetItem } from './FreshAgentActionSheet'
-import { cn } from '@/lib/utils'
 
 export function turnPlainText(turn: FreshAgentTurn): string {
   const text = turn.items
@@ -29,8 +28,10 @@ export type TurnActionCallbacks = {
 }
 
 /**
- * One source of truth for what you can do to a turn — consumed by the desktop
- * context menu and the mobile action sheet so they never drift apart.
+ * One source of truth for what you can do to a turn — consumed by the mobile
+ * action sheet directly and by the desktop unified context menu through the
+ * transcript's pane-registered FreshAgentTurnItemsBuilder, so the two
+ * surfaces never drift apart.
  */
 export function buildTurnActionItems(turn: FreshAgentTurn, callbacks: TurnActionCallbacks): ActionSheetItem[] {
   return [
@@ -64,7 +65,10 @@ export function buildTurnActionItems(turn: FreshAgentTurn, callbacks: TurnAction
 /**
  * Per-turn affordances. Pointer-capability aware:
  * - hover/fine: a hover toolbar (copy / fork / rewind) — hidden entirely on
- *   no-hover devices via the (hover:none) media variant;
+ *   no-hover devices via the (hover:none) media variant; right-click is owned
+ *   by the global ContextMenuProvider's unified fresh-agent menu (the turn
+ *   rows ride in through the pane-registered builder the transcript registers
+ *   around buildTurnActionItems);
  * - touch/no-hover: an always-visible ⋯ button (44px target) that opens the
  *   bottom action sheet; long-press on the turn does the same.
  */
@@ -160,70 +164,4 @@ export function FreshAgentTurnActions({
   )
 }
 
-type ContextMenuState = { x: number; y: number; turn: FreshAgentTurn } | null
 
-/**
- * Floating right-click menu for fine pointers. Touch devices use
- * FreshAgentActionSheet instead (same items via buildTurnActionItems).
- */
-export function FreshAgentTurnContextMenu({
-  state,
-  canFork,
-  canRollback,
-  rollbackBusy,
-  onForkFromTurn,
-  onRollbackToTurn,
-  onRewindToTurn,
-  onClose,
-}: TurnActionCallbacks & {
-  state: ContextMenuState
-  onClose: () => void
-}) {
-  useEffect(() => {
-    if (!state) return
-    const handle = () => onClose()
-    document.addEventListener('click', handle)
-    document.addEventListener('contextmenu', handle)
-    return () => {
-      document.removeEventListener('click', handle)
-      document.removeEventListener('contextmenu', handle)
-    }
-  }, [onClose, state])
-
-  if (!state) return null
-
-  const items = buildTurnActionItems(state.turn, { canFork, canRollback, rollbackBusy, onForkFromTurn, onRollbackToTurn, onRewindToTurn })
-
-  return (
-    <div
-      role="menu"
-      aria-label="Turn context menu"
-      className="fixed z-50 min-w-[220px] rounded-md border border-border bg-popover p-1 text-sm shadow-lg"
-      style={{
-        left: Math.min(state.x, typeof window !== 'undefined' ? window.innerWidth - 240 : state.x),
-        top: Math.min(state.y, typeof window !== 'undefined' ? window.innerHeight - 150 : state.y),
-      }}
-    >
-      {items.map((item) => (
-        <button
-          key={item.label}
-          type="button"
-          role="menuitem"
-          disabled={item.disabled}
-          className={cn(
-            'block w-full rounded px-3 py-1.5 text-left transition-colors',
-            item.disabled ? 'cursor-not-allowed opacity-40' : 'hover:bg-accent hover:text-accent-foreground',
-          )}
-          onClick={() => {
-            onClose()
-            if (!item.disabled) item.run()
-          }}
-        >
-          {item.label}
-        </button>
-      ))}
-    </div>
-  )
-}
-
-export type { ContextMenuState as FreshAgentTurnContextMenuState }

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -2895,6 +2895,7 @@ export function FreshAgentView({
             </div>
             <FreshAgentTranscript
               ref={transcriptRef}
+              paneId={paneId}
               turns={localEcho
                 ? [...turns, {
                     id: `__local-echo:${localEcho.requestId}`,

--- a/src/lib/pane-action-registry.ts
+++ b/src/lib/pane-action-registry.ts
@@ -1,3 +1,5 @@
+import type { ActionSheetItem } from '@/components/fresh-agent/FreshAgentActionSheet'
+
 export type TerminalActions = {
   copySelection: () => Promise<void> | void
   paste: () => Promise<void> | void
@@ -60,6 +62,33 @@ export function registerFreshAgentPaneActions(paneId: string, actions: FreshAgen
 
 export function getFreshAgentPaneActions(paneId: string): FreshAgentPaneActions | undefined {
   return freshAgentActionsRegistry.get(paneId)
+}
+
+/**
+ * Per-turn action items for the unified fresh-agent context menu, keyed by the
+ * owning pane. Registered by FreshAgentTranscript (the one place that can map
+ * a rendered article index to its action turn through the merged-line layout);
+ * consumed by the global ContextMenuProvider's fresh-agent menu builder, which
+ * prepends them for plain-text turn regions. Shares the item vocabulary with
+ * the touch action sheet (both flow from buildTurnActionItems), so desktop and
+ * mobile never drift. null/undefined means "no turn at that article index" —
+ * the menu then shows only its region/base rows.
+ */
+export type FreshAgentTurnItemsBuilder = (articleIndex: number) => ActionSheetItem[] | null
+
+const freshAgentTurnItemsRegistry = new Map<string, FreshAgentTurnItemsBuilder>()
+
+export function registerFreshAgentTurnItems(paneId: string, builder: FreshAgentTurnItemsBuilder): () => void {
+  freshAgentTurnItemsRegistry.set(paneId, builder)
+  return () => {
+    if (freshAgentTurnItemsRegistry.get(paneId) === builder) {
+      freshAgentTurnItemsRegistry.delete(paneId)
+    }
+  }
+}
+
+export function getFreshAgentTurnItemsBuilder(paneId: string): FreshAgentTurnItemsBuilder | undefined {
+  return freshAgentTurnItemsRegistry.get(paneId)
 }
 
 export function registerTerminalActions(paneId: string, actions: TerminalActions): () => void {

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -604,7 +604,7 @@ test.describe('Fresh Agent', () => {
     expect(monoFont).not.toBe(defaultFont)
   })
 
-  test('turn context menu renders on an opaque popover surface', async ({ freshellPage: _freshellPage, page, terminal }) => {
+  test('fresh-agent turn right-click opens the unified context menu on an opaque surface', async ({ freshellPage: _freshellPage, page, terminal }) => {
     await terminal.waitForTerminal()
     const sessionId = '63333000-0000-4333-8333-000000000006'
     await stubFreshclaudeThread(page, sessionId, [
@@ -631,15 +631,16 @@ test.describe('Fresh Agent', () => {
 
     const paneRoot = page.locator('[data-context="fresh-agent"]')
 
-    // Specialized sub-region partition: right-clicking the rendered code block
-    // inside a turn opens the PROVIDER's context-sensitive menu — exactly one
-    // menu, containing "Copy code block", and never the whole-turn menu.
+    // Specialized sub-region partition: right-clicking the rendered code
+    // block inside a turn opens THE fresh-agent context menu with the
+    // context-sensitive rows ("Copy code block") and no per-turn rows — one
+    // menu system, and the region selects which items it shows.
     const codeBlock = paneRoot.locator('article .prose pre code').first()
     await expect(codeBlock).toBeVisible({ timeout: 10_000 })
     await codeBlock.click({ button: 'right' })
     await expect(page.getByRole('menu')).toHaveCount(1)
     await expect(page.getByRole('menuitem', { name: 'Copy code block' })).toBeVisible()
-    await expect(page.getByRole('menu', { name: 'Turn context menu' })).toHaveCount(0)
+    await expect(page.getByRole('menuitem', { name: 'Copy turn text' })).toHaveCount(0)
     // Dismiss via a left-click outside the menu (the provider's pointerdown
     // dismissal); plain turn text has no click behavior of its own.
     await paneRoot.getByText('Here is the check:', { exact: true }).click()
@@ -652,21 +653,33 @@ test.describe('Fresh Agent', () => {
     // Single-menu invariant: exactly ONE menu may open for a turn gesture.
     // Before the provider carve-out, right-clicking a turn stacked the global
     // pane menu and the transcript's turn menu at the same coordinates (the
-    // "popup with blank lines" bug — two overlapping menus).
+    // "popup with blank lines" bug — two overlapping menus). The transcript
+    // menu has since been deleted outright; the unified menu below is the
+    // provider's fresh-agent menu with turn rows prepended.
     await expect(page.getByRole('menu')).toHaveCount(1)
 
-    // Fine-pointer desktop: right-clicking a turn opens the floating turn menu.
-    const menu = page.getByRole('menu', { name: 'Turn context menu' })
-    await expect(menu).toBeVisible()
+    // Fine-pointer desktop: right-clicking plain turn text opens the unified
+    // fresh-agent context menu — the per-turn rows first, then the base
+    // fresh-agent rows — all from the one portaled menu system.
+    const menu = page.getByRole('menu')
+    await expect(page.getByRole('menuitem', { name: 'Copy turn text' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Fork conversation from here' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Undo to here' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Rewind code to here' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Select all' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Copy session ID' })).toBeVisible()
 
-    // Regression pin: bg-popover previously resolved to no rule at all (the
-    // popover tokens were missing from the tailwind config/theme variables),
-    // so the menu floated over the transcript with a transparent background.
+    // Regression pin: a floating menu previously resolved to no surface rule
+    // at all (the popover tokens were missing from the tailwind config/theme
+    // variables), so the menu floated over the transcript with a transparent
+    // background. The unified menu paints bg-card, which equals the popover
+    // token in both bundled themes — the probe below still pins opacity.
     const backgroundColor = await menu.evaluate((el) => getComputedStyle(el).backgroundColor)
-    expect(backgroundColor, 'turn context menu must not be transparent').not.toBe('rgba(0, 0, 0, 0)')
+    expect(backgroundColor, 'context menu must not be transparent').not.toBe('rgba(0, 0, 0, 0)')
     expect(backgroundColor).not.toBe('transparent')
 
-    // And it must be the popover surface token itself, not accidental inheritance.
+    // And it must be the card/popover surface token value itself (equal in
+    // both bundled themes), not accidental inheritance.
     const expectedSurface = await page.evaluate(() => {
       const probe = document.createElement('div')
       probe.style.backgroundColor = 'hsl(var(--popover))'

--- a/test/e2e-browser/specs/fresh-agent.spec.ts
+++ b/test/e2e-browser/specs/fresh-agent.spec.ts
@@ -966,16 +966,16 @@ test.describe('Fresh Agent', () => {
     await expect(freshcodexRoot.getByText('private style reasoning should stay hidden')).toHaveCount(0)
     await expect(freshcodexRoot.locator('.fresh-agent-turn-header', { hasText: 'Freshcodex' })).toHaveCount(1)
     await expect(freshcodexRoot.locator('[data-turn-continuation="true"]')).toHaveCount(1)
-    await freshcodexRoot.getByRole('button', { name: 'Toggle activity details' }).click()
-    await expect(freshcodexRoot.getByText('private style reasoning should stay hidden')).toHaveCount(0)
     // The status strip shrank the transcript viewport by one row, so the
-    // "Jump to your message" glom chip overlays the top band where the
-    // Thinking toggle's click point lands. The chip re-derives from scroll
-    // position on every scroll-into-view, so mouse dismissing it is racy
-    // (Playwright re-scrolls to the toggle and the chip returns on top of the
-    // click point). Activate the toggle by keyboard Enter instead: focus +
+    // "Jump to your message" glom chip overlays the top band where these
+    // toggles' click points land. The chip re-derives from scroll position on
+    // every scroll-into-view, so mouse dismissing it is racy (Playwright
+    // re-scrolls to the toggle and the chip returns on top of the click
+    // point). Activate both toggles by keyboard Enter instead: focus +
     // keypress targets the element, not the point, so the overlay cannot
     // intercept the activation.
+    await freshcodexRoot.getByRole('button', { name: 'Toggle activity details' }).press('Enter')
+    await expect(freshcodexRoot.getByText('private style reasoning should stay hidden')).toHaveCount(0)
     await freshcodexRoot.getByRole('button', { name: 'Thinking' }).press('Enter')
     await expect(freshcodexRoot.getByText('private style reasoning should stay hidden')).toBeVisible()
     await freshcodexRoot.getByRole('button', { name: /Diff: src\/index\.css/ }).click()

--- a/test/unit/client/components/ContextMenuProvider.test.tsx
+++ b/test/unit/client/components/ContextMenuProvider.test.tsx
@@ -15,6 +15,7 @@ import freshAgentReducer, { sessionInit } from '@/store/freshAgentSlice'
 import tabRegistryReducer, { setTabRegistrySnapshot } from '@/store/tabRegistrySlice'
 import { terminalDetachMiddleware } from '@/store/terminalDetachMiddleware'
 import { ContextMenuProvider } from '@/components/context-menu/ContextMenuProvider'
+import { registerFreshAgentTurnItems } from '@/lib/pane-action-registry'
 import type { ClientExtensionEntry } from '@shared/extension-types'
 
 const defaultCliExtensions: ClientExtensionEntry[] = [
@@ -2744,7 +2745,7 @@ describe('fresh-agent turn carve-out', () => {
     )
   }
 
-  it('opens no provider menu for contextmenu inside article[data-turn-role]', () => {
+  it('opens the provider menu for a fine-pointer right-click on plain turn text', () => {
     renderFreshAgentFixture()
 
     const target = screen.getByText('Turn body text')
@@ -2753,13 +2754,16 @@ describe('fresh-agent turn carve-out', () => {
       target.dispatchEvent(event)
     })
 
-    expect(screen.queryByRole('menu')).toBeNull()
-    // The provider's capture-phase carve-out cancels the event: for a real
-    // article-targeted event the transcript's bubble-phase handler cancels it
-    // too (harmless double cancel), and a late Android contextmenu retargeted
-    // onto the transcript's sheet has no transcript handler at all — the
-    // provider must preventDefault or the browser's native menu opens.
+    // Exactly one menu, and it is the PROVIDER's fresh-agent menu — the
+    // transcript no longer renders a turn menu of its own (one menu system).
+    // The touch/sheet carve-out stays gesture-scoped: fine-pointer turn
+    // right-clicks are ordinary fresh-agent targets now.
     expect(event.defaultPrevented).toBe(true)
+    expect(screen.getAllByRole('menu')).toHaveLength(1)
+    expect(screen.getByRole('menuitem', { name: 'Select all' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Copy session ID' })).toBeInTheDocument()
+    // Without a pane-registered turn-items builder there are no turn rows.
+    expect(screen.queryByRole('menuitem', { name: 'Fork conversation from here' })).toBeNull()
   })
 
   it('still opens the pane menu for contextmenu in the pane container outside any turn article', () => {
@@ -2846,13 +2850,107 @@ describe('fresh-agent turn carve-out', () => {
       expect(screen.getByRole('menuitem', { name: 'Copy new version' })).toBeInTheDocument()
     })
 
-    it('keeps the whole-turn carve-out for plain turn text inside the specialized fixture (control)', () => {
+    it('opens the provider menu for plain turn text inside the specialized fixture (no more whole-turn carve-out)', () => {
       renderSpecializedFixture()
 
       const event = rightClick(screen.getByText('Plain turn text'))
 
       expect(event.defaultPrevented).toBe(true)
-      expect(screen.queryByRole('menu')).toBeNull()
+      expect(screen.getAllByRole('menu')).toHaveLength(1)
+      // Plain turn text hits no specialized sub-region, so the region items
+      // stay off; the base fresh-agent rows remain.
+      expect(screen.queryByRole('menuitem', { name: 'Copy code block' })).toBeNull()
+      expect(screen.getByRole('menuitem', { name: 'Select all' })).toBeInTheDocument()
+    })
+  })
+
+  describe('turn action items from the pane registry', () => {
+    function registerPaneTurnItems(onFork: (turnId: string) => void) {
+      return registerFreshAgentTurnItems('pane-1', (articleIndex) =>
+        articleIndex === 0
+          ? [
+              { label: 'Copy turn text', run: vi.fn() },
+              { label: 'Fork conversation from here', run: () => onFork('turn-1') },
+              { label: 'Undo to here', disabled: true, run: vi.fn() },
+              { label: 'Rewind code to here', destructive: true, run: vi.fn() },
+            ]
+          : null,
+      )
+    }
+
+    it('prepends the pane-registered turn actions for plain-text regions of a turn article', () => {
+      const onFork = vi.fn()
+      const unregister = registerPaneTurnItems(onFork)
+      try {
+        renderFreshAgentFixture({ 'data-turn-index': '0' })
+
+        const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 100, clientY: 100 })
+        act(() => {
+          screen.getByText('Turn body text').dispatchEvent(event)
+        })
+
+        // One menu system renders — the turn-specific rows come first, then a
+        // separator, then the base fresh-agent items.
+        expect(screen.getAllByRole('menu')).toHaveLength(1)
+        const labels = screen.getAllByRole('menuitem').map((el) => el.textContent)
+        expect(labels.slice(0, 4)).toEqual([
+          'Copy turn text',
+          'Fork conversation from here',
+          'Undo to here',
+          'Rewind code to here',
+        ])
+        expect(labels).toContain('Select all')
+        expect(labels).toContain('Copy session ID')
+
+        // Builder gates map onto MenuItem semantics: disabled rows stay
+        // inert, destructive rows render with danger styling.
+        expect(screen.getByRole('menuitem', { name: 'Undo to here' })).toBeDisabled()
+        expect(screen.getByRole('menuitem', { name: 'Rewind code to here' }).className).toContain('text-destructive')
+
+        // Item activation runs the builder's callback.
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Fork conversation from here' }))
+        expect(onFork).toHaveBeenCalledWith('turn-1')
+      } finally {
+        unregister()
+      }
+    })
+
+    it('keeps turn actions off specialized sub-regions of the same turn (the region selects items, not menus)', () => {
+      const onFork = vi.fn()
+      const unregister = registerPaneTurnItems(onFork)
+      try {
+        const { container } = renderWithProvider(
+          <div
+            data-context={ContextIds.FreshAgent}
+            data-tab-id="tab-1"
+            data-pane-id="pane-1"
+            data-session-id="sess-1"
+            data-provider="claude"
+            data-session-type="freshclaude"
+          >
+            <article data-turn-role="assistant" data-turn-index="0">
+              <div className="prose prose-sm" data-markdown-body="">
+                <pre><code>const answer = 42</code></pre>
+              </div>
+            </article>
+          </div>,
+        )
+
+        const codeEl = container.querySelector('.prose pre code') as HTMLElement
+        const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 100, clientY: 100 })
+        act(() => {
+          codeEl.dispatchEvent(event)
+        })
+
+        // The PR-#735 partition survives as ITEM selection within the one
+        // menu: code blocks keep their context rows and gain no turn rows.
+        expect(event.defaultPrevented).toBe(true)
+        expect(screen.getAllByRole('menu')).toHaveLength(1)
+        expect(screen.getByRole('menuitem', { name: 'Copy code block' })).toBeInTheDocument()
+        expect(screen.queryByRole('menuitem', { name: 'Fork conversation from here' })).toBeNull()
+      } finally {
+        unregister()
+      }
     })
   })
 

--- a/test/unit/client/components/fresh-agent/FreshAgentMobile.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentMobile.test.tsx
@@ -140,13 +140,20 @@ describe('mobile coarse-pointer transcript behavior', () => {
     expect(screen.queryByRole('menu', { name: 'Turn context menu' })).not.toBeInTheDocument()
   })
 
-  it('keeps the floating context menu on fine pointers', () => {
+  it('yields fine-pointer right-clicks to the global provider (no transcript-owned menu)', () => {
     stubCoarsePointer(false)
     render(<FreshAgentTranscript turns={TURNS} canFork={false} />)
 
     expect(screen.queryByRole('button', { name: 'Turn actions menu' })).not.toBeInTheDocument()
-    fireEvent.contextMenu(screen.getByRole('article', { name: 'You transcript turn' }))
-    expect(screen.getByRole('menu', { name: 'Turn context menu' })).toBeInTheDocument()
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+    act(() => {
+      screen.getByRole('article', { name: 'You transcript turn' }).dispatchEvent(event)
+    })
+    // The transcript renders no menu of its own on fine pointers and does not
+    // cancel the event — the global ContextMenuProvider's capture-phase
+    // listener opens its unified menu for this gesture.
+    expect(event.defaultPrevented).toBe(false)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
   })
 })
 

--- a/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentTranscript.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { createRoot, type Root } from 'react-dom/client'
 import { flushSync } from 'react-dom'
 import { FreshAgentTranscript, type FreshAgentTranscriptHandle } from '@/components/fresh-agent/FreshAgentTranscript'
+import { getFreshAgentTurnItemsBuilder } from '@/lib/pane-action-registry'
 import type { FreshAgentTranscriptItem, FreshAgentTurn } from '@shared/fresh-agent-contract'
 
 // Render markdown bodies synchronously. The real LazyMarkdown wraps MarkdownRenderer
@@ -1536,15 +1537,42 @@ describe('FreshAgentTranscript', () => {
       expect(screen.queryByRole('button', { name: 'Fork conversation from here' })).not.toBeInTheDocument()
     })
 
-    it('opens a context menu on right-click with fork wired to the turn', () => {
+    it('registers a pane-scoped turn-items builder for the unified context menu and no local menu of its own', () => {
       const onFork = vi.fn()
-      render(<FreshAgentTranscript turns={TURNS} canFork onForkFromTurn={onFork} />)
+      const { unmount } = render(
+        <FreshAgentTranscript paneId="pane-test" turns={TURNS} canFork onForkFromTurn={onFork} />,
+      )
 
-      fireEvent.contextMenu(screen.getByRole('article', { name: 'Assistant transcript turn' }))
-      const menu = screen.getByRole('menu', { name: 'Turn context menu' })
-      expect(menu).toHaveTextContent('Copy turn text')
-      fireEvent.click(screen.getByRole('menuitem', { name: 'Fork conversation from here' }))
+      // Fine-pointer right-click: the transcript yields the gesture to the
+      // global ContextMenuProvider — no preventDefault, no transcript-rendered
+      // menu. The provider builds the visible menu from the registry below.
+      const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+      act(() => {
+        screen.getByRole('article', { name: 'Assistant transcript turn' }).dispatchEvent(event)
+      })
+      expect(event.defaultPrevented).toBe(false)
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+
+      // The registered builder resolves an article index to that article's
+      // action turn and returns the SAME items the touch action sheet shows
+      // (buildTurnActionItems is the single builder for both surfaces).
+      const build = getFreshAgentTurnItemsBuilder('pane-test')
+      expect(build).toBeDefined()
+      const items = build!(1)
+      expect(items?.map((item) => item.label)).toEqual([
+        'Copy turn text',
+        'Fork conversation from here',
+        'Undo to here',
+        'Rewind code to here',
+      ])
+      items![1].run()
       expect(onFork).toHaveBeenCalledWith('turn-2')
+
+      // Unknown/out-of-range article indexes yield no turn rows.
+      expect(build!(42)).toBeNull()
+
+      unmount()
+      expect(getFreshAgentTurnItemsBuilder('pane-test')).toBeUndefined()
     })
 
     it('yields to the provider menu for a fine-pointer right-click on a code block inside a turn', () => {
@@ -1593,13 +1621,33 @@ describe('FreshAgentTranscript', () => {
       expect(onRewind).toHaveBeenCalledWith(expect.objectContaining({ id: 'turn-1', role: 'user' }))
     })
 
-    it('disables rewind in the context menu for assistant turns', () => {
+    it('gates fork/rollback/rewind per capability and role through the registered builder', () => {
       const onRewind = vi.fn()
-      render(<FreshAgentTranscript turns={TURNS} canFork={false} onRewindToTurn={onRewind} />)
+      render(
+        <FreshAgentTranscript
+          paneId="pane-test"
+          turns={TURNS}
+          canFork={false}
+          canRollback
+          onRollbackToTurn={vi.fn()}
+          onRewindToTurn={onRewind}
+        />,
+      )
 
-      fireEvent.contextMenu(screen.getByRole('article', { name: 'Assistant transcript turn' }))
-      const item = screen.getByRole('menuitem', { name: 'Rewind code to here' })
-      expect(item).toBeDisabled()
+      const build = getFreshAgentTurnItemsBuilder('pane-test')
+      expect(build).toBeDefined()
+      const userItems = build!(0)!
+      const assistantItems = build!(1)!
+
+      // User turn: fork needs the capability stamp; rewind is offered.
+      expect(userItems.find((item) => item.label === 'Fork conversation from here')?.disabled).toBe(true)
+      expect(userItems.find((item) => item.label === 'Rewind code to here')?.disabled).toBeFalsy()
+      expect(userItems.find((item) => item.label === 'Undo to here')?.disabled).toBeFalsy()
+
+      // Assistant turn: undo and rewind stay role-gated off, fork disabled.
+      expect(assistantItems.find((item) => item.label === 'Rewind code to here')?.disabled).toBe(true)
+      expect(assistantItems.find((item) => item.label === 'Undo to here')?.disabled).toBe(true)
+      expect(assistantItems.find((item) => item.label === 'Fork conversation from here')?.disabled).toBe(true)
     })
   })
 

--- a/test/unit/client/lib/pane-action-registry.test.ts
+++ b/test/unit/client/lib/pane-action-registry.test.ts
@@ -3,6 +3,9 @@ import {
   getTerminalActions,
   registerTerminalActions,
   type TerminalActions,
+  getFreshAgentTurnItemsBuilder,
+  registerFreshAgentTurnItems,
+  type FreshAgentTurnItemsBuilder,
 } from '@/lib/pane-action-registry'
 
 function createTerminalActions(): TerminalActions {
@@ -35,5 +38,27 @@ describe('pane action registry', () => {
     }
 
     expect(getTerminalActions(paneId)).toBeUndefined()
+  })
+
+  it('registers a per-pane fresh-agent turn-items builder and unregisters by identity', () => {
+    const paneId = 'pane-turn-items'
+    const staleBuilder: FreshAgentTurnItemsBuilder = () => [{ label: 'Stale', run: vi.fn() }]
+    const currentBuilder: FreshAgentTurnItemsBuilder = (articleIndex) =>
+      articleIndex === 0 ? [{ label: 'Copy turn text', run: vi.fn() }] : null
+
+    const unregisterStale = registerFreshAgentTurnItems(paneId, staleBuilder)
+    const unregisterCurrent = registerFreshAgentTurnItems(paneId, currentBuilder)
+
+    try {
+      unregisterStale()
+      expect(getFreshAgentTurnItemsBuilder(paneId)).toBe(currentBuilder)
+      // The builder maps an article index to turn action items (null off-turn).
+      expect(currentBuilder(0)?.map((item) => item.label)).toEqual(['Copy turn text'])
+      expect(currentBuilder(7)).toBeNull()
+    } finally {
+      unregisterCurrent()
+    }
+
+    expect(getFreshAgentTurnItemsBuilder(paneId)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Why

Two context-menu systems rendered inside the same fresh-agent pane. The global ContextMenuProvider (portaled, keyboard-navigable, full item set) and the transcript's own FreshAgentTurnContextMenu (inline, fewer items, different typography) were partitioned by PR #735's target carve-out: plain turn text got the smaller menu, code blocks got the good one, in the same pane. (In serif-styled panes the turn menu's buttons additionally rendered in the serif style's meta mono font rather than the app sans.)

## What changed

One menu system, one item builder:

- **FreshAgentTurnContextMenu deleted.** The provider's fresh-agent menu owns every fresh-agent right-click.
- **Plain-text turn regions** now prepend the per-turn rows — Copy turn text / Fork conversation from here / Undo to here / Rewind code to here — to the existing fresh-agent menu (Copy, Select all, region rows, Undo/Redo last turn, Copy session ID).
- **Single builder preserved.** The rows come from the transcript's pane-registered `FreshAgentTurnItemsBuilder` (new `registerFreshAgentTurnItems`/`getFreshAgentTurnItemsBuilder` in pane-action-registry, same idiom as the undo/redo pane registry), built around the existing `buildTurnActionItems` — the builder the touch action sheet already consumes. Registry resolution keys off the article's `data-turn-index` through the merged-line layout, preserving the "last contributing turn" fork/undo/rewind semantics.
- **The PR-#735 specialized-region partition survives as item selection**, not menu selection: code/tool/diff regions keep their context-sensitive rows and gain no turn rows. The mirrored-selector `isFreshAgentSpecializedRegion` keep-in-sync hazard is deleted with the second menu.
- **Touch behavior byte-identical:** the action sheet unchanged, and the provider's turn carve-out collapsed to gesture-in-flight only (Android-race handling and hybrid long-press fallback preserved).

Also fixes a pre-existing e2e flake in the same spec (serif test's activity-toggle click intercepted by the glom chip — reproduced on unmodified main), mirroring 877546aee's keyboard-activation fix.

## Test plan

- TDD red→green: 6 failing assertions pre-implementation, all green after.
- 162/162 pass across the four affected unit files; 445/445 fresh-agent component tests.
- `npm test` full coordinated cloud suite: green.
- Typecheck (client+server) and eslint: clean (0 errors; two warnings verified pre-existing at identical text on main).
- e2e: full fresh-agent.spec.ts green on the cloud backend at HEAD c12761878, including the rewritten unified-menu test (one menu, turn rows on plain text, code rows without turn rows on code blocks, opaque surface pin) and the deflaked serif test.