### PR TITLE
fix: configure managed Codex app-server MCP context

### DIFF
--- a/crates/freshell-codex/src/launch_lifecycle.rs
+++ b/crates/freshell-codex/src/launch_lifecycle.rs
@@ -47,7 +47,7 @@ use crate::app_server::BoxFuture;
 use crate::durability::{default_server_instance_id, mint_ownership_id};
 use crate::launch_plan::{
     codex_sidecar_spawn_spec, plan_codex_launch, plan_codex_launch_retry, CodexLaunchConfigError,
-    CodexLaunchPlan, CodexLaunchPlanInput, CodexLaunchRetryDecision,
+    CodexLaunchPlan, CodexLaunchPlanInput, CodexLaunchRetryDecision, CodexSidecarLaunchContext,
     CODEX_INITIAL_LAUNCH_RETRY_DELAY_MS,
 };
 use crate::remote_proxy::{CodexRemoteProxy, CodexRemoteProxyOptions, RemoteProxyEvent};
@@ -801,7 +801,17 @@ impl CodexTerminalLaunchManager {
         launch: CodexTerminalLaunch,
         generation: u64,
     ) -> Result<(), String> {
-        launch.sidecar.adopt(terminal_id, generation).await?;
+        if let Err(adoption_error) = launch.sidecar.adopt(terminal_id, generation).await {
+            if let Err(cleanup_error) = launch.sidecar.shutdown().await {
+                tracing::error!(
+                    target: "freshell_codex::launch",
+                    terminal_id,
+                    error = %cleanup_error,
+                    "codex_launch_adopt_cleanup_failed"
+                );
+            }
+            return Err(adoption_error);
+        }
         // S5.d.3 DECISION (recorded): `launch.plan.binding_reason` is
         // deliberately DROPPED here — the identity tail derives adopt-vs-rebind
         // from context, and no Rust wire frame carries sessionBindingReason.
@@ -1008,6 +1018,9 @@ struct SpawnedSidecar {
 pub struct SpawnedCodexAppServerRuntime {
     codex_command: Option<String>,
     start_budget: Duration,
+    /// Immutable, spawn-only configuration/context. It is intentionally not
+    /// copied into the child record or any durable sidecar identity state.
+    sidecar_context: CodexSidecarLaunchContext,
     /// Durable sidecar record store (Task 3). Production resolves the
     /// process-global handle ([`crate::sidecar_store::set_codex_sidecar_store`],
     /// wired at boot in Task 10); absent global ⇒ disabled store ⇒ behavior
@@ -1029,9 +1042,17 @@ impl SpawnedCodexAppServerRuntime {
     /// interpreter-plus-script support) falling back to `codex`. The record
     /// store resolves from the process-global handle; absent ⇒ disabled.
     pub fn new() -> Self {
+        Self::with_context(CodexSidecarLaunchContext::default())
+    }
+
+    /// Construct a newly spawned runtime with its immutable process context.
+    /// Reattached runtimes intentionally do not have this constructor: their
+    /// child process already exists and must remain unchanged.
+    pub fn with_context(sidecar_context: CodexSidecarLaunchContext) -> Self {
         Self {
             codex_command: None,
             start_budget: SIDECAR_START_BUDGET,
+            sidecar_context,
             store: codex_sidecar_store().unwrap_or_else(|| Arc::new(CodexSidecarStore::disabled())),
             state: tokio::sync::Mutex::new(None),
             adopted_metadata: Mutex::new(None),
@@ -1149,7 +1170,7 @@ impl CodexLaunchRuntime for SpawnedCodexAppServerRuntime {
             let port = allocate_loopback_port()?;
             let ws_url = format!("ws://127.0.0.1:{port}");
             let ownership_id = mint_ownership_id();
-            let spec = codex_sidecar_spawn_spec(&ws_url, &ownership_id);
+            let spec = codex_sidecar_spawn_spec(&ws_url, &ownership_id, &self.sidecar_context);
 
             let command = self.resolved_command();
             let mut parts = command.split_whitespace();

--- a/crates/freshell-codex/src/launch_plan.rs
+++ b/crates/freshell-codex/src/launch_plan.rs
@@ -24,6 +24,7 @@
 //! - `if (!sandbox) return undefined` — `Some("")` normalizes to `None`, not an error.
 
 use crate::durability::CODEX_SIDECAR_OWNERSHIP_ENV;
+use std::collections::BTreeMap;
 use std::fmt;
 
 // ─── constants ──────────────────────────────────────────────────────────────────────────
@@ -175,6 +176,9 @@ pub struct CodexLaunchPlanInput<'a> {
     pub model: Option<&'a str>,
     pub sandbox: Option<&'a str>,
     pub approval_policy: Option<&'a str>,
+    /// Spawn-only configuration/context for a newly created app-server. A
+    /// claimed survivor deliberately does not consume this new context.
+    pub sidecar_context: CodexSidecarLaunchContext,
 }
 
 /// The pure launch PLAN: every decision `planCreate` (`launch-planner.ts:125-163`)
@@ -203,6 +207,9 @@ pub struct CodexLaunchPlan {
     pub model: Option<String>,
     pub sandbox: Option<CodexSandboxMode>,
     pub approval_policy: Option<String>,
+    /// The immutable context a newly spawned runtime carries across retries.
+    /// Environment values are never persisted into sidecar records.
+    pub sidecar_context: CodexSidecarLaunchContext,
 }
 
 /// The `planCodexLaunch` decision tree (`ws-handler.ts:928-950` →
@@ -231,6 +238,7 @@ pub fn plan_codex_launch(
         model: input.model.map(str::to_string),
         sandbox,
         approval_policy: input.approval_policy.map(str::to_string),
+        sidecar_context: input.sidecar_context.clone(),
     })
 }
 
@@ -311,34 +319,71 @@ pub fn codex_remote_args(proxy_ws_url: &str) -> Result<[String; 4], CodexRemoteA
 
 // ─── app-server sidecar spawn spec (codex.rs::spawn_sidecar ⇐ runtime.ts:1246-1261) ─────
 
+/// The value-safe, immutable configuration a newly spawned managed app-server receives.
+/// The `config_args` are static configuration pairs; environment values remain only in the
+/// child process environment and are intentionally redacted from [`fmt::Debug`].
+#[derive(Clone, PartialEq, Eq, Default)]
+pub struct CodexSidecarLaunchContext {
+    pub config_args: Vec<String>,
+    pub env: BTreeMap<String, String>,
+}
+
+impl fmt::Debug for CodexSidecarLaunchContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CodexSidecarLaunchContext")
+            .field("config_args", &self.config_args)
+            .field("env_keys", &self.env.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
 /// The argv (after the `codex` program token) + env a managed app-server sidecar spawn
-/// carries. Pure description only — S4 owns the actual spawn.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// carries. Pure description only — S4 owns the actual spawn. Environment values are
+/// deliberately redacted from [`fmt::Debug`].
+#[derive(Clone, PartialEq, Eq)]
 pub struct CodexSidecarSpawnSpec {
     pub args: Vec<String>,
     pub env: Vec<(String, String)>,
 }
 
-/// `codex -c features.apps=false app-server --listen <ws_url>` with the ownership tag
-/// env (`FRESHELL_CODEX_SIDECAR_ID=<ownership_id>`) the `/proc` reaper keys on —
-/// exactly the shape `freshell-freshagent/src/codex.rs::spawn_sidecar` (⇐
-/// `runtime.ts:1246-1261`) builds today.
-pub fn codex_sidecar_spawn_spec(listen_ws_url: &str, ownership_id: &str) -> CodexSidecarSpawnSpec {
+impl fmt::Debug for CodexSidecarSpawnSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut env_keys = self.env.iter().map(|(key, _)| key).collect::<Vec<_>>();
+        env_keys.sort_unstable();
+        f.debug_struct("CodexSidecarSpawnSpec")
+            .field("args", &self.args)
+            .field("env_keys", &env_keys)
+            .finish()
+    }
+}
+
+/// `codex -c features.apps=false <context config> app-server --listen <ws_url>` with the
+/// ownership tag the `/proc` reaper keys on. Context environment values stay in the spawned
+/// process environment; the ownership tag is inserted after context merge so it wins on a
+/// collision. This is the shared shape terminal runtimes and fresh-agent use.
+pub fn codex_sidecar_spawn_spec(
+    listen_ws_url: &str,
+    ownership_id: &str,
+    context: &CodexSidecarLaunchContext,
+) -> CodexSidecarSpawnSpec {
     let mut args: Vec<String> = CODEX_MANAGED_REMOTE_CONFIG_ARGS
         .iter()
         .map(|s| s.to_string())
         .collect();
+    args.extend(context.config_args.iter().cloned());
     args.extend([
         "app-server".to_string(),
         "--listen".to_string(),
         listen_ws_url.to_string(),
     ]);
+    let mut env = context.env.clone();
+    env.insert(
+        CODEX_SIDECAR_OWNERSHIP_ENV.to_string(),
+        ownership_id.to_string(),
+    );
     CodexSidecarSpawnSpec {
         args,
-        env: vec![(
-            CODEX_SIDECAR_OWNERSHIP_ENV.to_string(),
-            ownership_id.to_string(),
-        )],
+        env: env.into_iter().collect(),
     }
 }
 
@@ -489,6 +534,7 @@ mod tests {
                 model: None,
                 sandbox: None,
                 approval_policy: None,
+                sidecar_context: CodexSidecarLaunchContext::default(),
             })
         );
     }
@@ -512,6 +558,7 @@ mod tests {
                 model: None,
                 sandbox: None,
                 approval_policy: None,
+                sidecar_context: CodexSidecarLaunchContext::default(),
             })
         );
     }
@@ -526,6 +573,7 @@ mod tests {
                 model: Some("gpt-5.2-codex"),
                 sandbox: Some("workspace-write"),
                 approval_policy: Some("on-request"),
+                sidecar_context: CodexSidecarLaunchContext::default(),
             }),
             Ok(CodexLaunchPlan {
                 session_id: Some("thread-s".to_string()),
@@ -536,6 +584,7 @@ mod tests {
                 model: Some("gpt-5.2-codex".to_string()),
                 sandbox: Some(CodexSandboxMode::WorkspaceWrite),
                 approval_policy: Some("on-request".to_string()),
+                sidecar_context: CodexSidecarLaunchContext::default(),
             })
         );
     }
@@ -675,7 +724,11 @@ mod tests {
     #[test]
     fn sidecar_spawn_spec_golden() {
         assert_eq!(
-            codex_sidecar_spawn_spec("ws://127.0.0.1:41234", "codex-sidecar-abc"),
+            codex_sidecar_spawn_spec(
+                "ws://127.0.0.1:41234",
+                "codex-sidecar-abc",
+                &CodexSidecarLaunchContext::default(),
+            ),
             CodexSidecarSpawnSpec {
                 args: vec![
                     "-c".to_string(),
@@ -690,6 +743,77 @@ mod tests {
                 )],
             }
         );
+    }
+
+    #[test]
+    fn sidecar_spawn_spec_places_context_before_app_server_and_redacts_values() {
+        let context = CodexSidecarLaunchContext {
+            config_args: vec![
+                "-c".to_string(),
+                "mcp_servers.freshell.command=\"node\"".to_string(),
+                "-c".to_string(),
+                "mcp_servers.freshell.env_vars=[\"FRESHELL_TOKEN\"]".to_string(),
+            ],
+            env: std::collections::BTreeMap::from([
+                (
+                    CODEX_SIDECAR_OWNERSHIP_ENV.to_string(),
+                    "context-must-not-win".to_string(),
+                ),
+                (
+                    "FRESHELL_PANE_ID".to_string(),
+                    "pane-context-test".to_string(),
+                ),
+                ("FRESHELL_TOKEN".to_string(), "not-visible".to_string()),
+            ]),
+        };
+
+        let spec =
+            codex_sidecar_spawn_spec("ws://127.0.0.1:41234", "sidecar-ownership-wins", &context);
+
+        assert_eq!(
+            spec.args,
+            vec![
+                "-c",
+                "features.apps=false",
+                "-c",
+                "mcp_servers.freshell.command=\"node\"",
+                "-c",
+                "mcp_servers.freshell.env_vars=[\"FRESHELL_TOKEN\"]",
+                "app-server",
+                "--listen",
+                "ws://127.0.0.1:41234",
+            ]
+        );
+        assert_eq!(
+            spec.env,
+            vec![
+                (
+                    CODEX_SIDECAR_OWNERSHIP_ENV.to_string(),
+                    "sidecar-ownership-wins".to_string(),
+                ),
+                ("FRESHELL_PANE_ID".to_string(), "pane-context-test".to_string()),
+                ("FRESHELL_TOKEN".to_string(), "not-visible".to_string()),
+            ],
+            "a BTreeMap makes process environment ordering deterministic and the ownership tag wins"
+        );
+
+        let context_debug = format!("{context:?}");
+        let spec_debug = format!("{spec:?}");
+        for rendered in [&context_debug, &spec_debug] {
+            assert!(rendered.contains("FRESHELL_TOKEN"));
+            assert!(rendered.contains(CODEX_SIDECAR_OWNERSHIP_ENV));
+            for value in [
+                "not-visible",
+                "context-must-not-win",
+                "sidecar-ownership-wins",
+                "pane-context-test",
+            ] {
+                assert!(
+                    !rendered.contains(value),
+                    "Debug output must expose environment names, never values"
+                );
+            }
+        }
     }
 
     // ── plan_codex_launch_retry — vectors ported from

--- a/crates/freshell-codex/src/runtime_select.rs
+++ b/crates/freshell-codex/src/runtime_select.rs
@@ -36,5 +36,7 @@ pub async fn select_codex_runtime(
             ));
         }
     }
-    Arc::new(SpawnedCodexAppServerRuntime::new())
+    Arc::new(SpawnedCodexAppServerRuntime::with_context(
+        plan.sidecar_context.clone(),
+    ))
 }

--- a/crates/freshell-codex/tests/launch_lifecycle.rs
+++ b/crates/freshell-codex/tests/launch_lifecycle.rs
@@ -12,6 +12,7 @@
 //! proves the fake-TUI → proxy → app-server relay end to end.
 #![cfg(feature = "real-transport")]
 
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -28,14 +29,85 @@ use freshell_codex::launch_lifecycle::{
     CodexTerminalLaunchManager, LaunchClass, SpawnedCodexAppServerRuntime,
     CODEX_LAUNCH_PLANNER_SHUTDOWN_MESSAGE, CODEX_SIDECAR_NOT_ADOPTABLE_MESSAGE,
 };
-use freshell_codex::launch_plan::{codex_remote_args, CodexLaunchPlanInput};
+use freshell_codex::launch_plan::{
+    codex_remote_args, plan_codex_launch, CodexLaunchPlanInput, CodexSidecarLaunchContext,
+};
 use freshell_codex::{
-    proc_cmdline, proc_starttime, verify_sidecar_identity, BoxFuture, CodexSidecarRecord,
-    CodexSidecarStore, IdentityVerdict, ReattachedCodexAppServerRuntime, SidecarReconciler,
-    SidecarRecordState, CODEX_SIDECAR_OWNERSHIP_ENV, SIDECAR_RECORD_VERSION,
+    proc_cmdline, proc_starttime, select_codex_runtime, verify_sidecar_identity, BoxFuture,
+    CodexSidecarRecord, CodexSidecarStore, IdentityVerdict, ReattachedCodexAppServerRuntime,
+    SidecarReconciler, SidecarRecordState, CODEX_SIDECAR_OWNERSHIP_ENV, SIDECAR_RECORD_VERSION,
 };
 
 const RECV_TIMEOUT: Duration = Duration::from_secs(10);
