### PR TITLE
fix(ui): remove blue fill/line from sidebar busy rows

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1112,13 +1112,9 @@ export const SidebarItem = memo(function SidebarItem(props: SidebarItemProps) {
               ? isActiveTab
                 ? 'bg-emerald-100 dark:bg-emerald-900/40 border-l-emerald-500'
                 : 'bg-emerald-50 dark:bg-emerald-900/20 border-l-emerald-500/70 hover:bg-emerald-100 dark:hover:bg-emerald-900/30'
-              : isBusy
-                ? isActiveTab
-                  ? 'bg-blue-100 dark:bg-blue-900/40 border-l-blue-500'
-                  : 'bg-blue-50 dark:bg-blue-900/20 border-l-blue-500/70 hover:bg-blue-100 dark:hover:bg-blue-900/30'
-                : isActiveTab
-                  ? 'bg-muted border-l-transparent'
-                  : 'hover:bg-muted/50 border-l-transparent'
+              : isActiveTab
+                ? 'bg-muted border-l-transparent'
+                : 'hover:bg-muted/50 border-l-transparent'
           )}
           data-context={ContextIds.SidebarSession}
           data-session-id={item.sessionId}

--- a/test/unit/client/components/Sidebar.test.tsx
+++ b/test/unit/client/components/Sidebar.test.tsx
@@ -5517,10 +5517,10 @@ describe('Sidebar Component - Session-Centric Display', () => {
       await act(async () => { vi.advanceTimersByTime(100) })
 
       const button = screen.getByRole('button', { name: /active busy session/i })
-      expect(button).toHaveClass('bg-blue-100')
-      expect(button).toHaveClass('border-l-2')
-      expect(button).toHaveClass('border-l-blue-500')
-      expect(button).toHaveClass('dark:bg-blue-900/40')
+      expect(button).toHaveClass('bg-muted')
+      expect(button).toHaveClass('border-l-transparent')
+      expect(button).not.toHaveClass('bg-blue-100')
+      expect(button).not.toHaveClass('border-l-blue-500')
     })
 
     it('applies transparent border and no color treatment for an inactive closed session', async () => {
@@ -5623,10 +5623,9 @@ describe('Sidebar Component - Session-Centric Display', () => {
       await act(async () => { vi.advanceTimersByTime(100) })
 
       const button = screen.getByRole('button', { name: /inactive busy session/i })
-      expect(button).toHaveClass('bg-blue-50')
-      expect(button).toHaveClass('border-l-2')
-      expect(button).toHaveClass('border-l-blue-500/70')
-      expect(button).toHaveClass('dark:bg-blue-900/20')
+      expect(button).not.toHaveClass('bg-blue-50')
+      expect(button).not.toHaveClass('border-l-blue-500')
+      expect(button).toHaveClass('border-l-transparent')
     })
   })
 })


### PR DESCRIPTION
The tab bar shows busy state only via blue icons, not blue fill backgrounds. The sidebar now matches — no blue background or blue left-border for busy sessions. The provider icon's blue color already signals busy state.