+const SYNTHETIC_CONTEXT_TOKEN: &str = "not-visible";
+
+/// Restores a process-global command override even when a test assertion panics. The
+/// production runtime intentionally resolves `CODEX_CMD` at spawn time, so this is the
+/// smallest way to exercise the public runtime-selection seam with the committed fixture.
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = self.previous.take() {
+            std::env::set_var(self.key, value);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+fn context_config_args() -> Vec<String> {
+    vec![
+        "-c".to_string(),
+        "mcp_servers.freshell.command=\"node\"".to_string(),
+        "-c".to_string(),
+        "mcp_servers.freshell.env_vars=[\"FRESHELL_TOKEN\"]".to_string(),
+    ]
+}
+
+fn sidecar_context(arg_log: &std::path::Path) -> CodexSidecarLaunchContext {
+    CodexSidecarLaunchContext {
+        config_args: context_config_args(),
+        env: BTreeMap::from([
+            (
+                "FAKE_CODEX_APP_SERVER_ARG_LOG".to_string(),
+                arg_log.display().to_string(),
+            ),
+            ("FRESHELL".to_string(), "1".to_string()),
+            (
+                "FRESHELL_URL".to_string(),
+                "http://freshell.test".to_string(),
+            ),
+            (
+                "FRESHELL_TOKEN".to_string(),
+                SYNTHETIC_CONTEXT_TOKEN.to_string(),
+            ),
+            (
+                "FRESHELL_TERMINAL_ID".to_string(),
+                "terminal-context-test".to_string(),
+            ),
+            (
+                "FRESHELL_TAB_ID".to_string(),
+                "tab-context-test".to_string(),
+            ),
+            (
+                "FRESHELL_PANE_ID".to_string(),
+                "pane-context-test".to_string(),
+            ),
+        ]),
+    }
+}
 
 // ── fake runtime: a loopback WS echo listener standing in for the app-server ──────
 
@@ -43,6 +115,7 @@ struct FakeRuntime {
     ws_url: String,
     ensure_ready_calls: Mutex<Vec<Option<String>>>,
     fail_ensure_ready: AtomicBool,
+    fail_ownership_update: AtomicBool,
     fail_prepare_retention: AtomicBool,
     shutdown_calls: AtomicU32,
     ownership_updates: Mutex<Vec<(String, u64)>>,
@@ -80,6 +153,7 @@ impl FakeRuntime {
             ws_url,
             ensure_ready_calls: Mutex::new(Vec::new()),
             fail_ensure_ready: AtomicBool::new(false),
+            fail_ownership_update: AtomicBool::new(false),
             fail_prepare_retention: AtomicBool::new(false),
             shutdown_calls: AtomicU32::new(0),
             ownership_updates: Mutex::new(Vec::new()),
@@ -110,6 +184,9 @@ impl CodexLaunchRuntime for FakeRuntime {
         generation: u64,
     ) -> BoxFuture<'_, Result<(), String>> {
         Box::pin(async move {
+            if self.fail_ownership_update.load(Ordering::SeqCst) {
+                return Err("fake runtime: ownership update failed".to_string());
+            }
             self.ownership_updates
                 .lock()
                 .unwrap()
@@ -452,6 +529,57 @@ async fn manager_adopts_by_terminal_id_and_tears_down_on_exit() {
         );
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
+}
+
+/// A failed terminal-side adoption still owns the prepared launch until its
+/// proxy and child have been discarded. Otherwise the moved launch would be
+/// stranded in the planner's active map until a later process shutdown.
+#[tokio::test]
+async fn failed_adoption_discards_the_still_owned_launch() {
+    let runtime = FakeRuntime::start().await;
+    let factory_runtime = runtime.clone();
+    let manager = CodexTerminalLaunchManager::new(Box::new(move |_plan| {
+        let rt = factory_runtime.clone() as Arc<dyn CodexLaunchRuntime>;
+        Box::pin(async move { rt })
+    }));
+    let launch = manager
+        .plan_create_with_retry_uncancellable(
+            &CodexLaunchPlanInput::default(),
+            1,
+            LaunchClass::Interactive,
+        )
+        .await
+        .expect("prepared launch");
+    let remote_ws_url = launch.remote_ws_url.clone();
+
+    runtime.fail_ownership_update.store(true, Ordering::SeqCst);
+    let error = manager
+        .adopt("term-adoption-failure", launch, 0)
+        .await
+        .expect_err("the injected ownership failure must reach the caller");
+    assert_eq!(error, "fake runtime: ownership update failed");
+    assert_eq!(
+        runtime.shutdown_calls.load(Ordering::SeqCst),
+        1,
+        "the still-owned sidecar must be discarded immediately"
+    );
+    assert!(
+        !matches!(
+            timeout(Duration::from_secs(1), connect_async(&remote_ws_url)).await,
+            Ok(Ok(_))
+        ),
+        "the failed adoption must close the planned proxy immediately"
+    );
+
+    // A later manager shutdown must find no active planned launch. This also
+    // proves the failure did not leave a proxy/child retained for the planner
+    // to clean up at process shutdown.
+    manager.shutdown().await;
+    assert_eq!(
+        runtime.shutdown_calls.load(Ordering::SeqCst),
+        1,
+        "failed adoption must not leave an active planned sidecar"
+    );
 }
 
 #[tokio::test]
@@ -948,6 +1076,133 @@ fn fake_app_server_command() -> String {
     let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs");
     format!("node {}", fixture.display())
+}
+
+async fn wait_for_arg_log(path: &std::path::Path) -> serde_json::Value {
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            return serde_json::from_str(&contents).expect("fixture arg log is valid JSON");
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "fake app-server did not write its argument observation"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+fn assert_captured_spawn_context(captured: &serde_json::Value) {
+    let argv = captured["argv"]
+        .as_array()
+        .expect("fixture records argv as an array")
+        .iter()
+        .map(|value| value.as_str().expect("fixture argv values are strings"))
+        .collect::<Vec<_>>();
+    let app_server_index = argv
+        .iter()
+        .position(|value| *value == "app-server")
+        .expect("sidecar must execute app-server");
+    assert_eq!(
+        &argv[..app_server_index],
+        [
+            "-c",
+            "features.apps=false",
+            "-c",
+            "mcp_servers.freshell.command=\"node\"",
+            "-c",
+            "mcp_servers.freshell.env_vars=[\"FRESHELL_TOKEN\"]",
+        ],
+        "all context config pairs must precede app-server"
+    );
+    assert_eq!(argv.get(app_server_index + 1).copied(), Some("--listen"));
+    assert!(
+        !argv.iter().any(|value| *value == SYNTHETIC_CONTEXT_TOKEN),
+        "context values must stay out of the child argv"
+    );
+    assert_eq!(
+        captured["env"]["FRESHELL_TOKEN"].as_str(),
+        Some(SYNTHETIC_CONTEXT_TOKEN),
+        "the child receives the context value through its environment"
+    );
+    assert_eq!(
+        captured["env"]["FRESHELL_TERMINAL_ID"].as_str(),
+        Some("terminal-context-test"),
+        "the child receives the terminal context through its environment"
+    );
+}
+
+#[tokio::test]
+async fn spawned_runtime_receives_context_but_reattached_runtime_does_not() {
+    let _codex_cmd = EnvVarGuard::set("CODEX_CMD", fake_app_server_command());
+    let dir = tempfile::tempdir().expect("temporary fixture observations");
+
+    // No reattach candidate: the production selector must construct a spawned
+    // runtime from the plan's context. The fixture sees its real child argv/env.
+    let spawned_log = dir.path().join("spawned.json");
+    let spawned_context = sidecar_context(&spawned_log);
+    let spawned_plan = plan_codex_launch(&CodexLaunchPlanInput {
+        sidecar_context: spawned_context,
+        ..Default::default()
+    })
+    .expect("valid spawned plan");
+    let spawned = select_codex_runtime(None, None, &spawned_plan).await;
+    spawned
+        .ensure_ready(None)
+        .await
+        .expect("spawned runtime becomes ready");
+    assert_captured_spawn_context(&wait_for_arg_log(&spawned_log).await);
+    spawned.shutdown().await.expect("tear down spawned child");
+
+    // A verified survivor keeps its original process unchanged. Give a NEW
+    // plan an observation path that only a wrongly-created replacement child
+    // could write, then prove selection reattaches instead.
+    let (_store_dir, store) = temp_sidecar_store();
+    let survivor = SpawnedCodexAppServerRuntime::with_command_and_store(
+        fake_app_server_command(),
+        store.clone(),
+    );
+    let survivor_ready = survivor
+        .ensure_ready(None)
+        .await
+        .expect("spawn survivor fixture");
+    survivor
+        .note_session_id("survivor-session".to_string())
+        .await
+        .expect("persist survivor session id");
+    let survivor_pid = survivor.child_pid().await.expect("survivor pid");
+    drop(survivor);
+
+    let (reconciler, report) = SidecarReconciler::boot_reconcile(store.clone());
+    assert_eq!(report.held, 1, "the live sidecar is held for reattachment");
+    let reconciler = Arc::new(reconciler);
+    let unexpected_spawn_log = dir.path().join("unexpected-replacement.json");
+    let survivor_plan = plan_codex_launch(&CodexLaunchPlanInput {
+        resume_session_id: Some("survivor-session"),
+        sidecar_context: sidecar_context(&unexpected_spawn_log),
+        ..Default::default()
+    })
+    .expect("valid resume plan");
+    let reattached = select_codex_runtime(Some(&reconciler), Some(&store), &survivor_plan).await;
+    let reattached_ready = reattached
+        .ensure_ready(None)
+        .await
+        .expect("reattach existing survivor");
+    assert_eq!(reattached_ready.ws_url, survivor_ready.ws_url);
+    assert!(
+        !unexpected_spawn_log.exists(),
+        "a reattached survivor must not start a replacement child with the new context"
+    );
+    assert!(
+        proc_starttime(survivor_pid as i32).is_some(),
+        "the verified survivor remains the live process"
+    );
+
+    reattached
+        .shutdown()
+        .await
+        .expect("tear down the test survivor");
+    wait_pid_gone(survivor_pid).await;
 }
 
 #[tokio::test]

--- a/crates/freshell-freshagent/src/codex.rs
+++ b/crates/freshell-freshagent/src/codex.rs
@@ -58,7 +58,7 @@ use tokio::sync::{oneshot, Mutex as TokioMutex};
 use freshell_codex::launch_lifecycle::{
     allocate_loopback_port, drain_child_io, SIDECAR_START_BUDGET,
 };
-use freshell_codex::launch_plan::codex_sidecar_spawn_spec;
+use freshell_codex::launch_plan::{codex_sidecar_spawn_spec, CodexSidecarLaunchContext};
 use freshell_codex::transport::{reap_owned_codex_sidecars, TungsteniteTransport};
 use freshell_codex::{
     mint_ownership_id, normalize_codex_thread_status, normalize_freshcodex_effort,
@@ -3716,7 +3716,11 @@ impl FreshCodexState {
         let ownership_id = mint_ownership_id();
         // The canonical argv + env: `-c features.apps=false app-server --listen <ws_url>`
         // plus the ownership tag the /proc reaper keys on (S5.d.1 unification).
-        let spec = codex_sidecar_spawn_spec(&ws_url, &ownership_id);
+        let spec = codex_sidecar_spawn_spec(
+            &ws_url,
+            &ownership_id,
+            &CodexSidecarLaunchContext::default(),
+        );
         let codex_cmd = std::env::var("CODEX_CMD").unwrap_or_else(|_| "codex".to_string());
         // Whitespace-split so a test fixture can point `CODEX_CMD` at an interpreter plus
         // script (e.g. `CODEX_CMD="node /path/fake-app-server.mjs"`) without needing the

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -40,10 +40,12 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use freshell_platform::detect::{host_os_live, is_windows, is_wsl_env_live, HostOs};
-use freshell_platform::mcp_inject::{cleanup_mcp_config, generate_mcp_injection, RealMcpRuntime};
+use freshell_platform::mcp_inject::{
+    build_managed_codex_mcp_renderings, cleanup_mcp_config, generate_mcp_injection, RealMcpRuntime,
+};
 use freshell_platform::spawn::{
     cli_provider_target, resolve_coding_cli_command, resolve_mcp_cwd, resolve_shell,
-    resolve_unix_shell_cwd, CliLaunchInputs, LaunchIntent,
+    resolve_unix_shell_cwd, CliLaunchInputs, LaunchIntent, McpInjection,
 };
 use freshell_platform::{
     build_cli_spawn_spec, build_spawn_spec, build_windows_cli_spawn_spec, CliLaunch, Env, RealEnv,
@@ -382,6 +384,53 @@ fn build_terminal_base_env(
         out.insert("FRESHELL_PANE_ID".to_string(), p.to_string());
     }
     out
+}
+
+/// One value-safe managed Codex rendering for this terminal tab's TUI and a
+/// newly spawned app-server. It intentionally does not implement `Debug` so
+/// terminal context values cannot reach log or error surfaces.
+struct CodexManagedLaunchSetup {
+    terminal_id: String,
+    runtime_cwd: Option<String>,
+    tui_mcp_injection: McpInjection,
+    terminal_env: BTreeMap<String, String>,
+    sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext,
+}
+
+/// Construct the managed pair once. The app-server receives the host-native
+/// rendering plus the terminal's canonical environment; the TUI receives its
+/// selected target rendering. A claimed survivor is selected below without
+/// consuming or rewriting this spawn-only setup.
+fn build_codex_managed_launch_setup(
+    terminal_id: String,
+    shell: ShellType,
+    host_os: HostOs,
+    is_wsl: bool,
+    resolved_cwd: Option<&str>,
+    tab_id: Option<&str>,
+    pane_id: Option<&str>,
+) -> Result<CodexManagedLaunchSetup, String> {
+    let runtime_cwd = resolve_mcp_cwd(resolved_cwd, &RealEnv, host_os, is_wsl);
+    let tui_target = cli_provider_target(shell, host_os, is_wsl, resolved_cwd, &RealEnv);
+    let renderings =
+        build_managed_codex_mcp_renderings(&RealMcpRuntime, &RealEnv, host_os, is_wsl, tui_target)
+            .map_err(|error| error.message)?;
+    let freshell_platform::mcp_inject::ManagedCodexMcpRenderings { tui, sidecar } = renderings;
+    let terminal_env = build_terminal_base_env(&RealEnv, &terminal_id, tab_id, pane_id);
+    let mut sidecar_env = sidecar.env;
+    // Canonical terminal values own any overlap with a future renderer.
+    sidecar_env.extend(terminal_env.clone());
+
+    Ok(CodexManagedLaunchSetup {
+        terminal_id,
+        runtime_cwd,
+        tui_mcp_injection: tui,
+        terminal_env,
+        sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext {
+            config_args: sidecar.args,
+            env: sidecar_env,
+        },
+    })
 }
 
 /// JS `String(Number(s))` for the `PORT` template slot (mirrored from
@@ -1492,17 +1541,23 @@ async fn settle_gated_create(inputs: GatedSettleInputs) -> Result<TerminalSpawnR
             .unwrap_or(ShellType::System);
 
         let target = cli_provider_target(shell_type, host_os, is_wsl, cwd.as_deref(), &RealEnv);
-        mcp_cwd = resolve_mcp_cwd(cwd.as_deref(), &RealEnv, host_os, is_wsl);
-
-        let mcp_injection = match generate_mcp_injection(
-            &RealMcpRuntime,
-            &mode,
-            &terminal_id,
-            mcp_cwd.as_deref(),
-            target,
-        ) {
-            Ok(i) => i,
-            Err(e) => return Err(fail_json(StatusCode::BAD_REQUEST, e.message)),
+        let managed_flag =
+            std::env::var(freshell_codex::launch_plan::FRESHELL_CODEX_MANAGED_LAUNCH_ENV).ok();
+        let codex_setup = if codex_create_uses_managed_launch(&mode, managed_flag.as_deref()) {
+            Some(
+                build_codex_managed_launch_setup(
+                    terminal_id.clone(),
+                    shell_type,
+                    host_os,
+                    is_wsl,
+                    cwd.as_deref(),
+                    Some(&tab_id),
+                    Some(&pane_id),
+                )
+                .map_err(|message| fail_json(StatusCode::BAD_REQUEST, message))?,
+            )
+        } else {
+            None
         };
 
         // opencode: allocate the loopback control endpoint BEFORE building the
@@ -1554,16 +1609,14 @@ async fn settle_gated_create(inputs: GatedSettleInputs) -> Result<TerminalSpawnR
         // `{codexAppServer}` providerSettings). Flag OFF: today's plain-CLI behavior,
         // byte-identical. The raw-resume rejection already ran in
         // `derive_resume_identity` — planning happens strictly after it.
-        let managed_flag =
-            std::env::var(freshell_codex::launch_plan::FRESHELL_CODEX_MANAGED_LAUNCH_ENV).ok();
-        codex_launch = if codex_create_uses_managed_launch(&mode, managed_flag.as_deref()) {
+        codex_launch = if let Some(setup) = codex_setup.as_ref() {
             let input = freshell_codex::launch_plan::CodexLaunchPlanInput {
-                cwd: cwd.as_deref(),
+                cwd: setup.runtime_cwd.as_deref(),
                 resume_session_id: resume_session_id.as_deref(),
                 model: model.as_deref(),
                 sandbox: sandbox.as_deref(),
                 approval_policy: permission_mode.as_deref(),
-                sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext::default(),
+                sidecar_context: setup.sidecar_context.clone(),
             };
             match freshell_codex::launch_lifecycle::CodexTerminalLaunchManager::global()
                 .plan_create_with_retry_uncancellable(
@@ -1588,6 +1641,45 @@ async fn settle_gated_create(inputs: GatedSettleInputs) -> Result<TerminalSpawnR
                 launch.session_id.as_deref(),
             );
         }
+
+        // The managed setup already rendered the TUI injection and built the
+        // terminal environment for this exact id/tab/pane. Non-managed paths
+        // retain the existing generic MCP/environment work.
+        let (mcp_injection, overrides) = match codex_setup {
+            Some(setup) => {
+                if setup.terminal_id.as_str() != terminal_id.as_str() {
+                    return Err(fail_json(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "managed Codex terminal setup did not match its spawn id".to_string(),
+                    ));
+                }
+                let CodexManagedLaunchSetup {
+                    terminal_id: _,
+                    runtime_cwd,
+                    tui_mcp_injection,
+                    terminal_env,
+                    sidecar_context: _,
+                } = setup;
+                mcp_cwd = runtime_cwd;
+                (tui_mcp_injection, terminal_env)
+            }
+            None => {
+                mcp_cwd = resolve_mcp_cwd(cwd.as_deref(), &RealEnv, host_os, is_wsl);
+                let mcp_injection = match generate_mcp_injection(
+                    &RealMcpRuntime,
+                    &mode,
+                    &terminal_id,
+                    mcp_cwd.as_deref(),
+                    target,
+                ) {
+                    Ok(injection) => injection,
+                    Err(error) => return Err(fail_json(StatusCode::BAD_REQUEST, error.message)),
+                };
+                let overrides =
+                    build_terminal_base_env(&RealEnv, &terminal_id, Some(&tab_id), Some(&pane_id));
+                (mcp_injection, overrides)
+            }
+        };
 
         // Freshell opencode TUI rebind plugin: the install (fs I/O) happens
         // HERE at the IO layer; the pure resolver only reads the result from
@@ -1654,8 +1746,6 @@ async fn settle_gated_create(inputs: GatedSettleInputs) -> Result<TerminalSpawnR
 
         let effective_shell = resolve_shell(shell_type, host_os, is_wsl);
         let windows_like = is_windows(host_os) || (is_wsl && effective_shell != ShellType::System);
-        let overrides =
-            build_terminal_base_env(&RealEnv, &terminal_id, Some(&tab_id), Some(&pane_id));
 
         spec = match &launch {
             Some(l) if windows_like => build_windows_cli_spawn_spec(
@@ -3551,6 +3641,269 @@ mod tests {
         std::fs::read_to_string(path).unwrap_or_default()
     }
 
+    const SYNTHETIC_FRESHELL_TOKEN: &str = "synthetic-rest-managed-codex-token";
+    const FRESHELL_CONTEXT_ENV_KEYS: [&str; 6] = [
+        "FRESHELL",
+        "FRESHELL_URL",
+        "FRESHELL_TOKEN",
+        "FRESHELL_TERMINAL_ID",
+        "FRESHELL_TAB_ID",
+        "FRESHELL_PANE_ID",
+    ];
+
+    /// The real dispatcher and committed fake app-server capture only these
+    /// allowlisted fields. Never derive Debug for this fixture: assertion
+    /// messages must not surface context values.
+    #[derive(serde::Deserialize)]
+    struct CapturedCodexProcess {
+        argv: Vec<String>,
+        env: BTreeMap<String, String>,
+    }
+
+    /// Snapshot values so the synthetic real-process fixture cannot leak a
+    /// test environment into another test. The values themselves are never
+    /// formatted or logged.
+    struct TestEnvRestore {
+        values: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl TestEnvRestore {
+        fn capture(keys: &[&'static str]) -> Self {
+            Self {
+                values: keys
+                    .iter()
+                    .map(|key| (*key, std::env::var_os(key)))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for TestEnvRestore {
+        fn drop(&mut self) {
+            for (key, value) in self.values.drain(..) {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    fn managed_codex_cli_spec() -> freshell_platform::CliCommandSpec {
+        freshell_platform::CliCommandSpec {
+            name: "codex".to_string(),
+            label: "Codex CLI".to_string(),
+            env_var: Some("CODEX_CMD".to_string()),
+            default_cmd: "codex".to_string(),
+            resume_args: Some(vec!["resume".to_string(), "{{sessionId}}".to_string()]),
+            model_args: Some(vec!["--model".to_string(), "{{model}}".to_string()]),
+            sandbox_args: Some(vec!["--sandbox".to_string(), "{{sandbox}}".to_string()]),
+            ..Default::default()
+        }
+    }
+
+    fn managed_codex_dispatcher() -> std::path::PathBuf {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs")
+            .canonicalize()
+            .expect("fake app-server fixture exists");
+        let dispatcher = std::env::temp_dir().join(format!(
+            "freshell-rest-managed-codex-dispatcher-{}-{}.mjs",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let script = format!(
+            r#"#!/usr/bin/env node
+import fs from 'node:fs'
+const args = process.argv.slice(2)
+if (args.includes('app-server')) {{
+  await import('file://{fixture}')
+}} else {{
+  fs.writeFileSync(process.env.CODEX_ARGV_CAPTURE_PATH, JSON.stringify({{
+    argv: args,
+    env: {{
+      FRESHELL: process.env.FRESHELL,
+      FRESHELL_URL: process.env.FRESHELL_URL,
+      FRESHELL_TOKEN: process.env.FRESHELL_TOKEN,
+      FRESHELL_TERMINAL_ID: process.env.FRESHELL_TERMINAL_ID,
+      FRESHELL_TAB_ID: process.env.FRESHELL_TAB_ID,
+      FRESHELL_PANE_ID: process.env.FRESHELL_PANE_ID,
+    }},
+  }}))
+  setInterval(() => undefined, 1000)
+}}
+"#,
+            fixture = fixture.display()
+        );
+        std::fs::write(&dispatcher, script).expect("write dispatcher");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&dispatcher).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&dispatcher, permissions).unwrap();
+        }
+        dispatcher
+    }
+
+    async fn wait_for_captured_codex_process(path: &std::path::Path) -> CapturedCodexProcess {
+        for _ in 0..200 {
+            if let Ok(content) = std::fs::read_to_string(path) {
+                if !content.is_empty() {
+                    return serde_json::from_str(&content).expect("captured process is JSON");
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("spawned codex child did not write its allowlisted capture")
+    }
+
+    fn freshell_mcp_pairs(argv: &[String]) -> Vec<(String, String)> {
+        argv.windows(2)
+            .filter(|pair| pair[0] == "-c" && pair[1].starts_with("mcp_servers.freshell."))
+            .map(|pair| (pair[0].clone(), pair[1].clone()))
+            .collect()
+    }
+
+    fn managed_env_vars_config() -> String {
+        let names = freshell_platform::mcp_inject::FRESHELL_MCP_CONTEXT_ENV_VARS
+            .iter()
+            .map(|name| format!("{name:?}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("mcp_servers.freshell.env_vars=[{names}]")
+    }
+
+    fn mcp_recipe_pairs(pairs: &[(String, String)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .filter(|(_, value)| {
+                value.starts_with("mcp_servers.freshell.command=")
+                    || value.starts_with("mcp_servers.freshell.args=")
+            })
+            .cloned()
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn managed_codex_terminal_tab_supplies_sidecar_context() {
+        // This is a real TUI + app-server pair, serialized with the crate's
+        // other Codex process fixtures. The local guard additionally restores
+        // the terminal-context inputs that its synthetic environment owns.
+        let _codex_environment = crate::codex::tests::ENV_LOCK.lock().await;
+        let _environment = TestEnvRestore::capture(&[
+            "AUTH_TOKEN",
+            "CODEX_ARGV_CAPTURE_PATH",
+            "CODEX_CMD",
+            "FAKE_CODEX_APP_SERVER_ARG_LOG",
+            "FRESHELL_CODEX_MANAGED_LAUNCH",
+            "FRESHELL_URL",
+            "PORT",
+        ]);
+        let dispatcher = managed_codex_dispatcher();
+        let tui_capture = unique_argv_file("managed-codex-tui");
+        let sidecar_capture = unique_argv_file("managed-codex-sidecar");
+        std::env::set_var("CODEX_CMD", &dispatcher);
+        std::env::set_var("CODEX_ARGV_CAPTURE_PATH", &tui_capture);
+        std::env::set_var("FAKE_CODEX_APP_SERVER_ARG_LOG", &sidecar_capture);
+        std::env::set_var("FRESHELL_CODEX_MANAGED_LAUNCH", "1");
+        std::env::set_var("PORT", "23126");
+        std::env::set_var("FRESHELL_URL", "http://127.0.0.1:23126");
+        std::env::set_var("AUTH_TOKEN", SYNTHETIC_FRESHELL_TOKEN);
+
+        let state =
+            state_with_registry().with_cli_commands(Arc::new(vec![managed_codex_cli_spec()]));
+        let registry = state.terminal_registry.clone().expect("registry wired");
+        let cwd = std::env::temp_dir();
+        let (status, body) = post(
+            app(state),
+            "/api/tabs",
+            json!({ "mode": "codex", "cwd": cwd.to_string_lossy() }),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "managed terminal tab must create");
+        let terminal_id = body["data"]["terminalId"]
+            .as_str()
+            .expect("terminal id")
+            .to_string();
+        let tab_id = body["data"]["tabId"].as_str().expect("tab id").to_string();
+        let pane_id = body["data"]["paneId"]
+            .as_str()
+            .expect("pane id")
+            .to_string();
+        let tui = wait_for_captured_codex_process(&tui_capture).await;
+        let sidecar = wait_for_captured_codex_process(&sidecar_capture).await;
+
+        // Collect evidence before cleanup; a failed assertion must never
+        // strand the real test fixture's PTY or its sidecar.
+        let tui_pairs = freshell_mcp_pairs(&tui.argv);
+        let sidecar_pairs = freshell_mcp_pairs(&sidecar.argv);
+        let expected_env_vars = managed_env_vars_config();
+        let tui_recipe = mcp_recipe_pairs(&tui_pairs);
+        let sidecar_recipe = mcp_recipe_pairs(&sidecar_pairs);
+        let sidecar_app_server_index = sidecar.argv.iter().position(|arg| arg == "app-server");
+        let sidecar_config_before_app_server = sidecar_app_server_index.is_some_and(|index| {
+            sidecar
+                .argv
+                .windows(2)
+                .enumerate()
+                .filter(|(_, pair)| pair[0] == "-c")
+                .all(|(pair_index, _)| pair_index < index)
+        });
+        let equal_context = tui.env == sidecar.env
+            && tui.env.len() == FRESHELL_CONTEXT_ENV_KEYS.len()
+            && FRESHELL_CONTEXT_ENV_KEYS
+                .iter()
+                .all(|key| tui.env.contains_key(*key))
+            && tui
+                .env
+                .get("FRESHELL_TERMINAL_ID")
+                .is_some_and(|value| value == &terminal_id)
+            && tui
+                .env
+                .get("FRESHELL_TAB_ID")
+                .is_some_and(|value| value == &tab_id)
+            && tui
+                .env
+                .get("FRESHELL_PANE_ID")
+                .is_some_and(|value| value == &pane_id);
+        let no_token_in_argv = [&tui.argv, &sidecar.argv].into_iter().all(|argv| {
+            !argv
+                .iter()
+                .any(|arg| arg.contains(SYNTHETIC_FRESHELL_TOKEN))
+        });
+        registry.kill(&terminal_id);
+        let _ = std::fs::remove_file(&tui_capture);
+        let _ = std::fs::remove_file(&sidecar_capture);
+        let _ = std::fs::remove_file(&dispatcher);
+
+        for pairs in [&tui_pairs, &sidecar_pairs] {
+            assert!(
+                pairs
+                    .iter()
+                    .any(|(flag, value)| flag == "-c" && value == &expected_env_vars),
+                "managed TUI and sidecar each need the exact static Freshell env_vars declaration"
+            );
+        }
+        assert!(
+            !tui_recipe.is_empty() && tui_recipe == sidecar_recipe,
+            "managed terminal-tab pair must receive the same Freshell MCP command recipe"
+        );
+        assert!(
+            sidecar_config_before_app_server,
+            "all sidecar configuration pairs must precede app-server"
+        );
+        assert!(
+            equal_context,
+            "managed terminal-tab TUI and sidecar must receive one equal six-key Freshell context"
+        );
+        assert!(
+            no_token_in_argv,
+            "synthetic Freshell token must never be serialized into argv"
+        );
+    }
+
     fn state_with_opencode_locator(home: std::path::PathBuf) -> FreshAgentState {
         state_with_registry().with_opencode_locator(Some(std::sync::Arc::new(
             freshell_sessions::opencode_locator::OpencodeLocator::new(home),
@@ -4618,6 +4971,8 @@ mod tests {
     async fn create_codex_tab_accepts_session_ref_and_derives_resume_args() {
         // DEV-0006 S5.e: the managed-launch default is ON; this suite exercises the
         // plain-CLI codex path (recording CLI spec, no app-server), so pin OFF.
+        let _codex_environment = crate::codex::tests::ENV_LOCK.lock().await;
+        let _environment = TestEnvRestore::capture(&["FRESHELL_CODEX_MANAGED_LAUNCH"]);
         std::env::set_var("FRESHELL_CODEX_MANAGED_LAUNCH", "0");
         let argv_file = unique_argv_file("codex-accept");
         let state =
@@ -5483,6 +5838,8 @@ mod tests {
     async fn rest_gate_skips_sidecar_live_candidate_create_proceeds_unchanged() {
         // DEV-0006 S5.e: the managed-launch default is ON; this suite exercises the
         // plain-CLI codex path (recording CLI spec, no app-server), so pin OFF.
+        let _codex_environment = crate::codex::tests::ENV_LOCK.lock().await;
+        let _environment = TestEnvRestore::capture(&["FRESHELL_CODEX_MANAGED_LAUNCH"]);
         std::env::set_var("FRESHELL_CODEX_MANAGED_LAUNCH", "0");
         const SIDECAR_LIVE: &str = "stale-cx";
         let argv_file = unique_argv_file("door3-sidecar-skip");
@@ -6360,6 +6717,8 @@ mod tests {
     async fn send_keys_enter_feeds_codex_locator() {
         // DEV-0006 S5.e: the managed-launch default is ON; this suite exercises the
         // plain-CLI codex path (sh-script fake codex, no app-server), so pin OFF.
+        let _codex_environment = crate::codex::tests::ENV_LOCK.lock().await;
+        let _environment = TestEnvRestore::capture(&["FRESHELL_CODEX_MANAGED_LAUNCH"]);
         std::env::set_var("FRESHELL_CODEX_MANAGED_LAUNCH", "0");
         let root = unique_temp_home("codex-submit");
         let argv_file = unique_argv_file("codex-submit");

--- a/crates/freshell-freshagent/src/terminal_tabs.rs
+++ b/crates/freshell-freshagent/src/terminal_tabs.rs
@@ -1563,6 +1563,7 @@ async fn settle_gated_create(inputs: GatedSettleInputs) -> Result<TerminalSpawnR
                 model: model.as_deref(),
                 sandbox: sandbox.as_deref(),
                 approval_policy: permission_mode.as_deref(),
+                sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext::default(),
             };
             match freshell_codex::launch_lifecycle::CodexTerminalLaunchManager::global()
                 .plan_create_with_retry_uncancellable(

--- a/crates/freshell-platform/src/mcp_inject.rs
+++ b/crates/freshell-platform/src/mcp_inject.rs
@@ -33,7 +33,9 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use crate::path::convert_windows_path_to_wsl_path;
 use crate::spawn::{McpInjection, ProviderTarget};
+use crate::{Env, HostOs};
 
 /// An MCP injection failure. `message` carries the reference-exact `Error.message`
 /// where one exists (`cw` throw sites); IO failures carry the OS error text.
@@ -66,6 +68,25 @@ impl std::error::Error for McpInjectError {}
 pub enum McpServerArg {
     Literal(String),
     Path(String),
+}
+
+/// Freshell context names that Codex forwards from the parent process to its
+/// stdio MCP child. Values intentionally remain in the parent environment.
+pub const FRESHELL_MCP_CONTEXT_ENV_VARS: [&str; 6] = [
+    "FRESHELL",
+    "FRESHELL_URL",
+    "FRESHELL_TOKEN",
+    "FRESHELL_TERMINAL_ID",
+    "FRESHELL_TAB_ID",
+    "FRESHELL_PANE_ID",
+];
+
+/// Target-specific inline MCP renderings for a managed Codex TUI and its
+/// host-native app-server sidecar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedCodexMcpRenderings {
+    pub tui: McpInjection,
+    pub sidecar: McpInjection,
 }
 
 /// The environment seam for the config writer: tmp dir (`os.tmpdir()`), WSL
@@ -206,20 +227,33 @@ pub fn build_mcp_server_command_args(
     target: ProviderTarget,
 ) -> Result<Vec<String>, McpInjectError> {
     let needs_win_paths = target == ProviderTarget::Windows && rt.is_wsl_environment();
-    Ok(rt
-        .server_command_args()?
-        .into_iter()
+    let recipe = resolve_mcp_server_command_recipe(rt)?;
+    render_mcp_server_command_recipe(&recipe, |path| {
+        if needs_win_paths {
+            Ok(rt.convert_to_windows_path(path))
+        } else {
+            Ok(path.to_string())
+        }
+    })
+}
+
+fn resolve_mcp_server_command_recipe(
+    rt: &dyn McpRuntime,
+) -> Result<Vec<McpServerArg>, McpInjectError> {
+    rt.server_command_args()
+}
+
+fn render_mcp_server_command_recipe(
+    recipe: &[McpServerArg],
+    mut render_path: impl FnMut(&str) -> Result<String, McpInjectError>,
+) -> Result<Vec<String>, McpInjectError> {
+    recipe
+        .iter()
         .map(|arg| match arg {
-            McpServerArg::Literal(s) => s,
-            McpServerArg::Path(p) => {
-                if needs_win_paths {
-                    rt.convert_to_windows_path(&p)
-                } else {
-                    p
-                }
-            }
+            McpServerArg::Literal(value) => Ok(value.clone()),
+            McpServerArg::Path(path) => render_path(path),
         })
-        .collect())
+        .collect()
 }
 
 /// `tomlEscape` (`cw:142-144`): wrap in `"` with `\` → `\\` and `"` → `\"`.
@@ -242,6 +276,81 @@ pub fn codex_inline_toml_args(server_args: &[String]) -> Vec<String> {
         "-c".to_string(),
         format!("mcp_servers.freshell.args=[{toml_args}]"),
     ]
+}
+
+fn managed_codex_inline_toml_args(server_args: &[String]) -> Vec<String> {
+    let mut args = codex_inline_toml_args(server_args);
+    let env_vars = FRESHELL_MCP_CONTEXT_ENV_VARS
+        .iter()
+        .map(|name| toml_escape(name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    args.extend([
+        "-c".to_string(),
+        format!("mcp_servers.freshell.env_vars=[{env_vars}]"),
+    ]);
+    args
+}
+
+/// Render one tagged MCP recipe for the managed Codex TUI and separately for
+/// the host-native app-server sidecar. The static `env_vars` declaration tells
+/// Codex which parent-process Freshell context names to retain for its stdio
+/// MCP child without placing any values in inline TOML.
+pub fn build_managed_codex_mcp_renderings(
+    runtime: &dyn McpRuntime,
+    env: &dyn Env,
+    host_os: HostOs,
+    is_wsl_env: bool,
+    tui_target: ProviderTarget,
+) -> Result<ManagedCodexMcpRenderings, McpInjectError> {
+    let recipe = resolve_mcp_server_command_recipe(runtime)?;
+    let sidecar_target = if host_os == HostOs::Windows {
+        ProviderTarget::Windows
+    } else {
+        ProviderTarget::Unix
+    };
+
+    Ok(ManagedCodexMcpRenderings {
+        tui: managed_codex_mcp_injection(&recipe, runtime, env, host_os, is_wsl_env, tui_target)?,
+        sidecar: managed_codex_mcp_injection(
+            &recipe,
+            runtime,
+            env,
+            host_os,
+            is_wsl_env,
+            sidecar_target,
+        )?,
+    })
+}
+
+fn managed_codex_mcp_injection(
+    recipe: &[McpServerArg],
+    runtime: &dyn McpRuntime,
+    env: &dyn Env,
+    host_os: HostOs,
+    is_wsl_env: bool,
+    target: ProviderTarget,
+) -> Result<McpInjection, McpInjectError> {
+    let needs_wsl_windows_paths = target == ProviderTarget::Windows && is_wsl_env;
+    let needs_native_windows_unix_paths =
+        host_os == HostOs::Windows && target == ProviderTarget::Unix;
+    let server_args = render_mcp_server_command_recipe(recipe, |path| {
+        if needs_wsl_windows_paths {
+            Ok(runtime.convert_to_windows_path(path))
+        } else if needs_native_windows_unix_paths {
+            convert_windows_path_to_wsl_path(path, env, is_wsl_env).ok_or_else(|| {
+                McpInjectError::new(
+                    "Cannot render managed Codex MCP path for a Unix TUI: failed to convert the Windows path to a WSL path.",
+                )
+            })
+        } else {
+            Ok(path.to_string())
+        }
+    })?;
+    Ok(McpInjection {
+        args: managed_codex_inline_toml_args(&server_args),
+        env: BTreeMap::new(),
+    })
 }
 
 fn tmp_file_path(rt: &dyn McpRuntime, terminal_id: &str) -> PathBuf {

--- a/crates/freshell-platform/src/mcp_inject_tests.rs
+++ b/crates/freshell-platform/src/mcp_inject_tests.rs
@@ -3,7 +3,9 @@
 //!   Split out to respect the campaign's ≤1K-lines-per-file limit.
 
 use super::*;
-use std::sync::atomic::{AtomicU64, Ordering};
+use crate::{HostOs, MapEnv};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
 
 static SCRATCH_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -39,6 +41,17 @@ struct FakeRt {
     tmp: PathBuf,
     wsl: bool,
     args: Vec<McpServerArg>,
+    server_command_args_calls: Arc<AtomicUsize>,
+}
+impl FakeRt {
+    fn new(tmp: &Path, wsl: bool, args: Vec<McpServerArg>) -> Self {
+        Self {
+            tmp: tmp.to_path_buf(),
+            wsl,
+            args,
+            server_command_args_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
 }
 impl McpRuntime for FakeRt {
     fn tmp_dir(&self) -> PathBuf {
@@ -52,6 +65,8 @@ impl McpRuntime for FakeRt {
         format!("\\\\wsl.localhost\\Ubuntu{}", linux_path.replace('/', "\\"))
     }
     fn server_command_args(&self) -> Result<Vec<McpServerArg>, McpInjectError> {
+        self.server_command_args_calls
+            .fetch_add(1, Ordering::SeqCst);
         Ok(self.args.clone())
     }
 }
@@ -65,11 +80,136 @@ fn mcp_unix_args() -> Vec<McpServerArg> {
 }
 
 fn fake_rt(tmp: &Path, wsl: bool) -> FakeRt {
-    FakeRt {
-        tmp: tmp.to_path_buf(),
-        wsl,
-        args: mcp_unix_args(),
+    FakeRt::new(tmp, wsl, mcp_unix_args())
+}
+
+const MANAGED_CODEX_CONTEXT_ENV_VARS_PAIR: &str = "mcp_servers.freshell.env_vars=[\"FRESHELL\", \"FRESHELL_URL\", \"FRESHELL_TOKEN\", \"FRESHELL_TERMINAL_ID\", \"FRESHELL_TAB_ID\", \"FRESHELL_PANE_ID\"]";
+
+fn managed_codex_pairs(args_pair: &str) -> Vec<String> {
+    vec![
+        "-c".to_string(),
+        "mcp_servers.freshell.command=\"node\"".to_string(),
+        "-c".to_string(),
+        args_pair.to_string(),
+        "-c".to_string(),
+        MANAGED_CODEX_CONTEXT_ENV_VARS_PAIR.to_string(),
+    ]
+}
+
+#[test]
+fn managed_codex_renderings_resolve_one_recipe_and_forward_only_names() {
+    let scratch = Scratch::new("managed-once");
+    let rt = fake_rt(scratch.path(), false);
+    let calls = Arc::clone(&rt.server_command_args_calls);
+    let env = MapEnv::new()
+        .with("FRESHELL_TOKEN", "token-not-in-argv")
+        .with("FRESHELL_TERMINAL_ID", "terminal-id-not-in-argv")
+        .with("FRESHELL_URL", "https://url-not-in-argv.invalid");
+
+    let renderings =
+        build_managed_codex_mcp_renderings(&rt, &env, HostOs::Linux, false, ProviderTarget::Unix)
+            .unwrap();
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    let expected = managed_codex_pairs(
+        "mcp_servers.freshell.args=[\"--import\", \"/repo/node_modules/tsx/dist/loader.mjs\", \"/repo/server/mcp/server.ts\"]",
+    );
+    assert_eq!(renderings.tui.args, expected);
+    assert_eq!(renderings.sidecar.args, expected);
+    for injection in [&renderings.tui, &renderings.sidecar] {
+        assert!(injection.env.is_empty());
+        assert!(injection
+            .args
+            .iter()
+            .all(|arg| !arg.starts_with("mcp_servers.freshell.env=")));
+        assert!(injection
+            .args
+            .iter()
+            .all(|arg| !arg.contains("token-not-in-argv")));
+        assert!(injection
+            .args
+            .iter()
+            .all(|arg| !arg.contains("terminal-id-not-in-argv")));
+        assert!(injection
+            .args
+            .iter()
+            .all(|arg| !arg.contains("url-not-in-argv.invalid")));
     }
+}
+
+#[test]
+fn managed_codex_renderings_use_unc_for_wsl_windows_tui_and_posix_for_sidecar() {
+    let scratch = Scratch::new("managed-wsl");
+    let rt = fake_rt(scratch.path(), true);
+    let renderings = build_managed_codex_mcp_renderings(
+        &rt,
+        &MapEnv::new(),
+        HostOs::Linux,
+        true,
+        ProviderTarget::Windows,
+    )
+    .unwrap();
+
+    assert_eq!(
+        renderings.tui.args,
+        managed_codex_pairs(
+            "mcp_servers.freshell.args=[\"--import\", \"\\\\\\\\wsl.localhost\\\\Ubuntu\\\\repo\\\\node_modules\\\\tsx\\\\dist\\\\loader.mjs\", \"\\\\\\\\wsl.localhost\\\\Ubuntu\\\\repo\\\\server\\\\mcp\\\\server.ts\"]",
+        )
+    );
+    assert_eq!(
+        renderings.sidecar.args,
+        managed_codex_pairs(
+            "mcp_servers.freshell.args=[\"--import\", \"/repo/node_modules/tsx/dist/loader.mjs\", \"/repo/server/mcp/server.ts\"]",
+        )
+    );
+}
+
+#[test]
+fn managed_codex_renderings_use_wsl_paths_for_native_windows_unix_tui() {
+    let scratch = Scratch::new("managed-win-unix");
+    let windows_args = vec![
+        McpServerArg::Literal("--import".to_string()),
+        McpServerArg::Path("C:\\repo\\node_modules\\tsx\\dist\\loader.mjs".to_string()),
+        McpServerArg::Path("C:\\repo\\server\\mcp\\server.ts".to_string()),
+    ];
+    let rt = FakeRt::new(scratch.path(), false, windows_args);
+    let env = MapEnv::new().with("WSL_MOUNT_PREFIX", "/mnt");
+    let renderings =
+        build_managed_codex_mcp_renderings(&rt, &env, HostOs::Windows, false, ProviderTarget::Unix)
+            .unwrap();
+
+    assert_eq!(
+        renderings.tui.args,
+        managed_codex_pairs(
+            "mcp_servers.freshell.args=[\"--import\", \"/mnt/c/repo/node_modules/tsx/dist/loader.mjs\", \"/mnt/c/repo/server/mcp/server.ts\"]",
+        )
+    );
+    assert_eq!(
+        renderings.sidecar.args,
+        managed_codex_pairs(
+            "mcp_servers.freshell.args=[\"--import\", \"C:\\\\repo\\\\node_modules\\\\tsx\\\\dist\\\\loader.mjs\", \"C:\\\\repo\\\\server\\\\mcp\\\\server.ts\"]",
+        )
+    );
+
+    let unconvertible_rt = FakeRt::new(
+        scratch.path(),
+        false,
+        vec![McpServerArg::Path(
+            "\\\\server\\share\\server.ts".to_string(),
+        )],
+    );
+    let err = build_managed_codex_mcp_renderings(
+        &unconvertible_rt,
+        &env,
+        HostOs::Windows,
+        false,
+        ProviderTarget::Unix,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.message,
+        "Cannot render managed Codex MCP path for a Unix TUI: failed to convert the Windows path to a WSL path."
+    );
 }
 
 #[test]
@@ -168,15 +308,15 @@ fn codex_unix_target_on_wsl_keeps_host_paths() {
 #[test]
 fn g_w1_native_windows_host_unix_target_keeps_windows_paths() {
     let scratch = Scratch::new("gw1");
-    let rt = FakeRt {
-        tmp: scratch.path().to_path_buf(),
-        wsl: false, // native Windows host: isWslEnvironment() is false
-        args: vec![
+    let rt = FakeRt::new(
+        scratch.path(),
+        false, // native Windows host: isWslEnvironment() is false
+        vec![
             McpServerArg::Literal("--import".to_string()),
             McpServerArg::Path("C:\\repo\\node_modules\\tsx\\dist\\loader.mjs".to_string()),
             McpServerArg::Path("C:\\repo\\server\\mcp\\server.ts".to_string()),
         ],
-    };
+    );
     let inj = generate_mcp_injection(&rt, "codex", "term1", None, ProviderTarget::Unix).unwrap();
     assert_eq!(
         inj.args[3],

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -48,8 +48,10 @@ use tokio::sync::mpsc;
 use tracing::Instrument;
 use uuid::Uuid;
 
-use freshell_platform::detect::{host_os_live, is_windows, is_wsl_env_live};
-use freshell_platform::mcp_inject::{cleanup_mcp_config, generate_mcp_injection, RealMcpRuntime};
+use freshell_platform::detect::{host_os_live, is_windows, is_wsl_env_live, HostOs};
+use freshell_platform::mcp_inject::{
+    build_managed_codex_mcp_renderings, cleanup_mcp_config, generate_mcp_injection, RealMcpRuntime,
+};
 use freshell_platform::spawn::{
     cli_provider_target, resolve_coding_cli_command, resolve_mcp_cwd, resolve_shell,
     resolve_unix_shell_cwd, CliLaunchInputs, LaunchIntent, McpInjection,
@@ -1981,6 +1983,55 @@ fn cli_provider_settings(
     (pick("permissionMode"), pick("model"), pick("sandbox"))
 }
 
+/// One value-safe rendering of the managed Codex launch shared by its TUI
+/// and a newly spawned app-server. It deliberately has no `Debug` impl: the
+/// parent environment carries terminal context values and must never be
+/// formatted into logs or error surfaces.
+struct CodexManagedLaunchSetup {
+    terminal_id: String,
+    runtime_cwd: Option<String>,
+    tui_mcp_injection: McpInjection,
+    terminal_env: BTreeMap<String, String>,
+    sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext,
+}
+
+/// Build the terminal-scoped managed Codex setup exactly once. The sidecar
+/// gets the host-native rendering and the same canonical terminal environment
+/// as the TUI; the TUI gets its selected target rendering. A claimed survivor
+/// never consumes this value (runtime selection preserves it unchanged).
+fn build_codex_managed_launch_setup(
+    terminal_id: String,
+    shell: ShellType,
+    host_os: HostOs,
+    is_wsl: bool,
+    resolved_cwd: Option<&str>,
+    tab_id: Option<&str>,
+    pane_id: Option<&str>,
+) -> Result<CodexManagedLaunchSetup, String> {
+    let runtime_cwd = resolve_mcp_cwd(resolved_cwd, &RealEnv, host_os, is_wsl);
+    let tui_target = cli_provider_target(shell, host_os, is_wsl, resolved_cwd, &RealEnv);
+    let renderings =
+        build_managed_codex_mcp_renderings(&RealMcpRuntime, &RealEnv, host_os, is_wsl, tui_target)
+            .map_err(|error| error.message)?;
+    let freshell_platform::mcp_inject::ManagedCodexMcpRenderings { tui, sidecar } = renderings;
+    let terminal_env = build_terminal_base_env(&RealEnv, &terminal_id, tab_id, pane_id);
+    let mut sidecar_env = sidecar.env;
+    // Canonical terminal values are the authority if a renderer ever grows an
+    // overlapping environment key.
+    sidecar_env.extend(terminal_env.clone());
+
+    Ok(CodexManagedLaunchSetup {
+        terminal_id,
+        runtime_cwd,
+        tui_mcp_injection: tui,
+        terminal_env,
+        sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext {
+            config_args: sidecar.args,
+            env: sidecar_env,
+        },
+    })
+}
+
 /// WS-side projection of [`CodexLaunchError`] keeping exactly the
 /// distinctions the create doors need (graceful restore/resume S1).
 pub(crate) enum PlanLaunchError {
@@ -2008,9 +2059,8 @@ impl PlanLaunchError {
 /// default ON since S5.e): plan the managed app-server launch
 /// (`planCodexLaunch`, ws:2442-2449: sidecar spawn + remote proxy, 5-attempt
 /// initial budget); the codex provider settings route through the PLAN, not
-/// argv (the `ws:2464-2465` strip). Flag `"0"` opts out to the plain-CLI shape
-/// (`Ok(None)` — the retired G-X0 shape; G-X1/G-X2 pin the live path since the
-/// S5.e flip).
+/// argv (the `ws:2464-2465` strip). Callers apply the explicit `"0"` opt-out
+/// before reaching this helper, retaining the plain-CLI shape.
 ///
 /// Extracted from `handle_create` so the auto-resume respawn seam (Task 4)
 /// plans identically. `Err` carries the thrown planCodexLaunch message —
@@ -2020,17 +2070,11 @@ impl PlanLaunchError {
 /// doors pass `None` (never-fired watch minted in the manager).
 async fn plan_codex_managed_launch(
     state: &WsState,
-    mode: &str,
-    raw_cwd: Option<&str>,
+    setup: &CodexManagedLaunchSetup,
     resume_session_id: Option<&str>,
     class: freshell_codex::launch_lifecycle::LaunchClass,
     cancel: Option<&mut tokio::sync::watch::Receiver<bool>>,
-) -> Result<Option<freshell_codex::launch_lifecycle::CodexTerminalLaunch>, PlanLaunchError> {
-    let managed_flag =
-        std::env::var(freshell_codex::launch_plan::FRESHELL_CODEX_MANAGED_LAUNCH_ENV).ok();
-    if !codex_create_uses_managed_launch(mode, managed_flag.as_deref()) {
-        return Ok(None);
-    }
+) -> Result<freshell_codex::launch_lifecycle::CodexTerminalLaunch, PlanLaunchError> {
     let codex_provider = state.settings.coding_cli.providers.get("codex");
     let provider_str = |key: &str| {
         codex_provider
@@ -2043,12 +2087,12 @@ async fn plan_codex_managed_launch(
     // `approvalPolicy: providerSettings?.permissionMode` (`ws:942`).
     let plan_approval = provider_str("permissionMode");
     let input = freshell_codex::launch_plan::CodexLaunchPlanInput {
-        cwd: raw_cwd,
+        cwd: setup.runtime_cwd.as_deref(),
         resume_session_id,
         model: plan_model.as_deref(),
         sandbox: plan_sandbox.as_deref(),
         approval_policy: plan_approval.as_deref(),
-        sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext::default(),
+        sidecar_context: setup.sidecar_context.clone(),
     };
     let manager = freshell_codex::launch_lifecycle::CodexTerminalLaunchManager::global();
     let result = match cancel {
@@ -2072,7 +2116,7 @@ async fn plan_codex_managed_launch(
                 .await
         }
     };
-    result.map(Some).map_err(|error| match error {
+    result.map_err(|error| match error {
         freshell_codex::launch_lifecycle::CodexLaunchError::QueueFull => PlanLaunchError::QueueFull,
         freshell_codex::launch_lifecycle::CodexLaunchError::Cancelled => PlanLaunchError::Cancelled,
         other => PlanLaunchError::Failed(other.to_string()),
@@ -2487,24 +2531,40 @@ pub(crate) fn derive_launch_prep(create: &TerminalCreate, mode: &str) -> LaunchP
 /// (which is `Handle::try_current()`-guarded — Task 2 — so this Drop can
 /// NEVER panic, even outside runtime context).
 pub(crate) struct PreparedCodexLaunch(
-    Option<freshell_codex::launch_lifecycle::CodexTerminalLaunch>,
+    Option<(
+        CodexManagedLaunchSetup,
+        freshell_codex::launch_lifecycle::CodexTerminalLaunch,
+    )>,
 );
 
 impl PreparedCodexLaunch {
-    pub(crate) fn new(
-        launch: Option<freshell_codex::launch_lifecycle::CodexTerminalLaunch>,
+    fn new(
+        setup: CodexManagedLaunchSetup,
+        launch: freshell_codex::launch_lifecycle::CodexTerminalLaunch,
     ) -> Self {
-        Self(launch)
+        Self(Some((setup, launch)))
     }
+
+    /// The ID was reserved before off-permit planning. Reuse it in
+    /// `handle_create`; do not mint or render a second terminal context.
+    fn terminal_id(&self) -> Option<&str> {
+        self.0.as_ref().map(|(setup, _)| setup.terminal_id.as_str())
+    }
+
     /// Hand the launch to the adoption path; the guard becomes inert.
-    pub(crate) fn take(&mut self) -> Option<freshell_codex::launch_lifecycle::CodexTerminalLaunch> {
+    fn take(
+        &mut self,
+    ) -> Option<(
+        CodexManagedLaunchSetup,
+        freshell_codex::launch_lifecycle::CodexTerminalLaunch,
+    )> {
         self.0.take()
     }
 }
 
 impl Drop for PreparedCodexLaunch {
     fn drop(&mut self) {
-        if let Some(launch) = self.0.take() {
+        if let Some((_, launch)) = self.0.take() {
             tracing::info!(
                 target: "freshell_ws::create",
                 "prepared_codex_launch_discarded"
@@ -2684,18 +2744,40 @@ pub(crate) async fn prepare_launch(
     // sessionRef/resumeSessionId keeps today's EXACT on-permit inline
     // planning path (LaunchClass::Interactive inside handle_create),
     // byte-identical to today.
-    let codex_launch = if prep.resume_session_id.is_some() {
+    let managed_flag =
+        std::env::var(freshell_codex::launch_plan::FRESHELL_CODEX_MANAGED_LAUNCH_ENV).ok();
+    let codex_launch = if prep.resume_session_id.is_some()
+        && codex_create_uses_managed_launch(&mode, managed_flag.as_deref())
+    {
+        // Reserve exactly one ID only for a managed resume that will plan.
+        // The structured guard carries it through the spawn-gate wait so the
+        // eventual PTY and already-spawned sidecar cannot diverge.
+        let host_os = host_os_live();
+        let setup = build_codex_managed_launch_setup(
+            Uuid::new_v4().simple().to_string(),
+            map_shell(create.shell),
+            host_os,
+            is_wsl_env_live(),
+            resolve_create_cwd(
+                create.cwd.as_deref(),
+                state.settings.default_cwd.as_deref(),
+                host_os,
+            )
+            .as_deref(),
+            create.tab_id.as_deref(),
+            create.pane_id.as_deref(),
+        )
+        .map_err(PrepareError::PlanFailed)?;
         match plan_codex_managed_launch(
             state,
-            &mode,
-            create.cwd.as_deref(),
+            &setup,
             prep.resume_session_id.as_deref(),
             freshell_codex::launch_lifecycle::LaunchClass::Restore,
             Some(cancel),
         )
         .await
         {
-            Ok(launch) => Some(PreparedCodexLaunch::new(launch)),
+            Ok(launch) => Some(PreparedCodexLaunch::new(setup, launch)),
             Err(PlanLaunchError::QueueFull) => return Err(PrepareError::PlanQueueFull),
             Err(PlanLaunchError::Cancelled) => return Err(PrepareError::Cancelled),
             Err(PlanLaunchError::Failed(message)) => return Err(PrepareError::PlanFailed(message)),
@@ -2944,11 +3026,6 @@ pub(crate) async fn handle_create(
         .await;
     }
 
-    // `terminalId` via UUID (nanoid-alphabet-compatible for the oracle validator);
-    // `streamId` via UUIDv4 (the reference's randomUUID()).
-    let terminal_id = Uuid::new_v4().simple().to_string();
-    let stream_id = Uuid::new_v4().to_string();
-
     let host_os = host_os_live();
     let is_wsl = is_wsl_env_live();
     let shell = map_shell(create.shell);
@@ -2974,6 +3051,17 @@ pub(crate) async fn handle_create(
         )
         .await;
     }
+
+    // `terminalId` via UUID (nanoid-alphabet-compatible for the oracle
+    // validator); `streamId` via UUIDv4. A prepared managed restore already
+    // reserved the terminal id before off-permit planning, so reuse that one
+    // instead of minting/rerendering a second context.
+    let terminal_id = prepared_codex
+        .as_ref()
+        .and_then(PreparedCodexLaunch::terminal_id)
+        .map(str::to_string)
+        .unwrap_or_else(|| Uuid::new_v4().simple().to_string());
+    let stream_id = Uuid::new_v4().to_string();
 
     // Resolve the effective cwd BEFORE any branch/mcp computation (`tr:1565` via
     // `resolve_create_cwd`): explicit `create.cwd`, else `settings.defaultCwd`,
@@ -3381,84 +3469,107 @@ pub(crate) async fn handle_create(
         None
     };
 
-    // codex `--remote <wsUrl>` (DEV-0006, `FRESHELL_CODEX_MANAGED_LAUNCH` default
-    // ON since S5.e): plan the managed app-server launch (`planCodexLaunch`,
-    // ws:2442-2449: sidecar spawn + remote proxy, 5-attempt initial budget) and
-    // point the TUI at the PROXY's ws URL; the codex provider settings route
-    // through the PLAN, not argv (the `ws:2464-2465` strip above). Flag `"0"`
-    // opts out to the plain-CLI shape (the retired G-X0 shape; G-X1/G-X2 pin the
-    // live path since the S5.e flip).
-    // Extracted to `plan_codex_managed_launch` (shared with the auto-resume
-    // respawn seam, Task 4). Legacy plans with the RAW create cwd (`ws:2444`
-    // passes `m.cwd`).
-    let codex_launch = match prepared_codex.as_mut() {
-        // Restore path with a derived resume id: planned pre-gate (P1).
-        // take() disarms the guard — from here the existing failed-spawn
-        // arm and adopt path own the launch exactly as today. The None arm
-        // below serves interactive creates AND the A4 fresh-plan exclusion
-        // (restore:true codex with no derived resume session id): both plan
-        // on-permit inline, byte-identical to today.
-        Some(guard) => guard.take(),
-        None => match plan_codex_managed_launch(
-            state,
-            &mode,
-            create.cwd.as_deref(),
-            resume_session_id.as_deref(),
-            freshell_codex::launch_lifecycle::LaunchClass::Interactive,
-            None,
-        )
-        .await
-        {
-            Ok(launch) => launch,
-            Err(error) => {
-                // A thrown planCodexLaunch surfaces through the generic create catch
-                // (`ws:2606-2614`) as an `error{code:PTY_SPAWN_FAILED}` frame.
-                // QueueFull/Cancelled are unreachable for Interactive-class
-                // `None`-cancel calls; `message()` keeps the frame text
-                // identical for `Failed`.
-                return send_create_error(
-                    out,
-                    ErrorCode::PtySpawnFailed,
-                    error.message(),
-                    &create.request_id,
-                )
-                .await;
-            }
-        },
+    // Build one managed setup for each newly spawned pair. A prepared resume
+    // hands us its original setup/launch; a fresh or A4-inline plan builds it
+    // only after every validation/duplicate gate above has passed.
+    let prepared_pair = prepared_codex.as_mut().and_then(PreparedCodexLaunch::take);
+    let managed_flag =
+        std::env::var(freshell_codex::launch_plan::FRESHELL_CODEX_MANAGED_LAUNCH_ENV).ok();
+    let (codex_setup, codex_launch) = match prepared_pair {
+        Some((setup, launch)) => (Some(setup), Some(launch)),
+        None if codex_create_uses_managed_launch(&mode, managed_flag.as_deref()) => {
+            let setup = match build_codex_managed_launch_setup(
+                terminal_id.clone(),
+                shell,
+                host_os,
+                is_wsl,
+                resolved_cwd.as_deref(),
+                create.tab_id.as_deref(),
+                create.pane_id.as_deref(),
+            ) {
+                Ok(setup) => setup,
+                Err(message) => {
+                    return send_create_error(
+                        out,
+                        ErrorCode::PtySpawnFailed,
+                        message,
+                        &create.request_id,
+                    )
+                    .await
+                }
+            };
+            let launch = match plan_codex_managed_launch(
+                state,
+                &setup,
+                resume_session_id.as_deref(),
+                freshell_codex::launch_lifecycle::LaunchClass::Interactive,
+                None,
+            )
+            .await
+            {
+                Ok(launch) => launch,
+                Err(error) => {
+                    return send_create_error(
+                        out,
+                        ErrorCode::PtySpawnFailed,
+                        error.message(),
+                        &create.request_id,
+                    )
+                    .await
+                }
+            };
+            (Some(setup), Some(launch))
+        }
+        None => (None, None),
     };
     let codex_remote_ws_url: Option<String> =
         codex_launch.as_ref().map(|l| l.remote_ws_url.clone());
 
-    // ProviderTarget + host-native mcp cwd (`tr:911-914,1153,1203,1236,1262`).
+    // The TUI target still drives CLI resolution. Managed Codex uses the
+    // setup's one-shot TUI rendering/environment; all other paths retain the
+    // existing generic MCP computation unchanged.
     let target = cli_provider_target(shell, host_os, is_wsl, resolved_cwd.as_deref(), &RealEnv);
-    let mcp_cwd = if mode == "shell" {
-        None
-    } else {
-        resolve_mcp_cwd(resolved_cwd.as_deref(), &RealEnv, host_os, is_wsl)
-    };
-
-    // MCP injection (§3.2 IO layer). Reference parity: a throw here propagates out
-    // of buildSpawnSpec BEFORE the pty.spawn try — no cleanup call on this path.
-    let mcp_injection = if mode == "shell" {
-        McpInjection::default()
-    } else {
-        match generate_mcp_injection(
-            &RealMcpRuntime,
-            &mode,
-            &terminal_id,
-            mcp_cwd.as_deref(),
-            target,
-        ) {
-            Ok(i) => i,
-            Err(e) => {
-                return send_create_error(
-                    out,
-                    ErrorCode::PtySpawnFailed,
-                    e.message,
-                    &create.request_id,
-                )
-                .await
-            }
+    let (mcp_cwd, mcp_injection, overrides) = match codex_setup {
+        Some(setup) => (
+            setup.runtime_cwd,
+            setup.tui_mcp_injection,
+            setup.terminal_env,
+        ),
+        None => {
+            let mcp_cwd = if mode == "shell" {
+                None
+            } else {
+                resolve_mcp_cwd(resolved_cwd.as_deref(), &RealEnv, host_os, is_wsl)
+            };
+            let mcp_injection = if mode == "shell" {
+                McpInjection::default()
+            } else {
+                match generate_mcp_injection(
+                    &RealMcpRuntime,
+                    &mode,
+                    &terminal_id,
+                    mcp_cwd.as_deref(),
+                    target,
+                ) {
+                    Ok(injection) => injection,
+                    Err(error) => {
+                        return send_create_error(
+                            out,
+                            ErrorCode::PtySpawnFailed,
+                            error.message,
+                            &create.request_id,
+                        )
+                        .await
+                    }
+                }
+            };
+            let overrides = build_terminal_base_env(
+                &RealEnv,
+                &terminal_id,
+                create.tab_id.as_deref(),
+                create.pane_id.as_deref(),
+            );
+            (mcp_cwd, mcp_injection, overrides)
         }
     };
 
@@ -3501,17 +3612,6 @@ pub(crate) async fn handle_create(
             .await
         }
     };
-
-    // `buildTerminalBaseEnv` (`tr:1529-1542`): FRESHELL/FRESHELL_URL/FRESHELL_TOKEN/
-    // FRESHELL_TERMINAL_ID/+TAB/PANE. U6 resolution: the Rust server's canonical
-    // port/token plumbing IS `PORT`/`AUTH_TOKEN` (main.rs), so the reference's
-    // env-derived computation carries over verbatim.
-    let overrides = build_terminal_base_env(
-        &RealEnv,
-        &terminal_id,
-        create.tab_id.as_deref(),
-        create.pane_id.as_deref(),
-    );
 
     // (`effective_shell`/`windows_like` are hoisted above the amplifier
     // pre-create block so its windows-arm reject evaluates the same predicate
@@ -4329,39 +4429,66 @@ pub async fn respawn_agent_terminal(
         None
     };
 
-    // codex `--remote <wsUrl>` (DEV-0006 S4, FLAG-GATED default OFF) — the
-    // same shared planner `handle_create` uses.
-    let codex_launch = match plan_codex_managed_launch(
-        state,
-        &mode,
-        req.cwd.as_deref(),
-        resume_session_id.as_deref(),
-        freshell_codex::launch_lifecycle::LaunchClass::Interactive,
-        None,
-    )
-    .await
-    {
-        Ok(launch) => launch,
-        Err(error) => return Err(RespawnError::LaunchUnresolvable(error.message())),
+    // A replacement Codex sidecar is a new process, so it receives a fresh
+    // setup from the replacement terminal id. Headless recovery intentionally
+    // has no tab/pane identities.
+    let managed_flag =
+        std::env::var(freshell_codex::launch_plan::FRESHELL_CODEX_MANAGED_LAUNCH_ENV).ok();
+    let codex_setup = if codex_create_uses_managed_launch(&mode, managed_flag.as_deref()) {
+        Some(
+            build_codex_managed_launch_setup(
+                terminal_id.clone(),
+                shell,
+                host_os,
+                is_wsl,
+                resolved_cwd.as_deref(),
+                None,
+                None,
+            )
+            .map_err(RespawnError::LaunchUnresolvable)?,
+        )
+    } else {
+        None
+    };
+    let codex_launch = match codex_setup.as_ref() {
+        Some(setup) => Some(
+            plan_codex_managed_launch(
+                state,
+                setup,
+                resume_session_id.as_deref(),
+                freshell_codex::launch_lifecycle::LaunchClass::Interactive,
+                None,
+            )
+            .await
+            .map_err(|error| RespawnError::LaunchUnresolvable(error.message()))?,
+        ),
+        None => None,
     };
     let codex_remote_ws_url: Option<String> =
         codex_launch.as_ref().map(|l| l.remote_ws_url.clone());
 
-    // ProviderTarget + host-native mcp cwd, then the MCP injection — same
-    // order and same IO layer as `handle_create` (a throw here propagates
-    // before the pty spawn; no cleanup call on this path, matching
-    // `handle_create`'s error arm).
+    // Managed Codex reuses its setup's TUI rendering/environment. Other
+    // replacement modes retain the existing generic computation.
     let target = cli_provider_target(shell, host_os, is_wsl, resolved_cwd.as_deref(), &RealEnv);
-    let mcp_cwd = resolve_mcp_cwd(resolved_cwd.as_deref(), &RealEnv, host_os, is_wsl);
-    let mcp_injection = match generate_mcp_injection(
-        &RealMcpRuntime,
-        &mode,
-        &terminal_id,
-        mcp_cwd.as_deref(),
-        target,
-    ) {
-        Ok(i) => i,
-        Err(e) => return Err(RespawnError::LaunchUnresolvable(e.message)),
+    let (mcp_cwd, mcp_injection, overrides) = match codex_setup {
+        Some(setup) => (
+            setup.runtime_cwd,
+            setup.tui_mcp_injection,
+            setup.terminal_env,
+        ),
+        None => {
+            let mcp_cwd = resolve_mcp_cwd(resolved_cwd.as_deref(), &RealEnv, host_os, is_wsl);
+            let mcp_injection = generate_mcp_injection(
+                &RealMcpRuntime,
+                &mode,
+                &terminal_id,
+                mcp_cwd.as_deref(),
+                target,
+            )
+            .map_err(|error| RespawnError::LaunchUnresolvable(error.message))?;
+            let overrides = build_terminal_base_env(&RealEnv, &terminal_id, None, None);
+            (mcp_cwd, mcp_injection, overrides)
+        }
     };
 
     // Freshell opencode TUI rebind plugin — same IO-layer precompute as
@@ -4401,10 +4528,6 @@ pub async fn respawn_agent_terminal(
             "mode '{mode}' resolved no CLI launch"
         )));
     };
-
-    // `buildTerminalBaseEnv` — FRESHELL_TAB_ID/FRESHELL_PANE_ID deliberately
-    // omitted (see the fn doc comment: not derivable server-side).
-    let overrides = build_terminal_base_env(&RealEnv, &terminal_id, None, None);
 
     // Branch selection mirrors `handle_create`/`buildSpawnSpec`.
     let effective_shell = resolve_shell(shell, host_os, is_wsl);

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -2048,6 +2048,7 @@ async fn plan_codex_managed_launch(
         model: plan_model.as_deref(),
         sandbox: plan_sandbox.as_deref(),
         approval_policy: plan_approval.as_deref(),
+        sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext::default(),
     };
     let manager = freshell_codex::launch_lifecycle::CodexTerminalLaunchManager::global();
     let result = match cancel {

--- a/crates/freshell-ws/tests/codex_managed_launch_e2e.rs
+++ b/crates/freshell-ws/tests/codex_managed_launch_e2e.rs
@@ -24,10 +24,12 @@
 //!
 //! Loopback ephemeral ports only — never 3001/3002.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
 use serde_json::json;
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
@@ -36,6 +38,53 @@ use freshell_ws::WsState;
 
 const AUTH_TOKEN: &str = "e2e-codex-managed-launch-token";
 const RECV_TIMEOUT: Duration = Duration::from_secs(20);
+const SYNTHETIC_FRESHELL_TOKEN: &str = "synthetic-managed-codex-context-token";
+const FRESHELL_CONTEXT_ENV_KEYS: [&str; 6] = [
+    "FRESHELL",
+    "FRESHELL_URL",
+    "FRESHELL_TOKEN",
+    "FRESHELL_TERMINAL_ID",
+    "FRESHELL_TAB_ID",
+    "FRESHELL_PANE_ID",
+];
+
+/// The dispatcher and fake app-server intentionally capture only this
+/// allowlisted process surface. Context values are synthetic test data and
+/// assertions below never print either captured environment map.
+#[derive(Deserialize)]
+struct CapturedCodexProcess {
+    argv: Vec<String>,
+    env: BTreeMap<String, String>,
+}
+
+/// Restore the process-global test seam without ever formatting its values.
+/// The fixture owns only synthetic context, but this keeps an ambient server
+/// environment intact even when an assertion aborts the test early.
+struct TestEnvRestore {
+    values: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl TestEnvRestore {
+    fn capture(keys: &[&'static str]) -> Self {
+        Self {
+            values: keys
+                .iter()
+                .map(|key| (*key, std::env::var_os(key)))
+                .collect(),
+        }
+    }
+}
+
+impl Drop for TestEnvRestore {
+    fn drop(&mut self) {
+        for (key, value) in self.values.drain(..) {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
 
 fn test_settings_value() -> serde_json::Value {
     serde_json::json!({
@@ -79,8 +128,9 @@ fn codex_cli_spec() -> freshell_platform::CliCommandSpec {
 /// Write the node dispatcher that plays BOTH codex roles:
 /// - argv contains `app-server` → run the committed fake app-server fixture
 ///   (`test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs`) — the sidecar.
-/// - otherwise (the TUI launch) → dump argv JSON to `$CODEX_ARGV_CAPTURE_PATH` and stay
-///   alive so the pane keeps running until the test kills it.
+/// - otherwise (the TUI launch) → dump complete argv plus only the six allowed
+///   Freshell environment fields to `$CODEX_ARGV_CAPTURE_PATH`, then stay alive
+///   so the pane keeps running until the test kills it.
 fn write_codex_dispatcher() -> std::path::PathBuf {
     let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../test/fixtures/coding-cli/codex-app-server/fake-app-server.mjs")
@@ -97,7 +147,17 @@ fn write_codex_dispatcher() -> std::path::PathBuf {
          if (args.includes('app-server')) {{\n\
            await import('file://{fixture}')\n\
          }} else {{\n\
-           fs.writeFileSync(process.env.CODEX_ARGV_CAPTURE_PATH, JSON.stringify(args))\n\
+           fs.writeFileSync(process.env.CODEX_ARGV_CAPTURE_PATH, JSON.stringify({{\n\
+             argv: args,\n\
+             env: {{\n\
+               FRESHELL: process.env.FRESHELL,\n\
+               FRESHELL_URL: process.env.FRESHELL_URL,\n\
+               FRESHELL_TOKEN: process.env.FRESHELL_TOKEN,\n\
+               FRESHELL_TERMINAL_ID: process.env.FRESHELL_TERMINAL_ID,\n\
+               FRESHELL_TAB_ID: process.env.FRESHELL_TAB_ID,\n\
+               FRESHELL_PANE_ID: process.env.FRESHELL_PANE_ID,\n\
+             }},\n\
+           }}))\n\
            setInterval(() => undefined, 1000)\n\
          }}\n",
         fixture = fixture.display()
@@ -113,7 +173,11 @@ fn write_codex_dispatcher() -> std::path::PathBuf {
     dispatcher
 }
 
-async fn spawn_server() -> (String, freshell_terminal::TerminalRegistry) {
+async fn spawn_server() -> (
+    String,
+    freshell_terminal::TerminalRegistry,
+    freshell_ws::WsState,
+) {
     let auth_token = Arc::new(AUTH_TOKEN.to_string());
     let broadcast_tx = Arc::new(tokio::sync::broadcast::channel::<String>(64).0);
     let settings =
@@ -174,7 +238,7 @@ async fn spawn_server() -> (String, freshell_terminal::TerminalRegistry) {
         fresh_agent_respawn_counts: Default::default(),
     };
 
-    let router = freshell_ws::router(state);
+    let router = freshell_ws::router(state.clone());
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind ephemeral loopback port");
@@ -183,7 +247,7 @@ async fn spawn_server() -> (String, freshell_terminal::TerminalRegistry) {
         let _ = axum::serve(listener, router).await;
     });
 
-    (format!("ws://{addr}/ws"), registry)
+    (format!("ws://{addr}/ws"), registry, state)
 }
 
 type TestWs =
@@ -217,19 +281,29 @@ async fn connect_and_handshake(url: &str) -> TestWs {
 
 /// Create a codex terminal and return the `terminal.created` frame (or the `error`
 /// frame, panicking with it for diagnosis).
-async fn create_codex_terminal(ws: &mut TestWs, request_id: &str, cwd: &str) -> serde_json::Value {
-    ws.send(WsMessage::Text(
-        json!({
-            "type": "terminal.create",
-            "requestId": request_id,
-            "mode": "codex",
-            "shell": "system",
-            "cwd": cwd,
-        })
-        .to_string(),
-    ))
-    .await
-    .expect("send terminal.create");
+async fn create_codex_terminal(
+    ws: &mut TestWs,
+    request_id: &str,
+    cwd: &str,
+    tab_id: Option<&str>,
+    pane_id: Option<&str>,
+) -> serde_json::Value {
+    let mut create = json!({
+        "type": "terminal.create",
+        "requestId": request_id,
+        "mode": "codex",
+        "shell": "system",
+        "cwd": cwd,
+    });
+    if let Some(tab_id) = tab_id {
+        create["tabId"] = json!(tab_id);
+    }
+    if let Some(pane_id) = pane_id {
+        create["paneId"] = json!(pane_id);
+    }
+    ws.send(WsMessage::Text(create.to_string()))
+        .await
+        .expect("send terminal.create");
     loop {
         let msg = tokio::time::timeout(RECV_TIMEOUT, ws.next())
             .await
@@ -266,6 +340,7 @@ async fn create_codex_terminal_resume(
             "mode": "codex",
             "shell": "system",
             "cwd": cwd,
+            "restore": true,
             "sessionRef": { "provider": "codex", "sessionId": resume_session_id },
         })
         .to_string(),
@@ -291,13 +366,13 @@ async fn create_codex_terminal_resume(
     }
 }
 
-/// Poll the capture file the dispatcher writes until it appears, then parse the argv.
-fn wait_for_captured_argv(path: &std::path::Path) -> Vec<String> {
+/// Poll a dispatcher or fake-app-server capture until it appears.
+fn wait_for_captured_process(path: &std::path::Path) -> CapturedCodexProcess {
     let deadline = std::time::Instant::now() + RECV_TIMEOUT;
     loop {
         if let Ok(raw) = std::fs::read_to_string(path) {
             if !raw.is_empty() {
-                return serde_json::from_str(&raw).expect("captured argv is a JSON array");
+                return serde_json::from_str(&raw).expect("captured process is JSON");
             }
         }
         assert!(
@@ -309,24 +384,172 @@ fn wait_for_captured_argv(path: &std::path::Path) -> Vec<String> {
     }
 }
 
+fn wait_for_captured_argv(path: &std::path::Path) -> Vec<String> {
+    wait_for_captured_process(path).argv
+}
+
 fn resume_pair_position(argv: &[String], session_id: &str) -> Option<usize> {
     argv.windows(2)
         .position(|w| w[0] == "resume" && w[1] == session_id)
 }
 
+/// Extract each complete Codex `-c` pair that configures the Freshell MCP
+/// server. Keeping the flag with its value protects ordering checks below.
+fn freshell_mcp_pairs(argv: &[String]) -> Vec<(String, String)> {
+    argv.windows(2)
+        .filter(|pair| pair[0] == "-c" && pair[1].starts_with("mcp_servers.freshell."))
+        .map(|pair| (pair[0].clone(), pair[1].clone()))
+        .collect()
+}
+
+fn managed_env_vars_config() -> String {
+    let names = freshell_platform::mcp_inject::FRESHELL_MCP_CONTEXT_ENV_VARS
+        .iter()
+        .map(|name| format!("{name:?}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("mcp_servers.freshell.env_vars=[{names}]")
+}
+
+fn mcp_recipe_pairs(pairs: &[(String, String)]) -> Vec<(String, String)> {
+    pairs
+        .iter()
+        .filter(|(_, value)| {
+            value.starts_with("mcp_servers.freshell.command=")
+                || value.starts_with("mcp_servers.freshell.args=")
+        })
+        .cloned()
+        .collect()
+}
+
+fn assert_spawned_pair_parity(
+    tui: &CapturedCodexProcess,
+    sidecar: &CapturedCodexProcess,
+    expected_terminal_id: &str,
+    expected_tab_id: Option<&str>,
+    expected_pane_id: Option<&str>,
+) {
+    let tui_pairs = freshell_mcp_pairs(&tui.argv);
+    let sidecar_pairs = freshell_mcp_pairs(&sidecar.argv);
+    let expected_env_vars = managed_env_vars_config();
+
+    for pairs in [&tui_pairs, &sidecar_pairs] {
+        assert!(
+            pairs
+                .iter()
+                .any(|(flag, value)| flag == "-c" && value == &expected_env_vars),
+            "managed Freshell MCP config must include the exact static env_vars pair"
+        );
+    }
+
+    let tui_recipe = mcp_recipe_pairs(&tui_pairs);
+    let sidecar_recipe = mcp_recipe_pairs(&sidecar_pairs);
+    assert!(
+        !tui_recipe.is_empty() && tui_recipe == sidecar_recipe,
+        "the TUI and newly spawned app-server must receive the same Freshell MCP command recipe"
+    );
+
+    let app_server_index = sidecar
+        .argv
+        .iter()
+        .position(|arg| arg == "app-server")
+        .expect("sidecar argv includes app-server");
+    assert!(
+        sidecar
+            .argv
+            .windows(2)
+            .enumerate()
+            .filter(|(_, pair)| pair[0] == "-c")
+            .all(|(index, _)| index < app_server_index),
+        "all sidecar configuration pairs must precede app-server"
+    );
+
+    let expected_keys = FRESHELL_CONTEXT_ENV_KEYS
+        .iter()
+        .copied()
+        .filter(|key| match *key {
+            "FRESHELL_TAB_ID" => expected_tab_id.is_some(),
+            "FRESHELL_PANE_ID" => expected_pane_id.is_some(),
+            _ => true,
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        tui.env == sidecar.env
+            && tui.env.len() == expected_keys.len()
+            && expected_keys.iter().all(|key| tui.env.contains_key(*key)),
+        "the TUI and newly spawned app-server must have equal allowlisted Freshell environments"
+    );
+    for capture in [tui, sidecar] {
+        assert!(
+            capture
+                .env
+                .get("FRESHELL_TERMINAL_ID")
+                .is_some_and(|id| id == expected_terminal_id),
+            "the spawned pair must receive the created terminal id"
+        );
+        match expected_tab_id {
+            Some(tab_id) => assert!(
+                capture
+                    .env
+                    .get("FRESHELL_TAB_ID")
+                    .is_some_and(|id| id == tab_id),
+                "the spawned pair must receive the requested tab id"
+            ),
+            None => assert!(
+                !capture.env.contains_key("FRESHELL_TAB_ID"),
+                "headless replacement launches intentionally omit tab id"
+            ),
+        }
+        match expected_pane_id {
+            Some(pane_id) => assert!(
+                capture
+                    .env
+                    .get("FRESHELL_PANE_ID")
+                    .is_some_and(|id| id == pane_id),
+                "the spawned pair must receive the requested pane id"
+            ),
+            None => assert!(
+                !capture.env.contains_key("FRESHELL_PANE_ID"),
+                "headless replacement launches intentionally omit pane id"
+            ),
+        }
+    }
+
+    for argv in [&tui.argv, &sidecar.argv] {
+        assert!(
+            !argv
+                .iter()
+                .any(|arg| arg.contains(SYNTHETIC_FRESHELL_TOKEN)),
+            "synthetic Freshell token must never be serialized into argv"
+        );
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "host-gated e2e (needs node + repo node_modules); mutates process env — run alone with --ignored --test-threads=1"]
 async fn codex_terminal_create_argv_default_managed_and_flag_zero_optout() {
+    let _environment = TestEnvRestore::capture(&[
+        "AUTH_TOKEN",
+        "CODEX_ARGV_CAPTURE_PATH",
+        "CODEX_CMD",
+        "FAKE_CODEX_APP_SERVER_ARG_LOG",
+        "FRESHELL_CODEX_MANAGED_LAUNCH",
+        "FRESHELL_URL",
+        "PORT",
+    ]);
     let dispatcher = write_codex_dispatcher();
     let tmp_cwd = std::env::temp_dir().join(format!("freshell-codex-e2e-{}", std::process::id()));
     std::fs::create_dir_all(&tmp_cwd).unwrap();
     std::env::set_var("CODEX_CMD", &dispatcher);
+    std::env::set_var("PORT", "23123");
+    std::env::set_var("FRESHELL_URL", "http://127.0.0.1:23123");
+    std::env::set_var("AUTH_TOKEN", SYNTHETIC_FRESHELL_TOKEN);
     // DEV-0006 S5.e: the managed-launch default is ON, so "unset" IS the managed
     // leg. (Phase 1 is the default; Phase 2 opts out with "0"; Phase 3 resumes
     // under the default.)
     std::env::remove_var("FRESHELL_CODEX_MANAGED_LAUNCH");
 
-    let (ws_url, registry) = spawn_server().await;
+    let (ws_url, registry, state) = spawn_server().await;
     let mut ws = connect_and_handshake(&ws_url).await;
 
     // ── Phase 1: default (unset) must plan the managed launch (--remote 4-tuple
@@ -336,11 +559,34 @@ async fn codex_terminal_create_argv_default_managed_and_flag_zero_optout() {
         std::process::id()
     ));
     let _ = std::fs::remove_file(&default_capture);
+    let default_sidecar_capture = std::env::temp_dir().join(format!(
+        "freshell-codex-e2e-sidecar-default-{}.json",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&default_sidecar_capture);
     std::env::set_var("CODEX_ARGV_CAPTURE_PATH", &default_capture);
+    std::env::set_var("FAKE_CODEX_APP_SERVER_ARG_LOG", &default_sidecar_capture);
 
-    let created = create_codex_terminal(&mut ws, "req-default", tmp_cwd.to_str().unwrap()).await;
+    let created = create_codex_terminal(
+        &mut ws,
+        "req-default",
+        tmp_cwd.to_str().unwrap(),
+        Some("tab-e2e-fresh"),
+        Some("pane-e2e-fresh"),
+    )
+    .await;
     let default_terminal_id = created["terminalId"].as_str().unwrap().to_string();
-    let default_argv = wait_for_captured_argv(&default_capture);
+    let default_tui = wait_for_captured_process(&default_capture);
+    let default_sidecar = wait_for_captured_process(&default_sidecar_capture);
+    let default_argv = &default_tui.argv;
+
+    assert_spawned_pair_parity(
+        &default_tui,
+        &default_sidecar,
+        &default_terminal_id,
+        Some("tab-e2e-fresh"),
+        Some("pane-e2e-fresh"),
+    );
 
     // The first four tokens (terminal-registry.ts:295-307; DEV-0006 live capture).
     assert_eq!(default_argv[0], "--remote", "argv: {default_argv:?}");
@@ -399,7 +645,8 @@ async fn codex_terminal_create_argv_default_managed_and_flag_zero_optout() {
     std::env::set_var("CODEX_ARGV_CAPTURE_PATH", &off_capture);
     std::env::set_var("FRESHELL_CODEX_MANAGED_LAUNCH", "0");
 
-    let created = create_codex_terminal(&mut ws, "req-off", tmp_cwd.to_str().unwrap()).await;
+    let created =
+        create_codex_terminal(&mut ws, "req-off", tmp_cwd.to_str().unwrap(), None, None).await;
     let off_terminal_id = created["terminalId"].as_str().unwrap().to_string();
     let off_argv = wait_for_captured_argv(&off_capture);
 
@@ -412,6 +659,12 @@ async fn codex_terminal_create_argv_default_managed_and_flag_zero_optout() {
         &["-c".to_string(), "tui.notification_method=bel".to_string()],
         "explicit \"0\" argv must keep the plain-CLI shape (retired G-X0): {off_argv:?}"
     );
+    assert!(
+        !freshell_mcp_pairs(&off_argv)
+            .iter()
+            .any(|(_, value)| value == &managed_env_vars_config()),
+        "explicit opt-out must not add the managed-sidecar-only env_vars configuration"
+    );
     registry.kill(&off_terminal_id);
 
     // ── Phase 3: managed resume — default (unset) + resumeSessionId; the resume
@@ -422,7 +675,13 @@ async fn codex_terminal_create_argv_default_managed_and_flag_zero_optout() {
         std::process::id()
     ));
     let _ = std::fs::remove_file(&resume_capture);
+    let resume_sidecar_capture = std::env::temp_dir().join(format!(
+        "freshell-codex-e2e-sidecar-resume-{}.json",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&resume_sidecar_capture);
     std::env::set_var("CODEX_ARGV_CAPTURE_PATH", &resume_capture);
+    std::env::set_var("FAKE_CODEX_APP_SERVER_ARG_LOG", &resume_sidecar_capture);
 
     let created = create_codex_terminal_resume(
         &mut ws,
@@ -432,7 +691,16 @@ async fn codex_terminal_create_argv_default_managed_and_flag_zero_optout() {
     )
     .await;
     let resume_terminal_id = created["terminalId"].as_str().unwrap().to_string();
-    let resume_argv = wait_for_captured_argv(&resume_capture);
+    let resume_tui = wait_for_captured_process(&resume_capture);
+    let resume_sidecar = wait_for_captured_process(&resume_sidecar_capture);
+    let resume_argv = &resume_tui.argv;
+    assert_spawned_pair_parity(
+        &resume_tui,
+        &resume_sidecar,
+        &resume_terminal_id,
+        None,
+        None,
+    );
     assert_eq!(
         resume_argv[0], "--remote",
         "managed resume argv: {resume_argv:?}"
@@ -451,8 +719,52 @@ async fn codex_terminal_create_argv_default_managed_and_flag_zero_optout() {
     );
     registry.kill(&resume_terminal_id);
 
+    // ── Phase 4: headless auto-resume gets a newly spawned managed pair, but
+    // ── intentionally has no layout ids ─────────────────────────────────────────
+    let auto_resume_capture = std::env::temp_dir().join(format!(
+        "freshell-codex-e2e-argv-auto-resume-{}.json",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&auto_resume_capture);
+    let auto_resume_sidecar_capture = std::env::temp_dir().join(format!(
+        "freshell-codex-e2e-sidecar-auto-resume-{}.json",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&auto_resume_sidecar_capture);
+    std::env::set_var("CODEX_ARGV_CAPTURE_PATH", &auto_resume_capture);
+    std::env::set_var(
+        "FAKE_CODEX_APP_SERVER_ARG_LOG",
+        &auto_resume_sidecar_capture,
+    );
+
+    let auto_resume_terminal_id = freshell_ws::terminal::respawn_agent_terminal(
+        &state,
+        &freshell_ws::terminal::AgentRespawnRequest {
+            mode: "codex".into(),
+            provider: "codex".into(),
+            session_id: "thread-e2e-auto-resume".into(),
+            create_request_id: "req-auto-resume".into(),
+            cwd: Some(tmp_cwd.to_string_lossy().into_owned()),
+        },
+    )
+    .await
+    .expect("managed Codex auto-resume spawn");
+    let auto_resume_tui = wait_for_captured_process(&auto_resume_capture);
+    let auto_resume_sidecar = wait_for_captured_process(&auto_resume_sidecar_capture);
+    let auto_resume_argv = &auto_resume_tui.argv;
+    assert_spawned_pair_parity(
+        &auto_resume_tui,
+        &auto_resume_sidecar,
+        &auto_resume_terminal_id,
+        None,
+        None,
+    );
+    assert!(
+        resume_pair_position(auto_resume_argv, "thread-e2e-auto-resume").is_some(),
+        "auto-resume argv must retain the Codex resume pair: {auto_resume_argv:?}"
+    );
+    registry.kill(&auto_resume_terminal_id);
+
     // ── Cleanup ───────────────────────────────────────────────────────────────────
-    std::env::remove_var("FRESHELL_CODEX_MANAGED_LAUNCH");
-    std::env::remove_var("CODEX_ARGV_CAPTURE_PATH");
-    std::env::remove_var("CODEX_CMD");
+    // `_environment` restores all process-global test seams on scope exit.
 }

--- a/crates/freshell-ws/tests/codex_sidecar_reattach_e2e.rs
+++ b/crates/freshell-ws/tests/codex_sidecar_reattach_e2e.rs
@@ -39,30 +39,133 @@
 //! exists off-Linux) and the tracked-spawn detach arm is Linux-gated.
 #![cfg(target_os = "linux")]
 
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
 use serde_json::json;
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 use freshell_codex::launch_lifecycle::{
-    set_global_codex_launch_manager_for_tests, CodexTerminalLaunchManager,
+    set_global_codex_launch_manager_for_tests, CodexLaunchRuntime, CodexRuntimeReady,
+    CodexTerminalLaunchManager, SpawnedCodexAppServerRuntime,
 };
 use freshell_codex::{
-    proc_cmdline, proc_starttime, select_codex_runtime, CodexSidecarRecord, CodexSidecarStore,
-    SidecarReconciler, SidecarRecordState, CODEX_SIDECAR_OWNERSHIP_ENV, SIDECAR_RECORD_VERSION,
+    proc_cmdline, proc_starttime, select_codex_runtime, BoxFuture, CodexSidecarRecord,
+    CodexSidecarStore, SidecarReconciler, SidecarRecordState, CODEX_SIDECAR_OWNERSHIP_ENV,
+    SIDECAR_RECORD_VERSION,
 };
 use freshell_ws::WsState;
 
 const AUTH_TOKEN: &str = "e2e-codex-sidecar-reattach-token";
 const RECV_TIMEOUT: Duration = Duration::from_secs(20);
+const SYNTHETIC_FRESHELL_TOKEN: &str = "synthetic-prepared-restore-token";
+const FRESHELL_CONTEXT_ENV_KEYS: [&str; 6] = [
+    "FRESHELL",
+    "FRESHELL_URL",
+    "FRESHELL_TOKEN",
+    "FRESHELL_TERMINAL_ID",
+    "FRESHELL_TAB_ID",
+    "FRESHELL_PANE_ID",
+];
 
 // ─── the set-once global manager over a swappable test reconciler/store ──────
 
 static TEST_RECONCILER: Mutex<Option<Arc<SidecarReconciler>>> = Mutex::new(None);
 static TEST_STORE: Mutex<Option<Arc<CodexSidecarStore>>> = Mutex::new(None);
+static TEST_FAIL_ADOPTION: AtomicBool = AtomicBool::new(false);
+
+/// A real spawned runtime whose ownership update deliberately fails. This keeps
+/// the test on the production process/proxy path while making the failure occur
+/// strictly after the PTY was spawned, which is the prepared-launch boundary.
+struct FailingAdoptionRuntime {
+    inner: SpawnedCodexAppServerRuntime,
+}
+
+impl FailingAdoptionRuntime {
+    fn new(sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext) -> Self {
+        Self {
+            inner: SpawnedCodexAppServerRuntime::with_context(sidecar_context),
+        }
+    }
+}
+
+impl CodexLaunchRuntime for FailingAdoptionRuntime {
+    fn ensure_ready(
+        &self,
+        cwd: Option<String>,
+    ) -> BoxFuture<'_, Result<CodexRuntimeReady, String>> {
+        self.inner.ensure_ready(cwd)
+    }
+
+    fn update_ownership_metadata(
+        &self,
+        _terminal_id: String,
+        _generation: u64,
+    ) -> BoxFuture<'_, Result<(), String>> {
+        // Give the PTY child a bounded opportunity to exec and write its
+        // allowlisted capture. The failure still happens only after the PTY
+        // exists, which is the lifecycle boundary under test.
+        Box::pin(async {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            Err("injected adoption failure".to_string())
+        })
+    }
+
+    fn shutdown(&self) -> BoxFuture<'_, Result<(), String>> {
+        self.inner.shutdown()
+    }
+}
+
+/// Restores the test-only factory mode even if an assertion fails, so the
+/// ordinary survivor scenarios never inherit an injected failure.
+struct AdoptionFailureMode;
+
+impl AdoptionFailureMode {
+    fn enable() -> Self {
+        TEST_FAIL_ADOPTION.store(true, Ordering::SeqCst);
+        Self
+    }
+}
+
+impl Drop for AdoptionFailureMode {
+    fn drop(&mut self) {
+        TEST_FAIL_ADOPTION.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Snapshot test-owned environment entries without ever formatting their
+/// values. The prepared-restore fixture uses only synthetic values, but the
+/// restoration is still panic-safe so no ambient context leaks across tests.
+struct TestEnvRestore {
+    values: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl TestEnvRestore {
+    fn capture(keys: &[&'static str]) -> Self {
+        Self {
+            values: keys
+                .iter()
+                .map(|key| (*key, std::env::var_os(key)))
+                .collect(),
+        }
+    }
+}
+
+impl Drop for TestEnvRestore {
+    fn drop(&mut self) {
+        for (key, value) in self.values.drain(..) {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
 
 /// Install the ONE process-wide launch manager (set-once): its factory
 /// re-reads the statics per plan and dispatches through the REAL production
@@ -77,8 +180,14 @@ fn install_global_manager() {
             // MutexGuards must never cross an await point.
             let reconciler = TEST_RECONCILER.lock().unwrap().clone();
             let store = TEST_STORE.lock().unwrap().clone();
+            let sidecar_context = plan.sidecar_context.clone();
             Box::pin(async move {
-                select_codex_runtime(reconciler.as_ref(), store.as_ref(), plan).await
+                if TEST_FAIL_ADOPTION.load(Ordering::SeqCst) {
+                    Arc::new(FailingAdoptionRuntime::new(sidecar_context))
+                        as Arc<dyn CodexLaunchRuntime>
+                } else {
+                    select_codex_runtime(reconciler.as_ref(), store.as_ref(), plan).await
+                }
             })
         }));
         assert!(
@@ -226,8 +335,9 @@ fn fixture_path() -> std::path::PathBuf {
 /// attribution from `codex_managed_launch_e2e.rs::write_codex_dispatcher`):
 /// - argv contains `app-server` → run the committed fake app-server fixture
 ///   (the manager-spawned sidecar; reads `FAKE_CODEX_APP_SERVER_BEHAVIOR`).
-/// - otherwise (the TUI launch) → dump argv JSON to
-///   `$CODEX_ARGV_CAPTURE_PATH` and stay alive until the test kills the pane.
+/// - otherwise (the TUI launch) → dump complete argv plus only the six
+///   allowlisted Freshell context fields to `$CODEX_ARGV_CAPTURE_PATH` and
+///   stay alive until the test kills the pane.
 fn codex_dispatcher() -> &'static std::path::PathBuf {
     static DISPATCHER: OnceLock<std::path::PathBuf> = OnceLock::new();
     DISPATCHER.get_or_init(|| {
@@ -243,7 +353,17 @@ fn codex_dispatcher() -> &'static std::path::PathBuf {
              if (args.includes('app-server')) {{\n\
                await import('file://{fixture}')\n\
              }} else {{\n\
-               fs.writeFileSync(process.env.CODEX_ARGV_CAPTURE_PATH, JSON.stringify(args))\n\
+               fs.writeFileSync(process.env.CODEX_ARGV_CAPTURE_PATH, JSON.stringify({{\n\
+                 argv: args,\n\
+                 env: {{\n\
+                   FRESHELL: process.env.FRESHELL,\n\
+                   FRESHELL_URL: process.env.FRESHELL_URL,\n\
+                   FRESHELL_TOKEN: process.env.FRESHELL_TOKEN,\n\
+                   FRESHELL_TERMINAL_ID: process.env.FRESHELL_TERMINAL_ID,\n\
+                   FRESHELL_TAB_ID: process.env.FRESHELL_TAB_ID,\n\
+                   FRESHELL_PANE_ID: process.env.FRESHELL_PANE_ID,\n\
+                 }},\n\
+               }}))\n\
                setInterval(() => undefined, 1000)\n\
              }}\n",
             fixture = fixture.display()
@@ -255,6 +375,15 @@ fn codex_dispatcher() -> &'static std::path::PathBuf {
         std::fs::set_permissions(&dispatcher, perms).unwrap();
         dispatcher
     })
+}
+
+/// The dispatcher and fake app-server deliberately capture no ambient
+/// environment outside this allowlist. Assertion messages below never print
+/// the captured values.
+#[derive(Deserialize)]
+struct CapturedCodexProcess {
+    argv: Vec<String>,
+    env: BTreeMap<String, String>,
 }
 
 async fn spawn_server() -> (String, freshell_terminal::TerminalRegistry) {
@@ -406,14 +535,56 @@ async fn create_codex_restore_terminal(
     }
 }
 
-/// Poll the capture file the dispatcher writes until it appears, then parse
-/// the argv (JSON array — the dispatcher shape).
-fn wait_for_captured_argv(path: &std::path::Path) -> Vec<String> {
+/// Same frozen restore create, but this one captures the expected post-PTY
+/// adoption error rather than panicking. It exercises the ownership-failure
+/// cleanup boundary of a preplanned restore launch.
+async fn create_codex_restore_terminal_expect_error(
+    ws: &mut TestWs,
+    request_id: &str,
+    cwd: &str,
+    session_id: &str,
+) -> serde_json::Value {
+    ws.send(WsMessage::Text(
+        json!({
+            "type": "terminal.create",
+            "requestId": request_id,
+            "mode": "codex",
+            "shell": "system",
+            "cwd": cwd,
+            "restore": true,
+            "sessionRef": { "provider": "codex", "sessionId": session_id },
+        })
+        .to_string(),
+    ))
+    .await
+    .expect("send terminal.create");
+    loop {
+        let msg = tokio::time::timeout(RECV_TIMEOUT, ws.next())
+            .await
+            .expect("terminal.create error within timeout")
+            .expect("stream open")
+            .expect("no ws error");
+        if let WsMessage::Text(text) = msg {
+            let value: serde_json::Value = serde_json::from_str(&text).expect("json frame");
+            match value["type"].as_str() {
+                Some("error") if value["requestId"] == json!(request_id) => return value,
+                Some("terminal.created") if value["requestId"] == json!(request_id) => {
+                    panic!("post-PTY adoption failure unexpectedly created a terminal")
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Poll the capture file the dispatcher or fake app-server writes until it
+/// appears, then parse its allowlisted process capture.
+fn wait_for_captured_process(path: &std::path::Path) -> CapturedCodexProcess {
     let deadline = std::time::Instant::now() + RECV_TIMEOUT;
     loop {
         if let Ok(raw) = std::fs::read_to_string(path) {
             if !raw.is_empty() {
-                return serde_json::from_str(&raw).expect("captured argv is a JSON array");
+                return serde_json::from_str(&raw).expect("captured process is JSON");
             }
         }
         assert!(
@@ -425,9 +596,66 @@ fn wait_for_captured_argv(path: &std::path::Path) -> Vec<String> {
     }
 }
 
+fn wait_for_captured_argv(path: &std::path::Path) -> Vec<String> {
+    wait_for_captured_process(path).argv
+}
+
 fn resume_pair_position(argv: &[String], session_id: &str) -> Option<usize> {
     argv.windows(2)
         .position(|w| w[0] == "resume" && w[1] == session_id)
+}
+
+fn freshell_mcp_pairs(argv: &[String]) -> Vec<(String, String)> {
+    argv.windows(2)
+        .filter(|pair| pair[0] == "-c" && pair[1].starts_with("mcp_servers.freshell."))
+        .map(|pair| (pair[0].clone(), pair[1].clone()))
+        .collect()
+}
+
+fn managed_env_vars_config() -> String {
+    let names = freshell_platform::mcp_inject::FRESHELL_MCP_CONTEXT_ENV_VARS
+        .iter()
+        .map(|name| format!("{name:?}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("mcp_servers.freshell.env_vars=[{names}]")
+}
+
+fn assert_prepared_pair_uses_one_reserved_context(
+    tui: &CapturedCodexProcess,
+    sidecar: &CapturedCodexProcess,
+) -> String {
+    let expected_env_vars = managed_env_vars_config();
+    for process in [tui, sidecar] {
+        assert!(
+            freshell_mcp_pairs(&process.argv)
+                .iter()
+                .any(|(flag, value)| flag == "-c" && value == &expected_env_vars),
+            "prepared managed pair must retain the exact static Freshell env_vars declaration"
+        );
+        assert!(
+            !process
+                .argv
+                .iter()
+                .any(|arg| arg.contains(SYNTHETIC_FRESHELL_TOKEN)),
+            "synthetic Freshell token must never be serialized into argv"
+        );
+    }
+    assert!(
+        tui.env == sidecar.env
+            // Prepared recovery launches are headless: tab/pane are
+            // intentionally absent, leaving the four non-layout fields.
+            && tui.env.len() == FRESHELL_CONTEXT_ENV_KEYS.len() - 2
+            && FRESHELL_CONTEXT_ENV_KEYS
+                .iter()
+                .take(4)
+                .all(|key| tui.env.contains_key(*key)),
+        "prepared TUI and newly spawned sidecar must receive one equal allowlisted context"
+    );
+    tui.env
+        .get("FRESHELL_TERMINAL_ID")
+        .cloned()
+        .expect("prepared terminal context includes terminal id")
 }
 
 // ─── the survivor: this test's OWN fake app-server child ─────────────────────
@@ -665,6 +893,102 @@ fn capture_path(name: &str) -> std::path::PathBuf {
     path
 }
 
+async fn poll_terminal_stopped(
+    registry: &freshell_terminal::TerminalRegistry,
+    terminal_id: &str,
+    budget: Duration,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        if !registry.is_pty_running(terminal_id) {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+// ─── prepared restore: reuse setup, then clean it up on failed adoption ──────
+
+#[test]
+fn prepared_codex_launch_reuses_reserved_setup_and_discards_after_adopt_failure() {
+    reattach_rt().block_on(async {
+        let _serial = test_lock().lock().await;
+        install_global_manager();
+        ensure_mcp_deps_resolvable();
+        let _environment = TestEnvRestore::capture(&[
+            "AUTH_TOKEN",
+            "CODEX_ARGV_CAPTURE_PATH",
+            "CODEX_CMD",
+            "FAKE_CODEX_APP_SERVER_BEHAVIOR",
+            "FAKE_CODEX_APP_SERVER_ARG_LOG",
+            "FRESHELL_CODEX_MANAGED_LAUNCH",
+            "FRESHELL_URL",
+            "PORT",
+        ]);
+        let _injected_failure = AdoptionFailureMode::enable();
+        std::env::set_var("CODEX_CMD", codex_dispatcher());
+        std::env::set_var("FRESHELL_CODEX_MANAGED_LAUNCH", "1");
+        std::env::set_var("PORT", "23125");
+        std::env::set_var("FRESHELL_URL", "http://127.0.0.1:23125");
+        std::env::set_var("AUTH_TOKEN", SYNTHETIC_FRESHELL_TOKEN);
+        std::env::remove_var("FAKE_CODEX_APP_SERVER_BEHAVIOR");
+        swap_test_reconciler(None, None);
+
+        let tui_capture = capture_path("prepared-adoption-failure-tui");
+        let sidecar_capture = capture_path("prepared-adoption-failure-sidecar");
+        std::env::set_var("CODEX_ARGV_CAPTURE_PATH", &tui_capture);
+        std::env::set_var("FAKE_CODEX_APP_SERVER_ARG_LOG", &sidecar_capture);
+
+        let (ws_url, registry) = spawn_server().await;
+        let mut ws = connect_and_handshake(&ws_url).await;
+        let cwd = scenario_cwd("prepared-adoption-failure");
+        let error = create_codex_restore_terminal_expect_error(
+            &mut ws,
+            "req-prepared-adoption-failure",
+            cwd.to_str().expect("utf8 cwd"),
+            "thread-prepared-adoption-failure",
+        )
+        .await;
+        let tui = wait_for_captured_process(&tui_capture);
+        let sidecar = wait_for_captured_process(&sidecar_capture);
+        let reserved_terminal_id = assert_prepared_pair_uses_one_reserved_context(&tui, &sidecar);
+        let proxy_url = tui
+            .argv
+            .windows(2)
+            .find(|pair| pair[0] == "--remote")
+            .map(|pair| pair[1].clone())
+            .expect("managed TUI receives the proxy URL");
+
+        // The injected runtime rejects only `adopt`, after the PTY has been
+        // spawned. The WS door must kill that PTY and the manager must tear
+        // the prepared sidecar/proxy down instead of leaving either launch
+        // behind for a later create.
+        let pty_stopped =
+            poll_terminal_stopped(&registry, &reserved_terminal_id, Duration::from_secs(8)).await;
+        let proxy_torn_down = poll_proxy_refused(&proxy_url, Duration::from_secs(8)).await;
+        swap_test_reconciler(None, None);
+
+        assert_eq!(error["code"], json!("PTY_SPAWN_FAILED"));
+        assert!(
+            error["message"]
+                .as_str()
+                .is_some_and(|message| message == "injected adoption failure"),
+            "post-PTY adoption failure must surface the ownership error"
+        );
+        assert!(
+            pty_stopped,
+            "the reserved terminal's PTY must be discarded after adoption fails"
+        );
+        assert!(
+            proxy_torn_down,
+            "the unadopted prepared sidecar/proxy must be discarded after adoption fails"
+        );
+    });
+}
+
 // ─── scenario 1: reattach to the surviving sidecar ────────────────────────────
 
 #[test]
@@ -673,6 +997,7 @@ fn restore_reattaches_tui_to_surviving_sidecar_preserving_in_flight_turn() {
         let _serial = test_lock().lock().await;
         install_global_manager();
         ensure_mcp_deps_resolvable();
+        TEST_FAIL_ADOPTION.store(false, Ordering::SeqCst);
         std::env::set_var("CODEX_CMD", codex_dispatcher());
         // DEV-0006 S5.e: unset = managed launch ON (the leg under test).
         std::env::remove_var("FRESHELL_CODEX_MANAGED_LAUNCH");
@@ -735,7 +1060,9 @@ fn restore_reattaches_tui_to_surviving_sidecar_preserving_in_flight_turn() {
         let (ws_url, registry) = spawn_server().await;
         let mut ws = connect_and_handshake(&ws_url).await;
         let capture = capture_path("reattach");
+        let replacement_capture = capture_path("reattach-replacement-sidecar");
         std::env::set_var("CODEX_ARGV_CAPTURE_PATH", &capture);
+        std::env::set_var("FAKE_CODEX_APP_SERVER_ARG_LOG", &replacement_capture);
         let cwd = scenario_cwd("reattach");
         let created = create_codex_restore_terminal(
             &mut ws,
@@ -769,6 +1096,10 @@ fn restore_reattaches_tui_to_surviving_sidecar_preserving_in_flight_turn() {
         let record_terminal_id =
             poll_record_terminal_id(&store, ownership_id, Duration::from_secs(10));
         let unclaimed = reconciler.unclaimed_len();
+        let replacement_child_started = replacement_capture
+            .metadata()
+            .map(|metadata| metadata.len() > 0)
+            .unwrap_or(false);
 
         // Cleanup: kill ONLY pids this test spawned. The pane kill queues the
         // reattached sidecar's teardown, which reaps the survivor (this
@@ -782,6 +1113,7 @@ fn restore_reattaches_tui_to_surviving_sidecar_preserving_in_flight_turn() {
         let _ = poll_proxy_refused(&proxy_url, Duration::from_secs(8)).await;
         swap_test_reconciler(None, None);
         std::env::remove_var("CODEX_ARGV_CAPTURE_PATH");
+        std::env::remove_var("FAKE_CODEX_APP_SERVER_ARG_LOG");
 
         // (3c) Asserts.
         assert!(
@@ -803,6 +1135,10 @@ fn restore_reattaches_tui_to_surviving_sidecar_preserving_in_flight_turn() {
             survivor_alive_same_incarnation,
             "the surviving sidecar (pid {survivor_pid}) must still be alive, same incarnation"
         );
+        assert!(
+            !replacement_child_started,
+            "a verified survivor must be reattached unchanged; no replacement app-server child may start"
+        );
         assert_eq!(
             record_terminal_id.as_deref(),
             Some(terminal_id.as_str()),
@@ -810,6 +1146,16 @@ fn restore_reattaches_tui_to_surviving_sidecar_preserving_in_flight_turn() {
         );
         assert_eq!(unclaimed, 0, "the one-shot claim was consumed");
     });
+}
+
+/// The host-gated verification entry point required for this binary's
+/// process-global Codex fixture. It deliberately delegates to the normal
+/// survivor test instead of replacing it, so the default package suite keeps
+/// exercising the original boundary too.
+#[test]
+#[ignore = "host-gated e2e; mutates process-global Codex launch seams — run alone with --ignored --test-threads=1"]
+fn ignored_survivor_reattach_keeps_verified_pid_and_starts_no_replacement() {
+    restore_reattaches_tui_to_surviving_sidecar_preserving_in_flight_turn();
 }
 
 // ─── scenario 2: no tracked survivor → today's fresh-spawn path ───────────────
@@ -820,6 +1166,7 @@ fn restore_falls_back_to_fresh_sidecar_without_tracked_survivor() {
         let _serial = test_lock().lock().await;
         install_global_manager();
         ensure_mcp_deps_resolvable();
+        TEST_FAIL_ADOPTION.store(false, Ordering::SeqCst);
         std::env::set_var("CODEX_CMD", codex_dispatcher());
         std::env::remove_var("FRESHELL_CODEX_MANAGED_LAUNCH");
 
@@ -913,6 +1260,7 @@ fn active_writer_collision_surfaces_minus32600_only_on_the_fresh_path() {
         let _serial = test_lock().lock().await;
         install_global_manager();
         ensure_mcp_deps_resolvable();
+        TEST_FAIL_ADOPTION.store(false, Ordering::SeqCst);
         std::env::set_var("CODEX_CMD", codex_dispatcher());
         std::env::remove_var("FRESHELL_CODEX_MANAGED_LAUNCH");
 

--- a/docs/plans/2026-09-07-codex-mcp-sidecar-config.md
+++ b/docs/plans/2026-09-07-codex-mcp-sidecar-config.md
@@ -1,0 +1,355 @@
+# Managed Codex Sidecar MCP Context Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+## User Request
+
+### Requested result
+Fix managed Codex startup so the Codex TUI and its separate app-server receive the same Freshell MCP configuration and terminal context, eliminating the indefinite “Booting MCP server: node_repl” state while preserving the Freshell MCP’s working tool access.
+
+### Explicit constraints
+- Use the-usual repair-and-review workflow.
+- Work in a dedicated repository worktree; do not modify or restart the live self-hosted Freshell server without explicit APPROVED authorization.
+- Preserve the managed Codex launch architecture and verify the affected behavior with meaningful automated coverage.
+
+### Accepted tradeoffs and residuals
+- Starting the Freshell MCP alongside node_repl may add roughly half a second to the startup round; the servers start concurrently.
+
+**Goal:** A newly spawned managed Codex app-server and its TUI use one immutable Freshell MCP/terminal-context snapshot, so Codex sees every configured MCP server and can use Freshell tools immediately.
+
+**Architecture:** Represent the already-resolved Codex configuration as an owned sidecar launch context: additive Codex `-c` arguments plus a deterministic environment override map. Carry that context through the existing managed launch plan to the spawned sidecar while the WS terminal path reuses the same snapshot for the TUI. For restore-class preplanning, mint and retain the terminal identity with that snapshot so the eventual PTY never receives a different MCP definition or `FRESHELL_*` context.
+
+**Tech Stack:** Rust 2021 workspace; Tokio process spawning and WebSocket proxy; existing `freshell-platform` MCP injection and CLI spawn builders; deterministic Rust unit/integration fixtures.
+
+## Global Constraints
+
+- Work only in `/home/dan/code/freshell/.worktrees/codex-mcp-sidecar-config` on `the-usual/codex-mcp-sidecar-config`; do not modify the live server or restart it.
+- Keep the existing managed Codex topology: one app-server, one loopback proxy, and one TUI. Preserve sidecar ownership tags, isolated `CODEX_HOME`, startup retry/queue behavior, reattachment behavior, and the explicit `FRESHELL_CODEX_MANAGED_LAUNCH=0` plain-CLI opt-out.
+- Build the MCP command only once per terminal launch attempt. The same resolved Codex config args must appear before `app-server` in the sidecar command and in the TUI’s normal Codex config segment.
+- Pass terminal context only to the spawned child process; do not place it in global process environment, durable sidecar records, logs, error strings, or `Debug` output. Any diagnostic formatting for the new context may expose environment keys but never their values.
+- Use the native sidecar working directory derived for MCP/config work, so a default or WSL-normalized terminal does not give the app-server a different usable directory than the MCP command and terminal launch.
+- Preserve survivor reattachment: an already-running sidecar cannot be retroactively reconfigured, so this change affects newly spawned sidecars and retry/recovery spawns without forcing a survivor restart.
+- Run focused Rust checks through Cargo, run the ignored managed-launch integration test alone, format with `cargo fmt --all`, and use the repository-coordinated broad gate only at the stage that requires it.
+
+## File Responsibilities
+
+| File | Responsibility in this change |
+| --- | --- |
+| `crates/freshell-codex/src/launch_plan.rs` | Own the redacted, immutable sidecar launch context and turn it into deterministic app-server argv/env. |
+| `crates/freshell-codex/src/launch_lifecycle.rs` | Keep the context attached to a managed plan and apply it only when spawning a new app-server. |
+| `crates/freshell-codex/src/runtime_select.rs` | Give a newly selected spawned runtime the plan’s context while leaving a reattached survivor unchanged. |
+| `crates/freshell-freshagent/src/codex.rs` | Explicitly retain its existing empty sidecar context when using the shared spawn-spec helper. |
+| `crates/freshell-ws/src/terminal.rs` | Build one Codex launch snapshot and reuse it across interactive create, restore preplanning, and PTY recovery. |
+| `crates/freshell-ws/tests/codex_managed_launch_e2e.rs` | Observe both actual child processes and assert MCP/context parity through the real Rust proxy path. |
+
+---
+
+### Task 1: Make managed sidecar configuration an owned, redacted spawn input
+
+**Files:**
+
+- Modify: `crates/freshell-codex/src/launch_plan.rs:172-342`
+- Modify: `crates/freshell-codex/src/launch_lifecycle.rs:46-53, 376-404, 1008-1167`
+- Modify: `crates/freshell-codex/src/runtime_select.rs:12-40`
+- Modify: `crates/freshell-freshagent/src/codex.rs:3714-3745`
+- Test: `crates/freshell-codex/src/launch_plan.rs:673-704`
+- Test: `crates/freshell-codex/tests/launch_lifecycle.rs`
+
+**Interfaces:**
+
+- Consumes: the existing `McpInjection { args, env }` and terminal base environment produced by the WS layer.
+- Produces: `CodexSidecarLaunchContext { config_args, env }`, carried in `CodexLaunchPlanInput`/`CodexLaunchPlan` and consumed only by `SpawnedCodexAppServerRuntime`.
+- Preserves: `CodexLaunchRuntime::ensure_ready(cwd)`, runtime selection, reattached sidecar behavior, and the `CODEX_MANAGED_REMOTE_CONFIG_ARGS`/ownership-tag order.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Add a focused golden proving that a supplied launch context is added between the existing managed config pair and `app-server`, that context environment reaches the spawn spec, and that the ownership key wins over an accidental same-name value. Keep the test values synthetic.
+
+```rust
+#[test]
+fn sidecar_spawn_spec_includes_context_without_exposing_or_losing_ownership() {
+    let context = CodexSidecarLaunchContext {
+        config_args: vec![
+            "-c".to_string(),
+            "mcp_servers.freshell.command='node'".to_string(),
+            "-c".to_string(),
+            "mcp_servers.freshell.args=['--import','tsx','server/mcp/server.ts']".to_string(),
+        ],
+        env: BTreeMap::from([
+            ("FRESHELL_TERMINAL_ID".to_string(), "term-test".to_string()),
+            ("FRESHELL_TOKEN".to_string(), "test-token".to_string()),
+            (
+                CODEX_SIDECAR_OWNERSHIP_ENV.to_string(),
+                "must-not-win".to_string(),
+            ),
+        ]),
+    };
+
+    let spec = codex_sidecar_spawn_spec(
+        "ws://127.0.0.1:41234",
+        "codex-sidecar-abc",
+        &context,
+    );
+
+    assert_eq!(
+        spec.args,
+        vec![
+            "-c", "features.apps=false",
+            "-c", "mcp_servers.freshell.command='node'",
+            "-c", "mcp_servers.freshell.args=['--import','tsx','server/mcp/server.ts']",
+            "app-server", "--listen", "ws://127.0.0.1:41234",
+        ]
+    );
+    assert_eq!(
+        spec.env.into_iter().collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([
+            ("FRESHELL_TERMINAL_ID".to_string(), "term-test".to_string()),
+            ("FRESHELL_TOKEN".to_string(), "test-token".to_string()),
+            (
+                CODEX_SIDECAR_OWNERSHIP_ENV.to_string(),
+                "codex-sidecar-abc".to_string(),
+            ),
+        ])
+    );
+}
+```
+
+Also add a runtime-level fake-app-server assertion that a context supplied through a plan reaches the actual spawned process, while a default context remains empty for existing direct-runtime and fresh-agent callers.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run:
+
+```bash
+cargo test -p freshell-codex sidecar_spawn_spec_includes_context_without_exposing_or_losing_ownership
+```
+
+Expected: FAIL because `CodexSidecarLaunchContext` and the third spawn-spec parameter do not yet exist, and the current sidecar argv stops after `features.apps=false` before `app-server`.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+In `launch_plan.rs`, define an owned context beside `CodexSidecarSpawnSpec`. Its custom `Debug` implementation must retain config-argument visibility for test diagnostics but render only sorted environment keys, never values.
+
+```rust
+#[derive(Clone, PartialEq, Eq, Default)]
+pub struct CodexSidecarLaunchContext {
+    pub config_args: Vec<String>,
+    pub env: BTreeMap<String, String>,
+}
+
+impl std::fmt::Debug for CodexSidecarLaunchContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodexSidecarLaunchContext")
+            .field("config_args", &self.config_args)
+            .field("env_keys", &self.env.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+```
+
+Add `sidecar_context: CodexSidecarLaunchContext` to `CodexLaunchPlanInput` and `CodexLaunchPlan`; `plan_codex_launch` clones it without interpreting it. Preserve default construction so existing non-context callers receive an empty context, and update every explicit `CodexLaunchPlan` golden in this file to expect `CodexSidecarLaunchContext::default()` unless that test deliberately supplies a context. Change the pure spawn builder to append `context.config_args` before `app-server`, merge `context.env` into a `BTreeMap`, then insert `CODEX_SIDECAR_OWNERSHIP_ENV` last before producing the deterministic vector.
+
+```rust
+pub fn codex_sidecar_spawn_spec(
+    listen_ws_url: &str,
+    ownership_id: &str,
+    context: &CodexSidecarLaunchContext,
+) -> CodexSidecarSpawnSpec {
+    let mut args = CODEX_MANAGED_REMOTE_CONFIG_ARGS
+        .iter()
+        .map(|value| (*value).to_string())
+        .collect::<Vec<_>>();
+    args.extend(context.config_args.iter().cloned());
+    args.extend([
+        "app-server".to_string(),
+        "--listen".to_string(),
+        listen_ws_url.to_string(),
+    ]);
+
+    let mut env = context.env.clone();
+    env.insert(CODEX_SIDECAR_OWNERSHIP_ENV.to_string(), ownership_id.to_string());
+    CodexSidecarSpawnSpec { args, env: env.into_iter().collect() }
+}
+```
+
+Construct `SpawnedCodexAppServerRuntime` with the context copied from its plan and call the new spawn builder in `ensure_ready`. `runtime_select::select_codex_runtime` must pass the plan context only to `SpawnedCodexAppServerRuntime`; a `ReattachedCodexAppServerRuntime` stays untouched because it never starts a child. Keep existing public constructors as empty-context convenience constructors and add context-taking constructors for the selector/tests. Update the fresh-agent use of the shared builder to pass `&CodexSidecarLaunchContext::default()` so that its unrelated launch remains byte-for-byte equivalent.
+
+- [ ] **Step 4: Run the focused test**
+
+Run:
+
+```bash
+cargo test -p freshell-codex sidecar_spawn_spec_includes_context_without_exposing_or_losing_ownership
+```
+
+Expected: PASS, including exact argument ordering and ownership-tag precedence.
+
+- [ ] **Step 5: Refactor while green**
+
+Remove any duplicated ad-hoc argv/environment merge introduced while making the test pass. Keep context construction in the WS layer and process construction in `freshell-codex`; do not add a callback or global mutable configuration path.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The altered types and shared sidecar spawn helper affect the Codex planner/lifecycle and fresh Codex compilation paths. Run:
+
+```bash
+cargo test -p freshell-codex
+cargo test -p freshell-freshagent codex
+cargo check -p freshell-ws --all-targets
+cargo fmt --all -- --check
+```
+
+Expected: PASS. If the fresh-agent crate has no matching `codex` filter, Cargo may report zero selected tests only after `cargo check -p freshell-freshagent --all-targets` passes; do not treat a filter mismatch as coverage.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add -- crates/freshell-codex/src/launch_plan.rs crates/freshell-codex/src/launch_lifecycle.rs crates/freshell-codex/src/runtime_select.rs crates/freshell-codex/tests/launch_lifecycle.rs crates/freshell-freshagent/src/codex.rs
+git commit -m "fix: carry Codex sidecar launch context"
+```
+
+### Task 2: Reuse one context for create, restore preplanning, recovery, and the real dual-process launch
+
+**Files:**
+
+- Modify: `crates/freshell-ws/src/terminal.rs:2021-2073, 2488-2526, 2644-2709, 2946-3513, 4330-4406`
+- Modify: `crates/freshell-ws/tests/codex_managed_launch_e2e.rs:65-104, 302-420`
+- Test: `crates/freshell-ws/src/terminal.rs:7004-7038`
+- Test: `crates/freshell-ws/tests/codex_managed_launch_e2e.rs:302-420`
+
+**Interfaces:**
+
+- Consumes: resolved terminal id, effective native MCP cwd, `McpInjection`, tab/pane identity, and `build_terminal_base_env` output.
+- Produces: one `CodexManagedLaunchSetup` containing the TUI injection, terminal environment, native sidecar cwd, and `CodexSidecarLaunchContext` for the same launch attempt.
+- Preserves: pre-gate restore planning, prepared-launch cleanup, proxy adoption, resume ordering, recovery spawning, non-Codex modes, and managed-launch opt-out.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Extend the ignored dual-role integration fixture so its dispatcher writes both TUI argv and only these environment fields to `CODEX_ARGV_CAPTURE_PATH`; retain the fake app-server’s existing `FAKE_CODEX_APP_SERVER_ARG_LOG` observation. Add helpers that extract only the Freshell MCP `-c` values and the six `FRESHELL_*` fields. For the managed fresh and managed-resume legs, assert equality of those normalized values and matching terminal id; continue asserting the live `initialize` relay.
+
+```rust
+#[derive(Debug, Deserialize)]
+struct CapturedCodexProcess {
+    argv: Vec<String>,
+    env: BTreeMap<String, Option<String>>,
+}
+
+fn freshell_mcp_config(argv: &[String]) -> Vec<String> {
+    argv.windows(2)
+        .filter_map(|pair| {
+            (pair[0] == "-c" && pair[1].starts_with("mcp_servers.freshell."))
+                .then(|| pair[1].clone())
+        })
+        .collect()
+}
+
+fn assert_freshell_launch_parity(
+    tui: &CapturedCodexProcess,
+    sidecar: &CapturedCodexProcess,
+    terminal_id: &str,
+) {
+    assert_eq!(freshell_mcp_config(&tui.argv), freshell_mcp_config(&sidecar.argv));
+    assert_eq!(tui.env, sidecar.env);
+    assert_eq!(tui.env["FRESHELL_TERMINAL_ID"].as_deref(), Some(terminal_id));
+    assert!(sidecar.argv.iter().position(|arg| arg == "app-server").is_some());
+}
+```
+
+Use non-secret fixture values. The test must include `tabId` and `paneId` on the fresh create so it proves those optional terminal-context fields are also identical. The app-server log must be read before `registry.kill`, and each phase must use its own capture file.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run:
+
+```bash
+cargo test -p freshell-ws --test codex_managed_launch_e2e -- --ignored --test-threads=1
+```
+
+Expected: FAIL on the managed fresh leg because the app-server observation has no Freshell MCP config arguments or `FRESHELL_TERMINAL_ID`, while the TUI observation does. The plain opt-out leg must remain unmodified.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+Add a private setup value in `terminal.rs`, with no `Debug` implementation that could reveal the configured token.
+
+```rust
+#[derive(Clone)]
+struct CodexManagedLaunchSetup {
+    terminal_id: String,
+    runtime_cwd: Option<String>,
+    mcp_injection: McpInjection,
+    terminal_env: BTreeMap<String, String>,
+    sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext,
+}
+```
+
+Create it in one helper after `resolve_mcp_cwd` and before managed sidecar planning. The helper must generate the Codex `McpInjection` once, build the terminal base environment once, merge `mcp_injection.env` then `terminal_env` into the sidecar environment, and pass the resolved native MCP cwd as `runtime_cwd`. Its central construction is:
+
+```rust
+let mcp_injection = generate_mcp_injection(
+    &RealMcpRuntime,
+    "codex",
+    terminal_id,
+    mcp_cwd.as_deref(),
+    target,
+)?;
+let terminal_env = build_terminal_base_env(&RealEnv, terminal_id, tab_id, pane_id);
+let mut sidecar_env = mcp_injection.env.clone();
+sidecar_env.extend(terminal_env.clone());
+let setup = CodexManagedLaunchSetup {
+    terminal_id: terminal_id.to_string(),
+    runtime_cwd: mcp_cwd,
+    sidecar_context: CodexSidecarLaunchContext {
+        config_args: mcp_injection.args.clone(),
+        env: sidecar_env,
+    },
+    mcp_injection,
+    terminal_env,
+};
+```
+
+Change `plan_codex_managed_launch` to accept the resolved sidecar cwd and context, place a clone in `CodexLaunchPlanInput`, and leave its early return untouched when managed launch is disabled or mode is not Codex. In the ordinary create path, construct this setup before calling that helper, pass its context to the sidecar plan, then use the same `mcp_injection` for `CliLaunchInputs` and the same `terminal_env` for the PTY spawn spec.
+
+For the restore pre-gate branch, mint the terminal id before planning only when a Codex resume sidecar will be materialized, construct the same setup from the final resolved cwd and requested tab/pane identifiers, and store both setup and launch in `PreparedCodexLaunch`. `handle_create` must reuse the stored terminal id/setup rather than minting or generating a second one; its existing `Drop` implementation must still discard an unadopted sidecar on every early return. Do not change the fresh restore exclusion, queue class, cancellation behavior, or resume validation order.
+
+In the auto-resume/recovery path, build the setup from the existing terminal id and its intentional `None` tab/pane identifiers before planning. Reuse its injection/environment for the replacement TUI and pass its sidecar context to the replacement app-server plan. Non-Codex paths retain their existing MCP construction and cleanup path unchanged.
+
+- [ ] **Step 4: Run the focused test**
+
+Run:
+
+```bash
+cargo test -p freshell-ws --test codex_managed_launch_e2e -- --ignored --test-threads=1
+```
+
+Expected: PASS. The fresh and resume managed legs show equal Freshell MCP config and terminal-context maps for the actual TUI and actual sidecar, the proxy relays `initialize`, and the explicit opt-out still has no `--remote`.
+
+- [ ] **Step 5: Refactor while green**
+
+Collapse any duplicated Codex setup construction into the one helper, keep `McpInjection` generation at the IO layer, and remove any one-off environment merging. Confirm an unprepared interactive create and a prepared restore both consume the same setup type without modifying shell, Claude, OpenCode, or survivor-reattach code.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The change crosses terminal creation, managed sidecar planning, lifecycle selection, recovery, and the dual-process integration harness. Run:
+
+```bash
+cargo test -p freshell-codex
+cargo test -p freshell-ws
+cargo test -p freshell-ws --test codex_managed_launch_e2e -- --ignored --test-threads=1
+cargo check --workspace --all-targets
+cargo fmt --all -- --check
+```
+
+Expected: PASS. The ignored e2e is run separately because it mutates process-global environment and uses the singleton launch manager.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add -- crates/freshell-ws/src/terminal.rs crates/freshell-ws/tests/codex_managed_launch_e2e.rs
+git commit -m "fix: share Codex MCP context with app server"
+```
+
+## Final Verification
+
+After both tasks and their task-level reviews, run the workflow’s final coordinated broad gate from the clean worktree branch. Preserve the baseline ledger distinction: the base had no reproducible failures after its clean retry. Record the exact command, result, and evidence in the external run state before independent complete-delta review.

--- a/docs/plans/2026-09-07-codex-mcp-sidecar-config.md
+++ b/docs/plans/2026-09-07-codex-mcp-sidecar-config.md
@@ -1,4 +1,4 @@
-# Managed Codex Sidecar MCP Context Implementation Plan
+# Managed Codex Sidecar MCP Parity Implementation Plan
 
 > **For agentic workers:** Execute this plan task by task with a fresh
 > implementer and a specification-plus-quality review after every task. Track
@@ -17,339 +17,356 @@ Fix managed Codex startup so the Codex TUI and its separate app-server receive t
 ### Accepted tradeoffs and residuals
 - Starting the Freshell MCP alongside node_repl may add roughly half a second to the startup round; the servers start concurrently.
 
-**Goal:** A newly spawned managed Codex app-server and its TUI use one immutable Freshell MCP/terminal-context snapshot, so Codex sees every configured MCP server and can use Freshell tools immediately.
+**Goal:** Every newly spawned managed Codex TUI/app-server pair receives one semantically identical Freshell MCP definition and one matching parent-process Freshell context, so the app-server can start and use the Freshell MCP instead of leaving the TUI waiting on the incomplete startup round.
 
-**Architecture:** Represent the already-resolved Codex configuration as an owned sidecar launch context: additive Codex `-c` arguments plus a deterministic environment override map. Carry that context through the existing managed launch plan to the spawned sidecar while the WS terminal path reuses the same snapshot for the TUI. For restore-class preplanning, mint and retain the terminal identity with that snapshot so the eventual PTY never receives a different MCP definition or `FRESHELL_*` context.
+**Architecture:** Resolve the Freshell MCP command recipe once, render it separately for the TUI execution target and the host-native app-server execution target, and add a value-free Codex `env_vars` declaration that forwards the six existing `FRESHELL_*` names from each parent process. Carry the host-side rendering and parent environment through the managed launch plan only to a newly spawned app-server; a verified survivor remains deliberately unmodified. Reserve the terminal identity before restore preplanning, retain it with the prepared launch, and make failed adoption tear down the still-owned sidecar transactionally.
 
-**Tech Stack:** Rust 2021 workspace; Tokio process spawning and WebSocket proxy; existing `freshell-platform` MCP injection and CLI spawn builders; deterministic Rust unit/integration fixtures.
+**Tech Stack:** Rust 2021 workspace; Tokio process spawning and WebSocket proxy; `freshell-platform` MCP injection/target helpers; existing Rust fake-sidecar integration tests; existing opt-in real Codex provider-contract harness for final acceptance.
 
 ## Global Constraints
 
-- Work only in `/home/dan/code/freshell/.worktrees/codex-mcp-sidecar-config` on `the-usual/codex-mcp-sidecar-config`; do not modify the live server or restart it.
-- Keep the existing managed Codex topology: one app-server, one loopback proxy, and one TUI. Preserve sidecar ownership tags, isolated `CODEX_HOME`, startup retry/queue behavior, reattachment behavior, and the explicit `FRESHELL_CODEX_MANAGED_LAUNCH=0` plain-CLI opt-out.
-- Build the MCP command only once per terminal launch attempt. The same resolved Codex config args must appear before `app-server` in the sidecar command and in the TUI’s normal Codex config segment.
-- Pass terminal context only to the spawned child process; do not place it in global process environment, durable sidecar records, logs, error strings, or `Debug` output. Any diagnostic formatting for the new context may expose environment keys but never their values.
-- Use the native sidecar working directory derived for MCP/config work, so a default or WSL-normalized terminal does not give the app-server a different usable directory than the MCP command and terminal launch.
-- Preserve survivor reattachment: an already-running sidecar cannot be retroactively reconfigured, so this change affects newly spawned sidecars and retry/recovery spawns without forcing a survivor restart.
-- Run focused Rust checks through Cargo, run the ignored managed-launch integration test alone, format with `cargo fmt --all`, and use the repository-coordinated broad gate only at the stage that requires it.
+- Work only in `/home/dan/code/freshell/.worktrees/codex-mcp-sidecar-config` on `the-usual/codex-mcp-sidecar-config`; do not restart or otherwise mutate the live port-3001 Freshell server.
+- Keep the managed topology intact: one app-server, one loopback proxy, and one TUI. Preserve the explicit `FRESHELL_CODEX_MANAGED_LAUNCH=0` plain-CLI opt-out, planning queue, retry budget, durable sidecar identity checks, and existing fresh-agent lane.
+- Codex 0.153.4 clears the stdio MCP child's inherited environment. The only safe transport for Freshell values is actual parent-process environment plus the fixed value-free `mcp_servers.freshell.env_vars` list below. Never serialize a token, endpoint, terminal id, tab id, or pane id into inline TOML, argv, a durable sidecar record, logs, errors, or Debug output.
+
+  ```text
+  FRESHELL
+  FRESHELL_URL
+  FRESHELL_TOKEN
+  FRESHELL_TERMINAL_ID
+  FRESHELL_TAB_ID
+  FRESHELL_PANE_ID
+  ```
+
+- A TUI may run in a different Windows/WSL namespace from the host-native sidecar. Equality is therefore semantic (one tagged recipe, the same literals and `env_vars` names), not byte-for-byte equality of rendered argv. The sidecar always receives host-native `resolve_mcp_cwd(...)`, never the raw requested create cwd.
+- A sidecar that is already running before a new restore cannot be reconfigured. Preserve its current verified-survivor reattach behavior; do not claim that it received the replacement TUI's context, do not kill it, and do not make its record's new ownership metadata a parity signal. The correction applies to every newly spawned/retry sidecar. This avoids interrupting active Codex work.
+- Do not alter the generic non-managed `generate_mcp_injection` behavior merely to serve this managed topology. Use a managed-Codex rendering helper. Do not alter the fresh-agent sidecar other than explicitly passing the default empty context through the shared spawn-spec API.
+- The existing raw sidecar command-line record may continue to persist static command/path and `env_vars` *names*. Do not perform a schema migration: actual Freshell values remain in process environment only, so a durable-record redesign is outside this request.
+- Treat the fake-sidecar integration test as process-construction/proxy coverage, not proof of Codex's literal terminal display. A separate isolated real-provider acceptance run is the only evidence allowed to make that display claim.
 
 ## File Responsibilities
 
 | File | Responsibility in this change |
 | --- | --- |
-| `crates/freshell-codex/src/launch_plan.rs` | Own the redacted, immutable sidecar launch context and turn it into deterministic app-server argv/env. |
-| `crates/freshell-codex/src/launch_lifecycle.rs` | Keep the context attached to a managed plan and apply it only when spawning a new app-server. |
-| `crates/freshell-codex/src/runtime_select.rs` | Give a newly selected spawned runtime the plan’s context while leaving a reattached survivor unchanged. |
-| `crates/freshell-freshagent/src/codex.rs` | Explicitly retain its existing empty sidecar context when using the shared spawn-spec helper. |
-| `crates/freshell-ws/src/terminal.rs` | Build one Codex launch snapshot and reuse it across interactive create, restore preplanning, and PTY recovery. |
-| `crates/freshell-ws/tests/codex_managed_launch_e2e.rs` | Observe both actual child processes and assert MCP/context parity through the real Rust proxy path. |
+| `crates/freshell-platform/src/mcp_inject.rs` | Resolve the tagged MCP recipe once and render safe target-specific managed-Codex injections with the fixed `env_vars` declaration. |
+| `crates/freshell-platform/src/mcp_inject_tests.rs` | Pin recipe-once behavior, no-value TOML, and Unix/WSL/Windows rendering matrix. |
+| `crates/freshell-codex/src/launch_plan.rs` | Own redacted sidecar context and deterministic app-server argv/environment composition. |
+| `crates/freshell-codex/src/launch_lifecycle.rs` | Apply context only to spawned runtimes and retain/discard launch ownership correctly after adoption failure. |
+| `crates/freshell-codex/src/runtime_select.rs` | Give a spawned runtime the context while preserving a reattached runtime unchanged. |
+| `crates/freshell-codex/tests/launch_lifecycle.rs` | Cover context spawn shape, redaction, and failed-adoption cleanup. |
+| `crates/freshell-ws/src/terminal.rs` | Build one private managed setup for each spawned WS terminal; reserve/reuse its id through restore preplanning and auto-resume. |
+| `crates/freshell-freshagent/src/terminal_tabs.rs` | Apply the same managed setup at the REST/MCP terminal-tab creation door. |
+| `crates/freshell-freshagent/src/codex.rs` | Keep the unrelated fresh-agent sidecar explicitly empty-context. |
+| `crates/freshell-ws/tests/codex_managed_launch_e2e.rs` | Observe both spawned roles and prove semantic config/context parity plus proxy initialization. |
+| `crates/freshell-ws/tests/codex_sidecar_reattach_e2e.rs` | Preserve and label the survivor-reattach boundary without treating it as a parity case. |
 
 ---
 
-### Task 1: Make managed sidecar configuration an owned, redacted spawn input
+### Task 1: Render one managed Codex MCP recipe safely for both execution targets
 
 **Files:**
 
-- Modify: `crates/freshell-codex/src/launch_plan.rs:172-342`
-- Modify: `crates/freshell-codex/src/launch_lifecycle.rs:46-53, 376-404, 1008-1167`
-- Modify: `crates/freshell-codex/src/runtime_select.rs:12-40`
+- Modify: `crates/freshell-platform/src/mcp_inject.rs:53-245,535-561`
+- Modify: `crates/freshell-platform/src/mcp_inject_tests.rs:34-194`
+
+**Interfaces:**
+
+- Consumes: one `Vec<McpServerArg>` returned by `McpRuntime::server_command_args`, the selected TUI `ProviderTarget`, host `HostOs`, WSL regime, and `Env` for native-Windows-to-WSL conversion.
+- Produces:
+
+  ```rust
+  pub const FRESHELL_MCP_CONTEXT_ENV_VARS: [&str; 6];
+
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct ManagedCodexMcpRenderings {
+      pub tui: McpInjection,
+      pub sidecar: McpInjection,
+  }
+
+  pub fn build_managed_codex_mcp_renderings(
+      runtime: &dyn McpRuntime,
+      env: &dyn Env,
+      host_os: HostOs,
+      is_wsl_env: bool,
+      tui_target: ProviderTarget,
+  ) -> Result<ManagedCodexMcpRenderings, McpInjectError>;
+  ```
+
+- Preserves: `generate_mcp_injection`'s existing five-mode behavior and its existing `g_x4`/`g_w1` compatibility goldens. The new helper is used only by a managed Codex launch.
+
+- [ ] **Step 1: Write the failing behavioral tests**
+
+  Extend `FakeRt` with a shared `Arc<AtomicUsize>` call counter. Add these focused tests in `mcp_inject_tests.rs`:
+
+  1. `managed_codex_renderings_resolve_one_recipe_and_forward_only_names`: use `MapEnv` with synthetic `FRESHELL_TOKEN=token-not-in-argv`; assert `server_command_args()` was called once; both renderings contain exactly one command pair, args pair, then `mcp_servers.freshell.env_vars=["FRESHELL", ...]`; neither rendering has `mcp_servers.freshell.env=`, `token-not-in-argv`, a terminal id, or a URL.
+  2. `managed_codex_renderings_use_unc_for_wsl_windows_tui_and_posix_for_sidecar`: use Linux/WSL host inputs and a Windows TUI target; assert the TUI path values are UNC-rendered and the sidecar values remain POSIX.
+  3. `managed_codex_renderings_use_wsl_paths_for_native_windows_unix_tui`: use native-Windows host inputs, Windows recipe paths, and a Unix TUI target; assert the TUI has `/mnt/<drive>/...` paths and the sidecar has Windows paths. A conversion failure must return `McpInjectError`, never pass a Windows path to the Unix TUI unchanged.
+
+  Each test must compare complete `-c` pairs, not substring-only prose. Keep the existing generic `g_w1_native_windows_host_unix_target_keeps_windows_paths` test unchanged to prove the new managed helper, not a global behavior rewrite, owns the correction.
+
+- [ ] **Step 2: Run the focused tests and verify the intended failure**
+
+  Run:
+
+  ```bash
+  cargo test -p freshell-platform managed_codex_renderings
+  ```
+
+  Expected: FAIL because there is no managed rendering helper, the generic Codex injection resolves the recipe per call, has no `env_vars` pair, and cannot produce separate target renderings.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+  In `mcp_inject.rs`:
+
+  1. Define `FRESHELL_MCP_CONTEXT_ENV_VARS` in fixed uppercase order.
+  2. Split the current `build_mcp_server_command_args` operation into a recipe-resolution boundary and a pure renderer. The managed helper calls `server_command_args()` once, retains the returned `McpServerArg` tags, and renders that one recipe twice.
+  3. Preserve the current WSL-to-Windows conversion for a Windows target on WSL. Add only the managed native-Windows-to-Unix branch using the existing `convert_windows_path_to_wsl_path`; map a nonconvertible tagged `Path` to a loud `McpInjectError` rather than emitting a wrong-namespace path.
+  4. Derive the sidecar target from the actual host: `ProviderTarget::Windows` only for native Windows, otherwise `ProviderTarget::Unix`. It must not inherit the TUI wrapper target.
+  5. Add a managed-only inline TOML builder that appends one deterministic `env_vars` `-c` pair after the existing command/args pairs. It serializes only the six names with `toml_escape`; it must never accept environment values as input.
+
+  The resulting vectors have this exact field order:
+
+  ```text
+  -c mcp_servers.freshell.command="node"
+  -c mcp_servers.freshell.args=[...target-rendered recipe...]
+  -c mcp_servers.freshell.env_vars=["FRESHELL", "FRESHELL_URL", "FRESHELL_TOKEN", "FRESHELL_TERMINAL_ID", "FRESHELL_TAB_ID", "FRESHELL_PANE_ID"]
+  ```
+
+- [ ] **Step 4: Run the focused tests**
+
+  Run:
+
+  ```bash
+  cargo test -p freshell-platform managed_codex_renderings
+  ```
+
+  Expected: PASS. The counter proves a single semantic recipe; target-specific path spellings and static `env_vars` order are exact; no synthetic value reaches TOML.
+
+- [ ] **Step 5: Refactor while green**
+
+  Keep one renderer over tagged `McpServerArg` values. Do not parse rendered TOML back into paths, duplicate the server-command discovery, or change the generic `generate_mcp_injection` Codex branch. Retain the existing public `build_mcp_server_command_args` as a thin one-rendering wrapper if existing callers require it.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+  Run:
+
+  ```bash
+  cargo test -p freshell-platform
+  cargo fmt --all -- --check
+  ```
+
+  Expected: PASS. This shared platform module owns every provider-injection golden, so its complete crate suite is the impacted set.
+
+- [ ] **Step 7: Commit the task**
+
+  ```bash
+  git add -- crates/freshell-platform/src/mcp_inject.rs crates/freshell-platform/src/mcp_inject_tests.rs
+  git commit -m "fix: render managed Codex MCP context per target"
+  ```
+
+### Task 2: Carry value-free sidecar configuration and clean up failed adoption transactionally
+
+**Files:**
+
+- Modify: `crates/freshell-codex/src/launch_plan.rs:162-343`
+- Modify: `crates/freshell-codex/src/launch_lifecycle.rs:796-850,1125-1305`
+- Modify: `crates/freshell-codex/src/runtime_select.rs:17-40`
 - Modify: `crates/freshell-freshagent/src/codex.rs:3714-3745`
-- Test: `crates/freshell-codex/src/launch_plan.rs:673-704`
-- Test: `crates/freshell-codex/tests/launch_lifecycle.rs`
+- Modify: `crates/freshell-codex/tests/launch_lifecycle.rs`
 
 **Interfaces:**
 
-- Consumes: the existing `McpInjection { args, env }` and terminal base environment produced by the WS layer.
-- Produces: `CodexSidecarLaunchContext { config_args, env }`, carried in `CodexLaunchPlanInput`/`CodexLaunchPlan` and consumed only by `SpawnedCodexAppServerRuntime`.
-- Preserves: `CodexLaunchRuntime::ensure_ready(cwd)`, runtime selection, reattached sidecar behavior, and the `CODEX_MANAGED_REMOTE_CONFIG_ARGS`/ownership-tag order.
+- Consumes: target-specific sidecar config args and the canonical `BTreeMap<String, String>` terminal environment supplied by a terminal-pane door.
+- Produces:
 
-- [ ] **Step 1: Write the failing behavioral test**
+  ```rust
+  #[derive(Clone, PartialEq, Eq, Default)]
+  pub struct CodexSidecarLaunchContext {
+      pub config_args: Vec<String>,
+      pub env: BTreeMap<String, String>,
+  }
+  ```
 
-Add a focused golden proving that a supplied launch context is added between the existing managed config pair and `app-server`, that context environment reaches the spawn spec, and that the ownership key wins over an accidental same-name value. Keep the test values synthetic.
+  `CodexLaunchPlanInput` owns a `sidecar_context`, `CodexLaunchPlan` retains its clone, and `SpawnedCodexAppServerRuntime::with_context(context)` is the only runtime constructor that consumes it.
 
-```rust
-#[test]
-fn sidecar_spawn_spec_includes_context_without_exposing_or_losing_ownership() {
-    let context = CodexSidecarLaunchContext {
-        config_args: vec![
-            "-c".to_string(),
-            "mcp_servers.freshell.command='node'".to_string(),
-            "-c".to_string(),
-            "mcp_servers.freshell.args=['--import','tsx','server/mcp/server.ts']".to_string(),
-        ],
-        env: BTreeMap::from([
-            ("FRESHELL_TERMINAL_ID".to_string(), "term-test".to_string()),
-            ("FRESHELL_TOKEN".to_string(), "test-token".to_string()),
-            (
-                CODEX_SIDECAR_OWNERSHIP_ENV.to_string(),
-                "must-not-win".to_string(),
-            ),
-        ]),
-    };
+- Preserves: `CodexLaunchRuntime::ensure_ready(cwd)`, all reattached runtime behavior, existing `CODEX_MANAGED_REMOTE_CONFIG_ARGS` ordering, durable record schema, and empty-context direct/fresh-agent callers.
 
-    let spec = codex_sidecar_spawn_spec(
-        "ws://127.0.0.1:41234",
-        "codex-sidecar-abc",
-        &context,
-    );
+- [ ] **Step 1: Write the failing behavioral tests**
 
-    assert_eq!(
-        spec.args,
-        vec![
-            "-c", "features.apps=false",
-            "-c", "mcp_servers.freshell.command='node'",
-            "-c", "mcp_servers.freshell.args=['--import','tsx','server/mcp/server.ts']",
-            "app-server", "--listen", "ws://127.0.0.1:41234",
-        ]
-    );
-    assert_eq!(
-        spec.env.into_iter().collect::<BTreeMap<_, _>>(),
-        BTreeMap::from([
-            ("FRESHELL_TERMINAL_ID".to_string(), "term-test".to_string()),
-            ("FRESHELL_TOKEN".to_string(), "test-token".to_string()),
-            (
-                CODEX_SIDECAR_OWNERSHIP_ENV.to_string(),
-                "codex-sidecar-abc".to_string(),
-            ),
-        ])
-    );
-}
-```
+  Add tests beside the existing planner/lifecycle fakes:
 
-Also add a runtime-level fake-app-server assertion that a context supplied through a plan reaches the actual spawned process, while a default context remains empty for existing direct-runtime and fresh-agent callers.
+  1. `sidecar_spawn_spec_places_context_before_app_server_and_redacts_values`: use a context containing static MCP pairs and synthetic `FRESHELL_TOKEN=not-visible`; assert `spec.args` is `-c features.apps=false`, context config pairs, `app-server --listen`; assert `spec.env` contains the token only as an environment value; assert ownership wins over a duplicate ownership key; assert `format!("{spec:?}")` and `format!("{context:?}")` contain environment key names but not `not-visible`.
+  2. `spawned_runtime_receives_context_but_reattached_runtime_does_not`: use the runtime-selection seam to assert a no-survivor plan constructs a spawned runtime whose fake child sees the supplied env/config; retain the existing survivor selector expectation and assert it does not start a second child.
+  3. `failed_adoption_discards_the_still_owned_launch`: make the fake runtime fail `update_ownership_metadata`, call `CodexTerminalLaunchManager::adopt`, and assert the original error is returned, proxy/child shutdown is attempted, and the planned sidecar is no longer retained in the planner active map.
 
-- [ ] **Step 2: Run the test and verify the intended failure**
+- [ ] **Step 2: Run the focused tests and verify the intended failure**
 
-Run:
+  Run:
 
-```bash
-cargo test -p freshell-codex sidecar_spawn_spec_includes_context_without_exposing_or_losing_ownership
-```
+  ```bash
+  cargo test -p freshell-codex sidecar_spawn_spec_places_context_before_app_server_and_redacts_values
+  cargo test -p freshell-codex failed_adoption_discards_the_still_owned_launch
+  ```
 
-Expected: FAIL because `CodexSidecarLaunchContext` and the third spawn-spec parameter do not yet exist, and the current sidecar argv stops after `features.apps=false` before `app-server`.
+  Expected: FAIL because the spawn spec has no context parameter and `adopt` returns early on the fallible sidecar adoption, leaving the moved launch without immediate cleanup.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-In `launch_plan.rs`, define an owned context beside `CodexSidecarSpawnSpec`. Its custom `Debug` implementation must retain config-argument visibility for test diagnostics but render only sorted environment keys, never values.
+  1. Add `CodexSidecarLaunchContext` next to `CodexSidecarSpawnSpec`. Implement custom `Debug` for both structures: show config args and sorted environment keys only, never values.
+  2. Add an owned default context to `CodexLaunchPlanInput` and clone it into `CodexLaunchPlan`. Update every full-plan golden to expect `CodexSidecarLaunchContext::default()` unless it deliberately supplies a context.
+  3. Change `codex_sidecar_spawn_spec(listen_ws_url, ownership_id, context)` to append `context.config_args` before `app-server`, merge `context.env` into a `BTreeMap`, then insert `FRESHELL_CODEX_SIDECAR_ID` last and return deterministic entries. Do not add literal `mcp_servers.freshell.env` values to config args.
+  4. Give `SpawnedCodexAppServerRuntime` a context field, keep `new()` as an empty-context convenience constructor, add `with_context`, and use the context in `ensure_ready`. `select_codex_runtime` passes `plan.sidecar_context.clone()` only when it creates a spawned runtime. The reattached branch remains byte-for-byte behaviorally unchanged.
+  5. In `CodexTerminalLaunchManager::adopt`, retain ownership of `launch` across `launch.sidecar.adopt(...)`. On error, call the existing best-effort discard/shutdown while still owning the launch, log a separate cleanup failure if one occurs, and return the original adoption error. Only build the event drain and insert into `adopted` after successful adoption.
+  6. Update `freshell-freshagent/src/codex.rs` to pass `&CodexSidecarLaunchContext::default()` to the shared spawn builder. It must not inherit terminal-pane MCP arguments or environment.
 
-```rust
-#[derive(Clone, PartialEq, Eq, Default)]
-pub struct CodexSidecarLaunchContext {
-    pub config_args: Vec<String>,
-    pub env: BTreeMap<String, String>,
-}
+- [ ] **Step 4: Run the focused tests**
 
-impl std::fmt::Debug for CodexSidecarLaunchContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CodexSidecarLaunchContext")
-            .field("config_args", &self.config_args)
-            .field("env_keys", &self.env.keys().collect::<Vec<_>>())
-            .finish()
-    }
-}
-```
+  Run:
 
-Add `sidecar_context: CodexSidecarLaunchContext` to `CodexLaunchPlanInput` and `CodexLaunchPlan`; `plan_codex_launch` clones it without interpreting it. Preserve default construction so existing non-context callers receive an empty context, and update every explicit `CodexLaunchPlan` golden in this file to expect `CodexSidecarLaunchContext::default()` unless that test deliberately supplies a context. Change the pure spawn builder to append `context.config_args` before `app-server`, merge `context.env` into a `BTreeMap`, then insert `CODEX_SIDECAR_OWNERSHIP_ENV` last before producing the deterministic vector.
+  ```bash
+  cargo test -p freshell-codex sidecar_spawn_spec_places_context_before_app_server_and_redacts_values
+  cargo test -p freshell-codex failed_adoption_discards_the_still_owned_launch
+  ```
 
-```rust
-pub fn codex_sidecar_spawn_spec(
-    listen_ws_url: &str,
-    ownership_id: &str,
-    context: &CodexSidecarLaunchContext,
-) -> CodexSidecarSpawnSpec {
-    let mut args = CODEX_MANAGED_REMOTE_CONFIG_ARGS
-        .iter()
-        .map(|value| (*value).to_string())
-        .collect::<Vec<_>>();
-    args.extend(context.config_args.iter().cloned());
-    args.extend([
-        "app-server".to_string(),
-        "--listen".to_string(),
-        listen_ws_url.to_string(),
-    ]);
-
-    let mut env = context.env.clone();
-    env.insert(CODEX_SIDECAR_OWNERSHIP_ENV.to_string(), ownership_id.to_string());
-    CodexSidecarSpawnSpec { args, env: env.into_iter().collect() }
-}
-```
-
-Construct `SpawnedCodexAppServerRuntime` with the context copied from its plan and call the new spawn builder in `ensure_ready`. `runtime_select::select_codex_runtime` must pass the plan context only to `SpawnedCodexAppServerRuntime`; a `ReattachedCodexAppServerRuntime` stays untouched because it never starts a child. Keep existing public constructors as empty-context convenience constructors and add context-taking constructors for the selector/tests. Update the fresh-agent use of the shared builder to pass `&CodexSidecarLaunchContext::default()` so that its unrelated launch remains byte-for-byte equivalent.
-
-- [ ] **Step 4: Run the focused test**
-
-Run:
-
-```bash
-cargo test -p freshell-codex sidecar_spawn_spec_includes_context_without_exposing_or_losing_ownership
-```
-
-Expected: PASS, including exact argument ordering and ownership-tag precedence.
+  Expected: PASS. A spawned fake sees the supplied environment, no debug path reveals a value, and failed adoption has an immediate cleanup owner.
 
 - [ ] **Step 5: Refactor while green**
 
-Remove any duplicated ad-hoc argv/environment merge introduced while making the test pass. Keep context construction in the WS layer and process construction in `freshell-codex`; do not add a callback or global mutable configuration path.
+  Centralize argv/environment merging in `codex_sidecar_spawn_spec`; do not duplicate it in the runtime or terminal layers. Keep the transactional cleanup inside the manager so WS, auto-resume, and REST/MCP callers receive the repair without separate error-path code.
 
 - [ ] **Step 6: Run impacted-test verification**
 
-The altered types and shared sidecar spawn helper affect the Codex planner/lifecycle and fresh Codex compilation paths. Run:
+  Run:
 
-```bash
-cargo test -p freshell-codex
-cargo test -p freshell-freshagent codex
-cargo check -p freshell-ws --all-targets
-cargo fmt --all -- --check
-```
+  ```bash
+  cargo test -p freshell-codex
+  cargo test -p freshell-freshagent codex
+  cargo check -p freshell-ws --all-targets
+  cargo fmt --all -- --check
+  ```
 
-Expected: PASS. If the fresh-agent crate has no matching `codex` filter, Cargo may report zero selected tests only after `cargo check -p freshell-freshagent --all-targets` passes; do not treat a filter mismatch as coverage.
+  Expected: PASS. If Cargo selects no fresh-agent tests for `codex`, also run `cargo check -p freshell-freshagent --all-targets`; do not count a zero-test filter as behavioral coverage.
 
 - [ ] **Step 7: Commit the task**
 
-```bash
-git add -- crates/freshell-codex/src/launch_plan.rs crates/freshell-codex/src/launch_lifecycle.rs crates/freshell-codex/src/runtime_select.rs crates/freshell-codex/tests/launch_lifecycle.rs crates/freshell-freshagent/src/codex.rs
-git commit -m "fix: carry Codex sidecar launch context"
-```
+  ```bash
+  git add -- crates/freshell-codex/src/launch_plan.rs crates/freshell-codex/src/launch_lifecycle.rs crates/freshell-codex/src/runtime_select.rs crates/freshell-codex/tests/launch_lifecycle.rs crates/freshell-freshagent/src/codex.rs
+  git commit -m "fix: carry managed Codex sidecar context safely"
+  ```
 
-### Task 2: Reuse one context for create, restore preplanning, recovery, and the real dual-process launch
+### Task 3: Build one launch setup at every terminal-pane spawn door and prove spawned-pair parity
 
 **Files:**
 
-- Modify: `crates/freshell-ws/src/terminal.rs:2021-2073, 2488-2526, 2644-2709, 2946-3513, 4330-4406`
-- Modify: `crates/freshell-ws/tests/codex_managed_launch_e2e.rs:65-104, 302-420`
-- Test: `crates/freshell-ws/src/terminal.rs:7004-7038`
-- Test: `crates/freshell-ws/tests/codex_managed_launch_e2e.rs:302-420`
+- Modify: `crates/freshell-ws/src/terminal.rs:2475-2526,2644-2715,2946-3820,4330-4602,5141-5175`
+- Modify: `crates/freshell-freshagent/src/terminal_tabs.rs:352-384,1500-2010`
+- Modify: `crates/freshell-ws/tests/codex_managed_launch_e2e.rs:65-420`
+- Modify: `crates/freshell-ws/tests/codex_sidecar_reattach_e2e.rs:671-978`
+- Test: `crates/freshell-ws/src/terminal.rs`
+- Test: `crates/freshell-freshagent/src/terminal_tabs.rs`
 
 **Interfaces:**
 
-- Consumes: resolved terminal id, effective native MCP cwd, `McpInjection`, tab/pane identity, and `build_terminal_base_env` output.
-- Produces: one `CodexManagedLaunchSetup` containing the TUI injection, terminal environment, native sidecar cwd, and `CodexSidecarLaunchContext` for the same launch attempt.
-- Preserves: pre-gate restore planning, prepared-launch cleanup, proxy adoption, resume ordering, recovery spawning, non-Codex modes, and managed-launch opt-out.
+- Consumes: final terminal id, selected TUI target, host/WSL inputs, resolved native MCP cwd, requested tab/pane identities, and `build_terminal_base_env` output.
+- Produces a private, deliberately non-`Debug` setup in each terminal-pane layer:
 
-- [ ] **Step 1: Write the failing behavioral test**
+  ```rust
+  struct CodexManagedLaunchSetup {
+      terminal_id: String,
+      runtime_cwd: Option<String>,
+      tui_mcp_injection: McpInjection,
+      terminal_env: BTreeMap<String, String>,
+      sidecar_context: CodexSidecarLaunchContext,
+  }
+  ```
 
-Extend the ignored dual-role integration fixture so its dispatcher writes both TUI argv and only these environment fields to `CODEX_ARGV_CAPTURE_PATH`; retain the fake app-server’s existing `FAKE_CODEX_APP_SERVER_ARG_LOG` observation. Add helpers that extract only the Freshell MCP `-c` values and the six `FRESHELL_*` fields. For the managed fresh and managed-resume legs, assert equality of those normalized values and matching terminal id; continue asserting the live `initialize` relay.
+- Preserves: terminal base-environment optional tab/pane semantics, plain opt-out behavior, fresh restore exclusion, resume gate ordering, queue cancellation, survivor reattachment, browser reconnect, non-Codex launch paths, and all existing session-id arguments.
 
-```rust
-#[derive(Debug, Deserialize)]
-struct CapturedCodexProcess {
-    argv: Vec<String>,
-    env: BTreeMap<String, Option<String>>,
-}
+- [ ] **Step 1: Write the failing behavioral tests**
 
-fn freshell_mcp_config(argv: &[String]) -> Vec<String> {
-    argv.windows(2)
-        .filter_map(|pair| {
-            (pair[0] == "-c" && pair[1].starts_with("mcp_servers.freshell."))
-                .then(|| pair[1].clone())
-        })
-        .collect()
-}
+  Extend the ignored dual-process fixture before production code:
 
-fn assert_freshell_launch_parity(
-    tui: &CapturedCodexProcess,
-    sidecar: &CapturedCodexProcess,
-    terminal_id: &str,
-) {
-    assert_eq!(freshell_mcp_config(&tui.argv), freshell_mcp_config(&sidecar.argv));
-    assert_eq!(tui.env, sidecar.env);
-    assert_eq!(tui.env["FRESHELL_TERMINAL_ID"].as_deref(), Some(terminal_id));
-    assert!(sidecar.argv.iter().position(|arg| arg == "app-server").is_some());
-}
-```
+  1. Have the fake TUI dispatcher write its complete argv plus an allowlisted map of only the six Freshell environment fields. Keep the fake app-server's existing capture and make it record the same allowlist. Use synthetic values; never print them in assertion messages.
+  2. Add `freshell_mcp_pairs(argv)` which extracts complete `-c` pairs beginning `mcp_servers.freshell.`. Add `assert_spawned_pair_parity(tui, sidecar, expected_terminal_id)` that asserts: exact static `env_vars` pair; command/args semantic recipe equality on the current target; equal six-key parent environment maps; expected terminal id; config pairs appear before sidecar `app-server`; and neither argv contains a synthetic token value.
+  3. Run that assertion for a fresh WS create and a resume/no-survivor or retry-spawn leg. Include `tabId` and `paneId` on the fresh leg, and assert the intentional absence behavior on auto-resume.
+  4. Add a REST/MCP terminal-tabs test using the same fake command/capture seam. It must verify this door supplies the context to a newly spawned sidecar rather than merely compiling after the type change.
+  5. Rename/adapt the survivor reattach test so it asserts the same verified PID is retained and no replacement child starts, but explicitly does **not** compare a newly minted setup to the survivor or call the outcome parity coverage.
+  6. Add a focused prepared-restore/adoption-failure test proving the reserved terminal id is reused exactly once and the prepared launch is discarded after a post-PTY adoption error.
 
-Use non-secret fixture values. The test must include `tabId` and `paneId` on the fresh create so it proves those optional terminal-context fields are also identical. The app-server log must be read before `registry.kill`, and each phase must use its own capture file.
+- [ ] **Step 2: Run the focused tests and verify the intended failure**
 
-- [ ] **Step 2: Run the test and verify the intended failure**
+  Run:
 
-Run:
+  ```bash
+  cargo test -p freshell-ws --test codex_managed_launch_e2e -- --ignored --test-threads=1
+  cargo test -p freshell-ws prepared_codex_launch_reuses_reserved_setup_and_discards_after_adopt_failure
+  cargo test -p freshell-freshagent managed_codex_terminal_tab_supplies_sidecar_context -- --nocapture
+  ```
 
-```bash
-cargo test -p freshell-ws --test codex_managed_launch_e2e -- --ignored --test-threads=1
-```
-
-Expected: FAIL on the managed fresh leg because the app-server observation has no Freshell MCP config arguments or `FRESHELL_TERMINAL_ID`, while the TUI observation does. The plain opt-out leg must remain unmodified.
+  Expected: the ignored integration test fails because the sidecar has neither Freshell MCP config nor terminal context; the preparation test fails because no setup/id travels with the prepared launch; the REST path has the same missing sidecar context.
 
 - [ ] **Step 3: Add the minimal production implementation**
 
-Add a private setup value in `terminal.rs`, with no `Debug` implementation that could reveal the configured token.
+  1. In each terminal-pane layer, add one setup-construction helper. It resolves `mcp_cwd` with `resolve_mcp_cwd`, derives the actual TUI `ProviderTarget`, calls `build_managed_codex_mcp_renderings` once, builds `terminal_env` once, and constructs `sidecar_context` from the **sidecar** rendering followed by `terminal_env` so the canonical terminal values win on an overlapping key. Its `runtime_cwd` is the resolved host-native MCP cwd. Its TUI injection is the **TUI** rendering.
+  2. In WS interactive create, mint the normal terminal id before managed planning, construct this setup after all existing validation/duplicate gates, pass its `runtime_cwd` and `sidecar_context` to `plan_codex_managed_launch`, then use its TUI injection/environment when spawning the PTY.
+  3. In WS restore preplanning, after resume validation but before `plan_codex_managed_launch`, reserve one UUID only for a managed Codex resume that will plan. Build the setup from that id and store both setup and launch in a structured `PreparedCodexLaunch`. Change `take()` to return both; `Drop` continues to discard an unconsumed launch. In `handle_create`, reuse the stored id/setup rather than minting or rendering a second time. Non-Codex and managed-disabled preplanning remain unchanged.
+  4. In auto-resume/recovery, build the setup from the replacement terminal id and its intentionally absent tab/pane values before planning a new sidecar. Reuse its TUI rendering/environment for the replacement PTY.
+  5. Apply the same construction/order in `freshell-freshagent/src/terminal_tabs.rs`: it already has terminal, tab, and pane ids before the managed plan; create the setup before planning and use it for both sidecar plan and CLI PTY. Do not default its sidecar context empty.
+  6. When runtime selection returns a verified survivor, retain the current reattach behavior. The plan's context is consumed only by a spawned runtime; do not add a survivor kill path, durable context snapshot, or a log that says the survivor was reconfigured.
+  7. Keep the explicit `FRESHELL_CODEX_MANAGED_LAUNCH=0` test leg unchanged: it must not receive a remote proxy or managed-sidecar-only config.
 
-```rust
-#[derive(Clone)]
-struct CodexManagedLaunchSetup {
-    terminal_id: String,
-    runtime_cwd: Option<String>,
-    mcp_injection: McpInjection,
-    terminal_env: BTreeMap<String, String>,
-    sidecar_context: freshell_codex::launch_plan::CodexSidecarLaunchContext,
-}
-```
+- [ ] **Step 4: Run the focused tests**
 
-Create it in one helper after `resolve_mcp_cwd` and before managed sidecar planning. The helper must generate the Codex `McpInjection` once, build the terminal base environment once, merge `mcp_injection.env` then `terminal_env` into the sidecar environment, and pass the resolved native MCP cwd as `runtime_cwd`. Its central construction is:
+  Run:
 
-```rust
-let mcp_injection = generate_mcp_injection(
-    &RealMcpRuntime,
-    "codex",
-    terminal_id,
-    mcp_cwd.as_deref(),
-    target,
-)?;
-let terminal_env = build_terminal_base_env(&RealEnv, terminal_id, tab_id, pane_id);
-let mut sidecar_env = mcp_injection.env.clone();
-sidecar_env.extend(terminal_env.clone());
-let setup = CodexManagedLaunchSetup {
-    terminal_id: terminal_id.to_string(),
-    runtime_cwd: mcp_cwd,
-    sidecar_context: CodexSidecarLaunchContext {
-        config_args: mcp_injection.args.clone(),
-        env: sidecar_env,
-    },
-    mcp_injection,
-    terminal_env,
-};
-```
+  ```bash
+  cargo test -p freshell-ws --test codex_managed_launch_e2e -- --ignored --test-threads=1
+  cargo test -p freshell-ws prepared_codex_launch_reuses_reserved_setup_and_discards_after_adopt_failure
+  cargo test -p freshell-freshagent managed_codex_terminal_tab_supplies_sidecar_context -- --nocapture
+  cargo test -p freshell-ws --test codex_sidecar_reattach_e2e -- --ignored --test-threads=1
+  ```
 
-Change `plan_codex_managed_launch` to accept the resolved sidecar cwd and context, place a clone in `CodexLaunchPlanInput`, and leave its early return untouched when managed launch is disabled or mode is not Codex. In the ordinary create path, construct this setup before calling that helper, pass its context to the sidecar plan, then use the same `mcp_injection` for `CliLaunchInputs` and the same `terminal_env` for the PTY spawn spec.
-
-For the restore pre-gate branch, mint the terminal id before planning only when a Codex resume sidecar will be materialized, construct the same setup from the final resolved cwd and requested tab/pane identifiers, and store both setup and launch in `PreparedCodexLaunch`. `handle_create` must reuse the stored terminal id/setup rather than minting or generating a second one; its existing `Drop` implementation must still discard an unadopted sidecar on every early return. Do not change the fresh restore exclusion, queue class, cancellation behavior, or resume validation order.
-
-In the auto-resume/recovery path, build the setup from the existing terminal id and its intentional `None` tab/pane identifiers before planning. Reuse its injection/environment for the replacement TUI and pass its sidecar context to the replacement app-server plan. Non-Codex paths retain their existing MCP construction and cleanup path unchanged.
-
-- [ ] **Step 4: Run the focused test**
-
-Run:
-
-```bash
-cargo test -p freshell-ws --test codex_managed_launch_e2e -- --ignored --test-threads=1
-```
-
-Expected: PASS. The fresh and resume managed legs show equal Freshell MCP config and terminal-context maps for the actual TUI and actual sidecar, the proxy relays `initialize`, and the explicit opt-out still has no `--remote`.
+  Expected: PASS. Each newly spawned WS/REST/retry pair has semantic MCP/context parity; the proxy still relays initialize; a retained survivor is explicitly preserved without a false parity assertion; failed adoption does not leave the prepared sidecar active.
 
 - [ ] **Step 5: Refactor while green**
 
-Collapse any duplicated Codex setup construction into the one helper, keep `McpInjection` generation at the IO layer, and remove any one-off environment merging. Confirm an unprepared interactive create and a prepared restore both consume the same setup type without modifying shell, Claude, OpenCode, or survivor-reattach code.
+  Collapse duplicated WS construction into one helper and keep REST's equivalent helper limited to its existing layer. Do not make a global environment mutation, store setup in durable sidecar state, or force a survivor replacement. Ensure `PreparedCodexLaunch` has one clear owner for its launch and no terminal resource is created solely by UUID reservation.
 
 - [ ] **Step 6: Run impacted-test verification**
 
-The change crosses terminal creation, managed sidecar planning, lifecycle selection, recovery, and the dual-process integration harness. Run:
+  Run:
 
-```bash
-cargo test -p freshell-codex
-cargo test -p freshell-ws
-cargo test -p freshell-ws --test codex_managed_launch_e2e -- --ignored --test-threads=1
-cargo check --workspace --all-targets
-cargo fmt --all -- --check
-```
+  ```bash
+  cargo test -p freshell-ws
+  cargo test -p freshell-freshagent
+  cargo test -p freshell-codex
+  cargo test -p freshell-ws --test codex_managed_launch_e2e -- --ignored --test-threads=1
+  cargo test -p freshell-ws --test codex_sidecar_reattach_e2e -- --ignored --test-threads=1
+  cargo check --workspace --all-targets
+  cargo fmt --all -- --check
+  ```
 
-Expected: PASS. The ignored e2e is run separately because it mutates process-global environment and uses the singleton launch manager.
+  Expected: PASS. The integration tests run alone because they mutate process-global launch seams and use the singleton manager.
 
 - [ ] **Step 7: Commit the task**
 
-```bash
-git add -- crates/freshell-ws/src/terminal.rs crates/freshell-ws/tests/codex_managed_launch_e2e.rs
-git commit -m "fix: share Codex MCP context with app server"
-```
+  ```bash
+  git add -- crates/freshell-ws/src/terminal.rs crates/freshell-freshagent/src/terminal_tabs.rs crates/freshell-ws/tests/codex_managed_launch_e2e.rs crates/freshell-ws/tests/codex_sidecar_reattach_e2e.rs
+  git commit -m "fix: configure spawned managed Codex pairs consistently"
+  ```
 
 ## Final Verification
 
-After both tasks and their task-level reviews, run the workflow’s final coordinated broad gate from the clean worktree branch. Preserve the baseline ledger distinction: the base had no reproducible failures after its clean retry. Record the exact command, result, and evidence in the external run state before independent complete-delta review.
+After task reviews pass, run the full branch verification through the repository coordinator and record the exact receipt in the external run state:
+
+```bash
+FRESHELL_TEST_SUMMARY='the-usual: managed Codex MCP parity' npm test
+```
+
+Expected: PASS through the coordinator from this branch worktree. Do not restart, deploy, or replace the live Rust server as part of verification.
+
+The final handoff must distinguish these facts accurately:
+
+1. Newly spawned and retry-spawned managed Codex pairs have automated semantic configuration/context parity and working MCP transport coverage.
+2. A sidecar already retained before a replacement TUI is deliberately reattached unchanged; it cannot receive the new context and may retain pre-fix behavior until a fresh managed launch. Active work is not forcibly interrupted.
+3. The literal `Booting MCP server: node_repl` claim is supported only by a bounded, isolated real-provider A/B acceptance run: the same Codex version/topology/node_repl configuration and scratch `CODEX_HOME`, with only app-server MCP parity varied. It must prove the corrected spawned pair clears the display within its declared timeout and a harmless MCP tool is discoverable/callable. If that lane is unavailable or its negative control does not reproduce, say that configuration transport and tool access were verified but do not claim causal proof of the exact TUI display.


### PR DESCRIPTION
Configures each newly spawned managed Codex app-server with the same logical Freshell MCP setup and terminal context as its TUI. Adds lifecycle, platform, WebSocket, and terminal-tab coverage. Verified with npm test: Cloud Build, four cloud Vitest shards, Electron 40 files / 432 tests, and port-contract tests. The isolated real-Codex A/B reproduced the old persistent startup label; the matched configuration did not render it and completed a harmless Freshell MCP canary call.