### PR TITLE
feat(ws): stagger terminal.create wire sends to prevent OpenCode/Bun crash on restore (kata rf0v)

### DIFF
--- a/docs/plans/2026-09-08-stagger-restore-launches.md
+++ b/docs/plans/2026-09-08-stagger-restore-launches.md
@@ -1,0 +1,550 @@
+# Stagger Restore-Driven terminal.create Launches Implementation Plan
+
+> **For agentic workers:** Execute this plan task by task with a fresh
+> implementer and a specification-plus-quality review after every task. Track
+> progress with the checkbox steps below.
+
+## User Request
+
+### Requested result
+Fix freshell kata rf0v: stagger restore-driven `terminal.create` dispatches (~400–500ms per pane) so a client reload/reconnect restoring multiple persisted panes never spawns multiple agent processes within the same ~100ms window, avoiding the known OpenCode/Bun concurrent-launch crash.
+
+### Explicit constraints
+- Fix only kata rf0v (restore-launch staggering); the build-mismatch deployment-hygiene item was explicitly excluded by the user.
+- TDD (red-green-refactor) with unit and e2e coverage per repo rules.
+- Work in a dedicated worktree branch; land via PR only after the user's explicit approval.
+
+### Accepted tradeoffs and residuals
+- Interactive launches don't strictly need staggering; sharing the same throttle is accepted as harmless.
+- This is a client-side mitigation; the upstream Bun bug remains unfixed (defense-in-depth if upstream lands a fix).
+
+**Goal:** A client reload/reconnect restoring N persisted terminal panes spaces `terminal.create` wire sends ~450ms apart so no two agent processes spawn within the same ~100ms window.
+
+**Architecture:** A new `TerminalCreateStagger` module paces `terminal.create` wire sends at a 450ms minimum interval. It sits inside `WsClient` at the `sendNow` level — the single wire-level chokepoint that all create paths (direct-ready, pre-verdict held-creates flush, ready-handler preReadyCreateQueue flush, reconnect re-send) funnel through. Non-create messages bypass the stagger entirely. The stagger is cleared on each `ready` frame so stale entries from a dead socket don't double-send. This mirrors the existing `RebindQueue` precedent (which paces `freshAgent.create` for hidden panes) but operates at the wire level rather than the view level, ensuring the stagger survives the ws-client's internal hold/queue/flush mechanisms.
+
+**Tech Stack:** TypeScript, React 18, Vitest (jsdom), Playwright (e2e), WebSocket
+
+## Global Constraints
+
+- Client-side code only (Vite-bundled `src/`); no server changes.
+- `@/` path alias → `src/`.
+- Follow existing patterns: `RebindQueue` (src/lib/rebind-queue.ts) for queue structure; `rebind-queue.test.ts` for test patterns.
+- Fake timers (`vi.useFakeTimers` + `vi.advanceTimersByTime`) for stagger timing assertions.
+- Singleton modules need `resetXxxForTests()` called in `test/setup/dom.ts` afterEach.
+- E2E specs run on cloud backend (`FRESHELL_E2E_BACKEND=cloud`); use `GCLOUD_ROBOT_HOME` for identity.
+- Pre-existing baseline failure: `test/unit/client/components/Sidebar.mobile.test.tsx` (kata ecsx) — not introduced by this work; excluded from the gate pass criterion.
+
+---
+
+### Task 1: Create TerminalCreateStagger module with unit tests
+
+**Files:**
+- Create: `src/lib/terminal-create-stagger.ts`
+- Test: `test/unit/client/lib/terminal-create-stagger.test.ts`
+- Modify: `test/setup/dom.ts:126` (add reset to afterEach)
+
+**Interfaces:**
+- Produces: `TerminalCreateStagger` class, `getTerminalCreateStagger()`, `resetTerminalCreateStaggerForTests()` — used by Task 2 in `ws-client.ts`
+
+- [ ] **Step 1: Write the failing behavioral tests**
+
+```typescript
+// test/unit/client/lib/terminal-create-stagger.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TerminalCreateStagger,
+  getTerminalCreateStagger,
+  resetTerminalCreateStaggerForTests,
+} from '@/lib/terminal-create-stagger'
+
+describe('TerminalCreateStagger', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetTerminalCreateStaggerForTests()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends the first message immediately (no prior send)', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => { sent.push('a') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+  })
+
+  it('spaces subsequent sends by STAGGER_INTERVAL_MS (450ms)', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => { sent.push('a') })
+    stagger.enqueue(() => { sent.push('b') })
+    stagger.enqueue(() => { sent.push('c') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+    vi.advanceTimersByTime(450)
+    expect(sent).toEqual(['a', 'b'])
+    vi.advanceTimersByTime(450)
+    expect(sent).toEqual(['a', 'b', 'c'])
+  })
+
+  it('no two sends land within the same 100ms window', () => {
+    const stagger = new TerminalCreateStagger()
+    const timestamps: number[] = []
+    for (let i = 0; i < 5; i++) {
+      stagger.enqueue(() => { timestamps.push(Date.now()) })
+    }
+    vi.advanceTimersByTime(0)
+    vi.advanceTimersByTime(450)
+    vi.advanceTimersByTime(450)
+    vi.advanceTimersByTime(450)
+    vi.advanceTimersByTime(450)
+    expect(timestamps).toHaveLength(5)
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i] - timestamps[i - 1]).toBeGreaterThanOrEqual(450)
+    }
+  })
+
+  it('clear drops all pending sends', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => { sent.push('a') })
+    stagger.enqueue(() => { sent.push('b') })
+    stagger.enqueue(() => { sent.push('c') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+    stagger.clear()
+    vi.advanceTimersByTime(1000)
+    expect(sent).toEqual(['a'])
+  })
+
+  it('resetForTests clears pending and resets lastSendAt', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => { sent.push('a') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+    stagger.resetForTests()
+    stagger.enqueue(() => { sent.push('b') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a', 'b'])
+  })
+
+  it('getTerminalCreateStagger returns a singleton reset by resetTerminalCreateStaggerForTests', () => {
+    const first = getTerminalCreateStagger()
+    expect(getTerminalCreateStagger()).toBe(first)
+    resetTerminalCreateStaggerForTests()
+    expect(getTerminalCreateStagger()).not.toBe(first)
+  })
+
+  it('handles enqueue from within a send callback (pump re-entrancy)', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => {
+      sent.push('a')
+      stagger.enqueue(() => { sent.push('b') })
+    })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+    vi.advanceTimersByTime(450)
+    expect(sent).toEqual(['a', 'b'])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/terminal-create-stagger.test.ts --config config/vitest/vitest.config.ts`
+
+Expected: FAIL because `src/lib/terminal-create-stagger.ts` does not exist (import error).
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+```typescript
+// src/lib/terminal-create-stagger.ts
+
+const STAGGER_INTERVAL_MS = 450
+
+/**
+ * TerminalCreateStagger — paces `terminal.create` wire sends at a minimum
+ * interval of STAGGER_INTERVAL_MS so a client reload/reconnect restoring
+ * multiple persisted panes never lands two agent-process spawns within the
+ * same ~100ms window (the known OpenCode/Bun concurrent-launch crash,
+ * upstream anomalyco/opencode#38366).
+ *
+ * Sits inside WsClient at the sendNow level — the single wire-level chokepoint
+ * that all create paths (direct-ready, held-creates flush, ready-handler
+ * flush, reconnect re-send) funnel through. Non-create messages bypass.
+ *
+ * Mirrors the RebindQueue precedent (src/lib/rebind-queue.ts) which paces
+ * freshAgent.create for hidden panes, but operates at the wire level rather
+ * than the view level.
+ */
+export class TerminalCreateStagger {
+  private pending: Array<() => void> = []
+  private lastSendAt = 0
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  enqueue(send: () => void): void {
+    this.pending.push(send)
+    this.pump()
+  }
+
+  clear(): void {
+    this.pending = []
+    if (this.timer !== null) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  resetForTests(): void {
+    this.clear()
+    this.lastSendAt = 0
+  }
+
+  private pump(): void {
+    if (this.timer !== null || this.pending.length === 0) return
+    const elapsed = Date.now() - this.lastSendAt
+    const delay = Math.max(0, STAGGER_INTERVAL_MS - elapsed)
+    this.timer = setTimeout(() => {
+      this.timer = null
+      this.lastSendAt = Date.now()
+      const next = this.pending.shift()
+      if (next) next()
+      this.pump()
+    }, delay)
+  }
+}
+
+let singleton: TerminalCreateStagger | null = null
+
+export function getTerminalCreateStagger(): TerminalCreateStagger {
+  if (!singleton) singleton = new TerminalCreateStagger()
+  return singleton
+}
+
+export function resetTerminalCreateStaggerForTests(): void {
+  singleton?.resetForTests()
+}
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/terminal-create-stagger.test.ts --config config/vitest/vitest.config.ts`
+
+Expected: PASS (all 7 tests)
+
+- [ ] **Step 5: Refactor while green**
+
+No refactor needed — the module is minimal and focused.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+Add the stagger reset to `test/setup/dom.ts` afterEach (line 126, after `resetTerminalReleaseMarks()`):
+
+```typescript
+import { resetTerminalCreateStaggerForTests } from '@/lib/terminal-create-stagger'
+// ... in afterEach:
+  resetWsClientForTests()
+  resetTerminalReleaseMarks()
+  resetTerminalCreateStaggerForTests()
+```
+
+Run: `npm run test:vitest -- run test/unit/client/lib/terminal-create-stagger.test.ts test/unit/client/lib/rebind-queue.test.ts --config config/vitest/vitest.config.ts`
+
+Expected: PASS (both stagger and rebind-queue suites green; the setup change doesn't break anything).
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/lib/terminal-create-stagger.ts test/unit/client/lib/terminal-create-stagger.test.ts test/setup/dom.ts
+git commit -m "feat(ws): add TerminalCreateStagger module for terminal.create wire-send pacing
+
+New module paces terminal.create wire sends at a 450ms minimum interval to
+prevent concurrent agent-process launches from crashing OpenCode/Bun on
+reload/reconnect (kata rf0v, upstream anomalyco/opencode#38366).
+
+Mirrors the RebindQueue precedent but operates at the WsClient.sendNow wire
+level, ensuring the stagger survives the ws-client's internal hold/queue/flush
+mechanisms. Includes singleton + resetForTests for test isolation."
+```
+
+---
+
+### Task 2: Wire the stagger into WsClient
+
+**Files:**
+- Modify: `src/lib/ws-client.ts` (import stagger, add field, route creates, clear on ready)
+- Test: `test/unit/client/ws-client-protocol-reload.test.ts` (add stagger assertions)
+- Test: `test/unit/client/lib/ws-client.test.ts` (add stagger assertions)
+
+**Interfaces:**
+- Consumes: `getTerminalCreateStagger()` from Task 1
+- Produces: `WsClient` routes `terminal.create` messages through the stagger at the wire level
+
+- [ ] **Step 1: Write the failing behavioral tests**
+
+Add a test to `test/unit/client/lib/ws-client.test.ts` that asserts `terminal.create` sends are staggered when multiple creates are sent while ready:
+
+```typescript
+// Add to test/unit/client/lib/ws-client.test.ts
+import { resetTerminalCreateStaggerForTests } from '@/lib/terminal-create-stagger'
+
+describe('WsClient terminal.create stagger', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetTerminalCreateStaggerForTests()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('paces terminal.create sends 450ms apart when multiple are ready', () => {
+    // ... setup: create WsClient with a mock WebSocket in 'ready' state
+    // ... send 3 terminal.create messages via wsClient.send()
+    // ... assert first sent immediately, second after 450ms, third after 900ms
+    // ... use the mock WebSocket's sent messages to verify timing
+  })
+
+  it('non-create messages bypass the stagger (sent immediately)', () => {
+    // ... send a terminal.create then a terminal.input
+    // ... assert terminal.create sent at t=0, terminal.input also sent at t=0
+    // ... (not delayed behind the create stagger)
+  })
+
+  it('clears the stagger on ready (no stale sends from dead socket)', () => {
+    // ... enqueue creates, disconnect, reconnect (ready)
+    // ... assert stagger was cleared and re-sent creates start fresh
+  })
+})
+```
+
+The implementer should follow the existing `ws-client.test.ts` patterns for mocking the WebSocket and driving the WsClient through connect→ready→send. See `test/unit/client/ws-client-protocol-reload.test.ts` for the `MockWebSocket` class pattern.
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts -t "terminal.create stagger" --config config/vitest/vitest.config.ts`
+
+Expected: FAIL because the stagger is not yet wired into WsClient (all creates sent immediately, no 450ms spacing).
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+In `src/lib/ws-client.ts`:
+
+1. Import the stagger at the top:
+```typescript
+import { getTerminalCreateStagger, type TerminalCreateStagger } from '@/lib/terminal-create-stagger'
+```
+
+2. Add a type guard for `terminal.create` messages (near `isCreateMessage` at line 109):
+```typescript
+function isTerminalCreateMessage(msg: unknown): boolean {
+  if (!msg || typeof msg !== 'object') return false
+  return (msg as { type?: unknown }).type === 'terminal.create'
+}
+```
+
+3. Add the stagger field to the `WsClient` class (near line 164):
+```typescript
+private terminalCreateStagger: TerminalCreateStagger = getTerminalCreateStagger()
+```
+
+4. Add a `sendCreateNow` helper method (near `sendNow` at line 946):
+```typescript
+private sendCreateNow(msg: unknown) {
+  this.terminalCreateStagger.enqueue(() => this.sendNow(msg))
+}
+```
+
+5. Route `terminal.create` sends through the stagger. At each create-related `sendNow` call site, replace `this.sendNow(msg)` with a check:
+
+**Line 852** (direct-ready path in `send`): the message could be any type. Replace:
+```typescript
+      this.sendNow(msg)
+```
+with:
+```typescript
+      if (isTerminalCreateMessage(msg)) {
+        this.sendCreateNow(msg)
+      } else {
+        this.sendNow(msg)
+      }
+```
+
+**Line 210** (`setReconcilePendingCreates`): these are always create messages from `heldCreates`. Replace `this.sendNow(msg)` with `this.sendCreateNow(msg)`.
+
+**Line 231** (`clearReconcileCreateHold`): these are always create messages. Replace `this.sendNow(msg)` with `this.sendCreateNow(msg)`.
+
+**Line 320** (ready handler non-reconcile flush): these are always create messages from `preReadyCreateQueue`. Replace `this.sendNow(createMsg)` with `this.sendCreateNow(createMsg)`.
+
+**Line 356** (reconnect re-send): these are always create messages from `inFlightCreates`. Replace `this.sendNow(entry.message)` with `this.sendCreateNow(entry.message)`.
+
+6. Clear the stagger on each `ready` frame. At the beginning of the `ready` block (line 263, right after `if (msg.type === 'ready') {`):
+```typescript
+      this.terminalCreateStagger.clear()
+```
+
+This ensures stale entries from a dead socket are dropped before the ready handler flushes/re-sends creates through the fresh stagger.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts -t "terminal.create stagger" --config config/vitest/vitest.config.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+Review the call sites for consistency. The `sendCreateNow` helper is the single point that routes through the stagger — verify all five call sites use it correctly and no `terminal.create` message bypasses it.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The stagger affects ALL tests that send `terminal.create` messages through the ws-client. Run the ws-client suites and the TerminalView lifecycle suites:
+
+Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client-protocol-reload.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/TerminalView.launchRetry.test.tsx test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx test/e2e/terminal-restart-recovery.test.tsx --config config/vitest/vitest.config.ts`
+
+Expected: PASS. Tests that assert `terminal.create` sends arrive immediately may need to advance fake timers by 450ms to flush the stagger. If any existing test fails because it expects an immediate `terminal.create` but the stagger delays it, advance the test's fake timers by `STAGGER_INTERVAL_MS` (450) to flush the send. Do NOT reduce the stagger interval or disable the stagger for tests — the test must accommodate the real behavior.
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/lib/ws-client.ts test/unit/client/lib/ws-client.test.ts
+git commit -m "feat(ws): route terminal.create through TerminalCreateStagger in WsClient
+
+All terminal.create wire sends now pass through the TerminalCreateStagger
+which paces them 450ms apart at the sendNow level — the single wire-level
+chokepoint. This catches all paths: direct-ready, held-creates flush,
+ready-handler preReadyCreateQueue flush, and reconnect re-send.
+
+Non-create messages (freshAgent.create, terminal.input, etc.) bypass the
+stagger entirely. The stagger is cleared on each ready frame to drop stale
+entries from a dead socket.
+
+Fixes kata rf0v."
+```
+
+---
+
+### Task 3: E2E test — restore stagger invariant on reload
+
+**Files:**
+- Modify: `src/lib/test-harness.ts:115-122` (add send timestamps to sentWsMessages)
+- Modify: `src/lib/test-harness.ts:57-58` (add getSentWsMessagesWithTimestamps to interface)
+- Modify: `src/lib/test-harness.ts:188` (add getSentWsMessagesWithTimestamps implementation)
+- Modify: `test/e2e-browser/helpers/test-harness.ts` (add getSentWsMessagesWithTimestamps proxy)
+- Create: `test/e2e-browser/specs/restore-create-stagger-rust.spec.ts`
+
+**Interfaces:**
+- Consumes: `WsClient` with stagger from Task 2
+- Produces: E2E proof that a multi-pane reload spaces terminal.create sends ≥400ms apart
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Create `test/e2e-browser/specs/restore-create-stagger-rust.spec.ts` following the patterns from `create-protection-restore-storm-rust.spec.ts` and `restore-matrix.spec.ts`:
+
+```typescript
+// test/e2e-browser/specs/restore-create-stagger-rust.spec.ts
+import { test, expect } from '@playwright/test'
+import { createE2eServerHandle } from '../helpers/e2e-server'
+// ... copy per-spec helpers per repo convention (collectLeaves, allLeafTerminalIds,
+//     selectShellIfPickerShowing) from existing specs
+
+test.describe('restore create stagger', () => {
+  test('multiple persisted terminal panes space terminal.create sends >=400ms on reload', async () => {
+    // 1. Start an ephemeral Rust server (createE2eServerHandle, rust-only)
+    // 2. Open browser, connect, create 5+ terminal panes (shell mode for simplicity)
+    // 3. Persist state (flush localStorage)
+    // 4. Restart the Rust server (so panes have no live terminals)
+    // 5. Reload the page
+    // 6. Wait for all panes to anchor (allLeafTerminalIds)
+    // 7. Read getSentWsMessagesWithTimestamps()
+    // 8. Filter for type === 'terminal.create'
+    // 9. Assert: for every consecutive pair, timestamp[i+1] - timestamp[i] >= 400
+    // 10. Assert: all panes eventually anchor (no wedge)
+  })
+})
+```
+
+The implementer should follow the existing spec patterns: use `createE2eServerHandle` for an ephemeral Rust server, `TestHarness` for the browser interaction, and per-spec-copied helpers (`collectLeaves`, `allLeafTerminalIds`, `selectShellIfPickerShowing`) per the repo convention (specs copy helpers, don't import across spec boundaries).
+
+Also modify `src/lib/test-harness.ts` to add timestamps:
+
+```typescript
+// Line 115: modify recordSentWsMessage to include a timestamp
+const recordSentWsMessage = (msg: unknown) => {
+  try {
+    const copy = JSON.parse(JSON.stringify(msg))
+    ;(copy as { __sentAt?: number }).__sentAt = Date.now()
+    sentWsMessages.push(copy)
+  } catch {
+    ;(msg as { __sentAt?: number }).__sentAt = Date.now()
+    sentWsMessages.push(msg)
+  }
+  if (sentWsMessages.length > 500) sentWsMessages.shift()
+}
+```
+
+```typescript
+// Line 57-58: add to interface
+  getSentWsMessagesWithTimestamps?: () => Array<{ __sentAt?: number; type?: string; requestId?: string }>
+```
+
+```typescript
+// Line 188: add implementation (after getSentWsMessages)
+    getSentWsMessagesWithTimestamps: () => [...sentWsMessages] as Array<{ __sentAt?: number; type?: string; requestId?: string }>,
+```
+
+```typescript
+// test/e2e-browser/helpers/test-harness.ts: add proxy method
+  async getSentWsMessagesWithTimestamps(): Promise<Array<{ __sentAt?: number; type?: string; requestId?: string }>> {
+    return this.page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      if (!harness) throw new Error('Test harness not installed')
+      return harness.getSentWsMessagesWithTimestamps?.() ?? []
+    })
+  }
+```
+
+- [ ] **Step 2: Run the test and verify the intended failure**
+
+Run: `FRESHELL_E2E_BACKEND=cloud GCLOUD_ROBOT_HOME=$HOME/.codex/skills/gcloud-robot npm run test:e2e -- --grep "restore create stagger"`
+
+Expected: FAIL — the stagger is wired but the test may fail if the e2e harness or spec setup is incorrect. The primary failure to verify: `terminal.create` sends are NOT spaced ≥400ms apart (or the test infrastructure isn't set up yet). If the stagger from Task 2 is working, the test should PASS — if so, verify it FAILS when the stagger is disabled (e.g., by temporarily setting STAGGER_INTERVAL_MS to 0) to confirm the test actually detects the missing behavior.
+
+- [ ] **Step 3: Add the minimal production implementation**
+
+The test-harness timestamp additions (above) are the production code for this task. The e2e spec itself is the test. No additional production code beyond the test-harness changes.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `FRESHELL_E2E_BACKEND=cloud GCLOUD_ROBOT_HOME=$HOME/.codex/skills/gcloud-robot npm run test:e2e -- --grep "restore create stagger"`
+
+Expected: PASS
+
+- [ ] **Step 5: Refactor while green**
+
+Review the e2e spec for unnecessary complexity. Ensure it follows the per-spec helper convention and doesn't import across spec boundaries.
+
+- [ ] **Step 6: Run impacted-test verification**
+
+The test-harness change (adding `__sentAt` to sentWsMessages) affects all e2e tests that read `getSentWsMessages()`. The `__sentAt` field is additive and should not break existing assertions (they check `msg.type`, `msg.requestId`, etc., not strict equality). Run a sample of existing e2e specs to verify:
+
+Run: `FRESHELL_E2E_BACKEND=cloud GCLOUD_ROBOT_HOME=$HOME/.codex/skills/gcloud-robot npm run test:e2e -- --grep "terminal.create|restore|reconnect"`
+
+Expected: PASS (existing specs unaffected by the additive `__sentAt` field).
+
+- [ ] **Step 7: Commit the task**
+
+```bash
+git add src/lib/test-harness.ts test/e2e-browser/helpers/test-harness.ts test/e2e-browser/specs/restore-create-stagger-rust.spec.ts
+git commit -m "test(e2e): add restore-create-stagger e2e spec and sentWsMessage timestamps
+
+E2E spec persists multiple terminal panes, restarts the server, reloads,
+and asserts terminal.create wire sends are spaced >=400ms apart — proving
+the TerminalCreateStagger prevents the concurrent-launch crash window on
+restore (kata rf0v).
+
+Adds __sentAt timestamps to the test harness sentWsMessages recording so
+e2e specs can assert wire-send timing. The field is additive and backward
+compatible with existing getSentWsMessages() consumers."
+```

--- a/docs/plans/2026-09-08-stagger-restore-launches.md
+++ b/docs/plans/2026-09-08-stagger-restore-launches.md
@@ -105,7 +105,7 @@ describe('TerminalCreateStagger', () => {
     }
   })
 
-  it('clear drops all pending sends', () => {
+  it('clear drops all pending sends and resets lastSendAt', () => {
     const stagger = new TerminalCreateStagger()
     const sent: string[] = []
     stagger.enqueue(() => { sent.push('a') })
@@ -116,6 +116,10 @@ describe('TerminalCreateStagger', () => {
     stagger.clear()
     vi.advanceTimersByTime(1000)
     expect(sent).toEqual(['a'])
+    // After clear(), lastSendAt is reset — next send goes immediately
+    stagger.enqueue(() => { sent.push('d') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a', 'd'])
   })
 
   it('resetForTests clears pending and resets lastSendAt', () => {
@@ -196,6 +200,7 @@ export class TerminalCreateStagger {
       clearTimeout(this.timer)
       this.timer = null
     }
+    this.lastSendAt = 0
   }
 
   resetForTests(): void {
@@ -225,7 +230,7 @@ export function getTerminalCreateStagger(): TerminalCreateStagger {
 }
 
 export function resetTerminalCreateStaggerForTests(): void {
-  singleton?.resetForTests()
+  singleton = null
 }
 ```
 
@@ -350,35 +355,31 @@ function isTerminalCreateMessage(msg: unknown): boolean {
 private terminalCreateStagger: TerminalCreateStagger = getTerminalCreateStagger()
 ```
 
-4. Add a `sendCreateNow` helper method (near `sendNow` at line 946):
+4. Add a `sendCreateNow` helper method (near `sendNow` at line 946). This method filters by message type — only `terminal.create` is staggered; `freshAgent.create` and other create-type messages bypass the stagger and send immediately:
+
 ```typescript
 private sendCreateNow(msg: unknown) {
-  this.terminalCreateStagger.enqueue(() => this.sendNow(msg))
+  if (isTerminalCreateMessage(msg)) {
+    this.terminalCreateStagger.enqueue(() => this.sendNow(msg))
+  } else {
+    this.sendNow(msg)
+  }
 }
 ```
 
-5. Route `terminal.create` sends through the stagger. At each create-related `sendNow` call site, replace `this.sendNow(msg)` with a check:
+5. Route create-related sends through the stagger. At each create-related `sendNow` call site, replace `this.sendNow(msg)` with `this.sendCreateNow(msg)`. Since `sendCreateNow` internally checks `isTerminalCreateMessage`, it is a safe drop-in: `terminal.create` messages are staggered; all others (including `freshAgent.create`) send immediately.
 
-**Line 852** (direct-ready path in `send`): the message could be any type. Replace:
-```typescript
-      this.sendNow(msg)
-```
-with:
-```typescript
-      if (isTerminalCreateMessage(msg)) {
-        this.sendCreateNow(msg)
-      } else {
-        this.sendNow(msg)
-      }
-```
+**Line 852** (direct-ready path in `send`): replace `this.sendNow(msg)` with `this.sendCreateNow(msg)`.
 
-**Line 210** (`setReconcilePendingCreates`): these are always create messages from `heldCreates`. Replace `this.sendNow(msg)` with `this.sendCreateNow(msg)`.
+**Line 210** (`setReconcilePendingCreates`): replace `this.sendNow(msg)` with `this.sendCreateNow(msg)`.
 
-**Line 231** (`clearReconcileCreateHold`): these are always create messages. Replace `this.sendNow(msg)` with `this.sendCreateNow(msg)`.
+**Line 231** (`clearReconcileCreateHold`): replace `this.sendNow(msg)` with `this.sendCreateNow(msg)`.
 
-**Line 320** (ready handler non-reconcile flush): these are always create messages from `preReadyCreateQueue`. Replace `this.sendNow(createMsg)` with `this.sendCreateNow(createMsg)`.
+**Line 320** (ready handler non-reconcile flush): replace `this.sendNow(createMsg)` with `this.sendCreateNow(createMsg)`.
 
-**Line 356** (reconnect re-send): these are always create messages from `inFlightCreates`. Replace `this.sendNow(entry.message)` with `this.sendCreateNow(entry.message)`.
+**Line 356** (reconnect re-send): replace `this.sendNow(entry.message)` with `this.sendCreateNow(entry.message)`.
+
+Non-create paths (line 341 pendingMessages, line 510 hello, line 750/813 ping, line 898 terminal.interest) keep calling `this.sendNow(...)` directly.
 
 6. Clear the stagger on each `ready` frame. At the beginning of the `ready` block (line 263, right after `if (msg.type === 'ready') {`):
 ```typescript
@@ -403,7 +404,9 @@ The stagger affects ALL tests that send `terminal.create` messages through the w
 
 Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client-protocol-reload.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/TerminalView.launchRetry.test.tsx test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx test/e2e/terminal-restart-recovery.test.tsx --config config/vitest/vitest.config.ts`
 
-Expected: PASS. Tests that assert `terminal.create` sends arrive immediately may need to advance fake timers by 450ms to flush the stagger. If any existing test fails because it expects an immediate `terminal.create` but the stagger delays it, advance the test's fake timers by `STAGGER_INTERVAL_MS` (450) to flush the send. Do NOT reduce the stagger interval or disable the stagger for tests — the test must accommodate the real behavior.
+Expected: PASS. Tests that assert `terminal.create` sends arrive immediately may need to advance fake timers by 450ms to flush the stagger. Do NOT reduce the stagger interval or disable the stagger for tests — the test must accommodate the real behavior.
+
+**Important:** Approximately 6 existing tests in `test/unit/client/lib/ws-client.test.ts` send `terminal.create` through the real `WsClient` and assert on `MockWebSocket.instances[N].sent` immediately after `await p` (which flushes microtasks only). The stagger's first send uses `setTimeout(0)` (a macrotask), which does not fire on `await`. These tests need `vi.advanceTimersByTime(0)` (for the first create) or `vi.advanceTimersByTime(450 * N)` (for N creates) added after `await p` and before asserting on `.sent`. The specific tests are: "connect-time queued create flushes after ready" (~line 137), "connect failure then ready flush sends queued create exactly once" (~line 153), "reconnect with unknown terminalId resends in-flight create" (~line 193), "does not resend a create after terminal.created already cleared it" (~line 212), "evicted queued creates" (~line 239), "resends an in-flight create after reconnect" (~line 271). Line numbers may drift; the implementer should identify all tests that send `terminal.create` and assert on `.sent` without advancing timers.
 
 - [ ] **Step 7: Commit the task**
 
@@ -440,32 +443,38 @@ Fixes kata rf0v."
 
 - [ ] **Step 1: Write the failing behavioral test**
 
-Create `test/e2e-browser/specs/restore-create-stagger-rust.spec.ts` following the patterns from `create-protection-restore-storm-rust.spec.ts` and `restore-matrix.spec.ts`:
+Create `test/e2e-browser/specs/restore-create-stagger-rust.spec.ts` following the patterns from `create-protection-restore-storm-rust.spec.ts` and `restore-matrix.spec.ts`. Use `RustServer` from `../helpers/rust-server.js` (NOT `createE2eServerHandle` which does not exist). Register the spec in `RUST_ONLY_SPECS` in `test/e2e-browser/playwright.config.ts`. Seed `panes.defaultNewPane: 'shell'` in the server config so tab-add creates shell terminals directly (the default `'ask'` mode creates picker panes with zero `terminal.create` sends).
 
 ```typescript
 // test/e2e-browser/specs/restore-create-stagger-rust.spec.ts
-import { test, expect } from '@playwright/test'
-import { createE2eServerHandle } from '../helpers/e2e-server'
+import { test, expect } from '../helpers/fixtures.js'
+import { RustServer, type TestServerInfo } from '../helpers/rust-server.js'
+import { TestHarness } from '../helpers/test-harness.js'
 // ... copy per-spec helpers per repo convention (collectLeaves, allLeafTerminalIds,
 //     selectShellIfPickerShowing) from existing specs
 
 test.describe('restore create stagger', () => {
   test('multiple persisted terminal panes space terminal.create sends >=400ms on reload', async () => {
-    // 1. Start an ephemeral Rust server (createE2eServerHandle, rust-only)
-    // 2. Open browser, connect, create 5+ terminal panes (shell mode for simplicity)
-    // 3. Persist state (flush localStorage)
-    // 4. Restart the Rust server (so panes have no live terminals)
-    // 5. Reload the page
-    // 6. Wait for all panes to anchor (allLeafTerminalIds)
-    // 7. Read getSentWsMessagesWithTimestamps()
-    // 8. Filter for type === 'terminal.create'
-    // 9. Assert: for every consecutive pair, timestamp[i+1] - timestamp[i] >= 400
-    // 10. Assert: all panes eventually anchor (no wedge)
+    // 1. Start an ephemeral Rust server: new RustServer({ ... }) with server.start()
+    // 2. Seed config: setupHome callback sets config.json with
+    //    { version: 1, settings: { panes: { defaultNewPane: 'shell' } } }
+    //    (matching create-protection-restore-storm-rust.spec.ts:98-105)
+    // 3. Open browser, connect, create 5+ terminal panes via tab-add
+    // 4. Dismiss the boot tab's picker pane via selectShellIfPickerShowing
+    // 5. Persist state (flush localStorage)
+    // 6. Restart the Rust server (server.restartAbrupt()) so panes have no live terminals
+    // 7. Reload the page
+    // 8. Wait for all panes to anchor (allLeafTerminalIds)
+    // 9. Read getSentWsMessagesWithTimestamps()
+    // 10. Filter for type === 'terminal.create'
+    // 11. Assert: for every consecutive pair, timestamp[i+1] - timestamp[i] >= 400
+    // 12. Assert: all panes eventually anchor (no wedge)
   })
 })
-```
 
-The implementer should follow the existing spec patterns: use `createE2eServerHandle` for an ephemeral Rust server, `TestHarness` for the browser interaction, and per-spec-copied helpers (`collectLeaves`, `allLeafTerminalIds`, `selectShellIfPickerShowing`) per the repo convention (specs copy helpers, don't import across spec boundaries).
+// Also add to RUST_ONLY_SPECS in test/e2e-browser/playwright.config.ts:
+//   /restore-create-stagger-rust\.spec\.ts$/
+```
 
 Also modify `src/lib/test-harness.ts` to add timestamps:
 
@@ -490,7 +499,11 @@ const recordSentWsMessage = (msg: unknown) => {
 ```
 
 ```typescript
-// Line 188: add implementation (after getSentWsMessages)
+// Line 188: modify getSentWsMessages to strip __sentAt (backward compatible)
+    getSentWsMessages: () => sentWsMessages.map((msg) => {
+      const { __sentAt, ...rest } = msg as { __sentAt?: number }
+      return rest
+    }),
     getSentWsMessagesWithTimestamps: () => [...sentWsMessages] as Array<{ __sentAt?: number; type?: string; requestId?: string }>,
 ```
 

--- a/docs/plans/2026-09-08-stagger-restore-launches.md
+++ b/docs/plans/2026-09-08-stagger-restore-launches.md
@@ -230,6 +230,7 @@ export function getTerminalCreateStagger(): TerminalCreateStagger {
 }
 
 export function resetTerminalCreateStaggerForTests(): void {
+  singleton?.clear()
   singleton = null
 }
 ```
@@ -381,12 +382,19 @@ private sendCreateNow(msg: unknown) {
 
 Non-create paths (line 341 pendingMessages, line 510 hello, line 750/813 ping, line 898 terminal.interest) keep calling `this.sendNow(...)` directly.
 
-6. Clear the stagger on each `ready` frame. At the beginning of the `ready` block (line 263, right after `if (msg.type === 'ready') {`):
+6. Clear the stagger on disconnect AND on each `ready` frame. Between a socket disconnect and the next `ready`, stale timer callbacks from the dead socket can fire and call `sendNow` on the replacement socket (which may already be OPEN but not yet `ready`), reopening the crash window. Clear on both transitions:
+
+**On disconnect** — in the `handleDisconnect` method (or wherever `_state` transitions to `disconnected`/`connecting`, e.g. the `onclose`/`onerror` handlers). Add:
 ```typescript
       this.terminalCreateStagger.clear()
 ```
 
-This ensures stale entries from a dead socket are dropped before the ready handler flushes/re-sends creates through the fresh stagger.
+**On `ready`** — at the beginning of the `ready` block (line 263, right after `if (msg.type === 'ready') {`):
+```typescript
+      this.terminalCreateStagger.clear()
+```
+
+The disconnect clear drops stale callbacks that haven't fired yet. The ready clear is a belt-and-suspenders defense: if a callback fired between disconnect and ready (race window), the ready clear drops any remaining entries before the ready handler flushes/re-sends creates through the fresh stagger.
 
 - [ ] **Step 4: Run the focused test**
 
@@ -402,11 +410,11 @@ Review the call sites for consistency. The `sendCreateNow` helper is the single 
 
 The stagger affects ALL tests that send `terminal.create` messages through the ws-client. Run the ws-client suites and the TerminalView lifecycle suites:
 
-Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client-protocol-reload.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/TerminalView.launchRetry.test.tsx test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx test/e2e/terminal-restart-recovery.test.tsx --config config/vitest/vitest.config.ts`
+Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client-protocol-reload.test.ts test/unit/client/lib/ws-client.reconcile.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/TerminalView.launchRetry.test.tsx test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx test/e2e/terminal-restart-recovery.test.tsx --config config/vitest/vitest.config.ts`
 
 Expected: PASS. Tests that assert `terminal.create` sends arrive immediately may need to advance fake timers by 450ms to flush the stagger. Do NOT reduce the stagger interval or disable the stagger for tests — the test must accommodate the real behavior.
 
-**Important:** Approximately 6 existing tests in `test/unit/client/lib/ws-client.test.ts` send `terminal.create` through the real `WsClient` and assert on `MockWebSocket.instances[N].sent` immediately after `await p` (which flushes microtasks only). The stagger's first send uses `setTimeout(0)` (a macrotask), which does not fire on `await`. These tests need `vi.advanceTimersByTime(0)` (for the first create) or `vi.advanceTimersByTime(450 * N)` (for N creates) added after `await p` and before asserting on `.sent`. The specific tests are: "connect-time queued create flushes after ready" (~line 137), "connect failure then ready flush sends queued create exactly once" (~line 153), "reconnect with unknown terminalId resends in-flight create" (~line 193), "does not resend a create after terminal.created already cleared it" (~line 212), "evicted queued creates" (~line 239), "resends an in-flight create after reconnect" (~line 271). Line numbers may drift; the implementer should identify all tests that send `terminal.create` and assert on `.sent` without advancing timers.
+**Important:** Approximately 6 existing tests in `test/unit/client/lib/ws-client.test.ts` AND several tests in `test/unit/client/lib/ws-client.reconcile.test.ts` send `terminal.create` through the real `WsClient` and assert on `MockWebSocket.instances[N].sent` immediately after `await p` (which flushes microtasks only). The stagger's first send uses `setTimeout(0)` (a macrotask), which does not fire on `await`. These tests need `vi.advanceTimersByTime(0)` (for the first create) or `vi.advanceTimersByTime(450 * N)` (for N creates) added after `await p` and before asserting on `.sent`. The specific tests in `ws-client.test.ts` are: "connect-time queued create flushes after ready" (~line 137), "connect failure then ready flush sends queued create exactly once" (~line 153), "reconnect with unknown terminalId resends in-flight create" (~line 193), "does not resend a create after terminal.created already cleared it" (~line 212), "evicted queued creates" (~line 239), "resends an in-flight create after reconnect" (~line 271). In `ws-client.reconcile.test.ts`: "keeps the legacy replay", "releases creates OUTSIDE the pending set", "without paneReconcileV1 the pre-ready flush is byte-identical", and any other test that flushes creates through the real WsClient. Line numbers may drift; the implementer should identify all tests that send `terminal.create` and assert on `.sent` without advancing timers.
 
 - [ ] **Step 7: Commit the task**
 
@@ -467,13 +475,19 @@ test.describe('restore create stagger', () => {
     // 8. Wait for all panes to anchor (allLeafTerminalIds)
     // 9. Read getSentWsMessagesWithTimestamps()
     // 10. Filter for type === 'terminal.create'
-    // 11. Assert: for every consecutive pair, timestamp[i+1] - timestamp[i] >= 400
-    // 12. Assert: all panes eventually anchor (no wedge)
+    // 11. Assert: at least 2 terminal.create messages were captured (cardinality check)
+    // 12. Assert: for every consecutive pair, timestamp[i+1] - timestamp[i] >= 400
+    // 13. Assert: all panes eventually anchor (no wedge)
   })
 })
 
-// Also add to RUST_ONLY_SPECS in test/e2e-browser/playwright.config.ts:
-//   /restore-create-stagger-rust\.spec\.ts$/
+// Also modify test/e2e-browser/playwright.config.ts:
+// 1. Add /restore-create-stagger-rust\.spec\.ts$/ to RUST_ONLY_SPECS array
+//    (excludes it from the match-all chromium project)
+// 2. Add /restore-create-stagger-rust\.spec\.ts$/ to the rust-chromium
+//    project's testMatch array (the explicit list that DOES collect rust-only specs)
+// Both additions are needed — RUST_ONLY_SPECS alone excludes from chromium but
+// does NOT include in rust-chromium (which has its own explicit testMatch list).
 ```
 
 Also modify `src/lib/test-harness.ts` to add timestamps:
@@ -549,7 +563,7 @@ Expected: PASS (existing specs unaffected by the additive `__sentAt` field).
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add src/lib/test-harness.ts test/e2e-browser/helpers/test-harness.ts test/e2e-browser/specs/restore-create-stagger-rust.spec.ts
+git add src/lib/test-harness.ts test/e2e-browser/helpers/test-harness.ts test/e2e-browser/specs/restore-create-stagger-rust.spec.ts test/e2e-browser/playwright.config.ts
 git commit -m "test(e2e): add restore-create-stagger e2e spec and sentWsMessage timestamps
 
 E2E spec persists multiple terminal panes, restarts the server, reloads,

--- a/docs/plans/2026-09-08-stagger-restore-launches.md
+++ b/docs/plans/2026-09-08-stagger-restore-launches.md
@@ -282,8 +282,8 @@ mechanisms. Includes singleton + resetForTests for test isolation."
 
 **Files:**
 - Modify: `src/lib/ws-client.ts` (import stagger, add field, route creates, clear on ready)
-- Test: `test/unit/client/ws-client-protocol-reload.test.ts` (add stagger assertions)
 - Test: `test/unit/client/lib/ws-client.test.ts` (add stagger assertions)
+- Test: `test/unit/client/lib/ws-client.reconcile.test.ts` (modify existing tests for setTimeout(0) stagger)
 
 **Interfaces:**
 - Consumes: `getTerminalCreateStagger()` from Task 1
@@ -336,6 +336,16 @@ describe('WsClient terminal.create stagger', () => {
     // 8. Now deliver the ready frame
     // 9. Assert the create is re-sent through the fresh stagger (via inFlightCreates replay)
   })
+
+  it('cancelCreate retracts a queued create — stagger callback skips the send', () => {
+    // 1. Setup: WsClient with mock WebSocket, connect → ready
+    // 2. Send 3 terminal.create messages (first sends immediately, 2nd/3rd queued)
+    // 3. Call wsClient.cancelCreate(requestId_of_2nd) before the 450ms timer fires
+    // 4. Advance fake timers by 450ms — 2nd create's timer fires but skips send
+    //    (inFlightCreates no longer has the requestId)
+    // 5. Advance fake timers by 450ms — 3rd create sends normally
+    // 6. Assert: mock socket received 1st and 3rd creates, NOT 2nd
+  })
 })
 ```
 
@@ -373,11 +383,20 @@ private terminalCreateStagger: TerminalCreateStagger = getTerminalCreateStagger(
 
 ```typescript
 private sendCreateNow(msg: unknown) {
-  if (isTerminalCreateMessage(msg)) {
-    this.terminalCreateStagger.enqueue(() => this.sendNow(msg))
-  } else {
+  if (!isTerminalCreateMessage(msg)) {
     this.sendNow(msg)
+    return
   }
+  const requestId = (msg as { requestId?: string }).requestId
+  this.terminalCreateStagger.enqueue(() => {
+    // Guard: cancelCreate may have retracted this create while it was
+    // queued in the stagger. If so, skip the send entirely. This preserves
+    // the existing cancelCreate → reconcile-verdict-fold contract from
+    // App.tsx (lines 1203-1207) where stale create parameters are
+    // retracted before the fold-corrected resend.
+    if (requestId && !this.inFlightCreates.has(requestId)) return
+    this.sendNow(msg)
+  })
 }
 ```
 
@@ -395,19 +414,16 @@ private sendCreateNow(msg: unknown) {
 
 Non-create paths (line 341 pendingMessages, line 510 hello, line 750/813 ping, line 898 terminal.interest) keep calling `this.sendNow(...)` directly.
 
-6. Clear the stagger on disconnect AND on each `ready` frame. Between a socket disconnect and the next `ready`, stale timer callbacks from the dead socket can fire and call `sendNow` on the replacement socket (which may already be OPEN but not yet `ready`), reopening the crash window. Clear on both transitions:
+6. Clear the stagger on ALL socket teardown paths AND on each `ready` frame. Between a socket disconnect and the next `ready`, stale timer callbacks from the dead socket can fire and call `sendNow` on the replacement socket (which may already be OPEN but not yet `ready`), reopening the crash window. Clear on both transitions:
 
-**On disconnect** — in the `handleDisconnect` method (or wherever `_state` transitions to `disconnected`/`connecting`, e.g. the `onclose`/`onerror` handlers). Add:
-```typescript
-      this.terminalCreateStagger.clear()
-```
+**On all socket teardown** — in every path that transitions the connection to a non-ready state: the `onclose` handler, the `onerror` handler, the public `disconnect()` method, AND `abandonStaleSocket()` (which detaches `onclose` before opening a replacement — an `onclose`-only clear would miss it). Add `this.terminalCreateStagger.clear()` to each of these paths.
 
 **On `ready`** — at the beginning of the `ready` block (line 263, right after `if (msg.type === 'ready') {`):
 ```typescript
       this.terminalCreateStagger.clear()
 ```
 
-The disconnect clear drops stale callbacks that haven't fired yet. The ready clear is a belt-and-suspenders defense: if a callback fired between disconnect and ready (race window), the ready clear drops any remaining entries before the ready handler flushes/re-sends creates through the fresh stagger.
+The teardown clear drops stale callbacks that haven't fired yet (covering onclose, onerror, disconnect, and abandonStaleSocket). The ready clear is a belt-and-suspenders defense: if a callback fired between teardown and ready (race window), the ready clear drops any remaining entries before the ready handler flushes/re-sends creates through the fresh stagger.
 
 - [ ] **Step 4: Run the focused test**
 
@@ -423,7 +439,7 @@ Review the call sites for consistency. The `sendCreateNow` helper is the single 
 
 The stagger affects ALL tests that send `terminal.create` messages through the ws-client. Run the ws-client suites and the TerminalView lifecycle suites:
 
-Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client-protocol-reload.test.ts test/unit/client/lib/ws-client.reconcile.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/TerminalView.launchRetry.test.tsx test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx test/e2e/terminal-restart-recovery.test.tsx --config config/vitest/vitest.config.ts`
+Run: `npm run test:vitest -- run test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client.reconcile.test.ts test/unit/client/components/TerminalView.lifecycle.test.tsx test/unit/client/components/TerminalView.launchRetry.test.tsx test/unit/client/components/TerminalView.hidden-rebind.test.tsx test/e2e/terminal-create-attach-ordering.test.tsx test/e2e/terminal-restart-recovery.test.tsx --config config/vitest/vitest.config.ts`
 
 Expected: PASS. Tests that assert `terminal.create` sends arrive immediately may need to advance fake timers by 450ms to flush the stagger. Do NOT reduce the stagger interval or disable the stagger for tests — the test must accommodate the real behavior.
 
@@ -483,14 +499,18 @@ test.describe('restore create stagger', () => {
     // 3. Open browser, connect, create 5+ terminal panes via tab-add
     // 4. Dismiss the boot tab's picker pane via selectShellIfPickerShowing
     // 5. Persist state (flush localStorage)
-    // 6. Restart the Rust server (server.restartAbrupt()) so panes have no live terminals
-    // 7. Reload the page
-    // 8. Wait for all panes to anchor (allLeafTerminalIds)
-    // 9. Read getSentWsMessagesWithTimestamps()
-    // 10. Filter for type === 'terminal.create'
-    // 11. Assert: at least 2 terminal.create messages were captured (cardinality check)
-    // 12. Assert: for every consecutive pair, timestamp[i+1] - timestamp[i] >= 400
-    // 13. Assert: all panes eventually anchor (no wedge)
+    // 6. Capture idsBefore = allLeafTerminalIds() (terminal IDs before restart)
+    // 7. Restart the Rust server (server.restartAbrupt()) so panes have no live terminals
+    // 8. Reload the page
+    // 9. Wait for all panes to anchor with NEW terminal IDs:
+    //    poll allLeafTerminalIds() until every pane has a terminalId that is
+    //    non-null AND NOT in idsBefore (proves they're fresh creates, not stale
+    //    pre-restart IDs — matching create-protection-restore-storm-rust.spec.ts pattern)
+    // 10. Read getSentWsMessagesWithTimestamps()
+    // 11. Filter for type === 'terminal.create'
+    // 12. Assert: at least 2 terminal.create messages were captured (cardinality check)
+    // 13. Assert: for every consecutive pair, timestamp[i+1] - timestamp[i] >= 400
+    // 14. Assert: all panes eventually anchor (no wedge)
   })
 })
 

--- a/docs/plans/2026-09-08-stagger-restore-launches.md
+++ b/docs/plans/2026-09-08-stagger-restore-launches.md
@@ -323,6 +323,19 @@ describe('WsClient terminal.create stagger', () => {
     // ... enqueue creates, disconnect, reconnect (ready)
     // ... assert stagger was cleared and re-sent creates start fresh
   })
+
+  it('clears the stagger on disconnect — stale timer does NOT fire on replacement socket before ready', () => {
+    // 1. Setup: WsClient with mock WebSocket, connect → ready
+    // 2. Send a terminal.create (first one fires immediately via setTimeout(0))
+    // 3. Send a second terminal.create (queued, timer armed for 450ms)
+    // 4. Disconnect the socket (simulate onclose)
+    // 5. Connect a replacement mock WebSocket (simulate reconnect, but do NOT deliver ready yet)
+    // 6. Advance fake timers by 450ms — the stale timer from step 3 would fire here
+    // 7. Assert the replacement socket received ZERO terminal.create messages
+    //    (the disconnect clear dropped the pending callback before it could fire)
+    // 8. Now deliver the ready frame
+    // 9. Assert the create is re-sent through the fresh stagger (via inFlightCreates replay)
+  })
 })
 ```
 
@@ -419,7 +432,7 @@ Expected: PASS. Tests that assert `terminal.create` sends arrive immediately may
 - [ ] **Step 7: Commit the task**
 
 ```bash
-git add src/lib/ws-client.ts test/unit/client/lib/ws-client.test.ts
+git add src/lib/ws-client.ts test/unit/client/lib/ws-client.test.ts test/unit/client/lib/ws-client.reconcile.test.ts
 git commit -m "feat(ws): route terminal.create through TerminalCreateStagger in WsClient
 
 All terminal.create wire sends now pass through the TerminalCreateStagger

--- a/src/lib/terminal-create-stagger.ts
+++ b/src/lib/terminal-create-stagger.ts
@@ -1,0 +1,66 @@
+const STAGGER_INTERVAL_MS = 450
+
+/**
+ * TerminalCreateStagger — paces `terminal.create` wire sends at a minimum
+ * interval of STAGGER_INTERVAL_MS so a client reload/reconnect restoring
+ * multiple persisted panes never lands two agent-process spawns within the
+ * same ~100ms window (the known OpenCode/Bun concurrent-launch crash,
+ * upstream anomalyco/opencode#38366).
+ *
+ * Sits inside WsClient at the sendNow level — the single wire-level chokepoint
+ * that all create paths (direct-ready, held-creates flush, ready-handler
+ * flush, reconnect re-send) funnel through. Non-create messages bypass.
+ *
+ * Mirrors the RebindQueue precedent (src/lib/rebind-queue.ts) which paces
+ * freshAgent.create for hidden panes, but operates at the wire level rather
+ * than the view level.
+ */
+export class TerminalCreateStagger {
+  private pending: Array<() => void> = []
+  private lastSendAt = 0
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  enqueue(send: () => void): void {
+    this.pending.push(send)
+    this.pump()
+  }
+
+  clear(): void {
+    this.pending = []
+    if (this.timer !== null) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+    this.lastSendAt = 0
+  }
+
+  resetForTests(): void {
+    this.clear()
+    this.lastSendAt = 0
+  }
+
+  private pump(): void {
+    if (this.timer !== null || this.pending.length === 0) return
+    const elapsed = Date.now() - this.lastSendAt
+    const delay = Math.max(0, STAGGER_INTERVAL_MS - elapsed)
+    this.timer = setTimeout(() => {
+      this.timer = null
+      this.lastSendAt = Date.now()
+      const next = this.pending.shift()
+      if (next) next()
+      this.pump()
+    }, delay)
+  }
+}
+
+let singleton: TerminalCreateStagger | null = null
+
+export function getTerminalCreateStagger(): TerminalCreateStagger {
+  if (!singleton) singleton = new TerminalCreateStagger()
+  return singleton
+}
+
+export function resetTerminalCreateStaggerForTests(): void {
+  singleton?.clear()
+  singleton = null
+}

--- a/src/lib/test-harness.ts
+++ b/src/lib/test-harness.ts
@@ -55,6 +55,7 @@ export interface FreshellTestHarness {
   unregisterTerminalBuffer: (terminalId: string) => void
   getPerfAuditSnapshot: () => PerfAuditSnapshot | null
   getSentWsMessages?: () => unknown[]
+  getSentWsMessagesWithTimestamps?: () => Array<{ __sentAt?: number; type?: string; requestId?: string }>
   clearSentWsMessages?: () => void
   recordSentWsMessage?: (msg: unknown) => void
   recordTerminalWrite?: (event: TerminalWriteEvent) => void
@@ -114,8 +115,11 @@ export function installTestHarness(
   let terminalWriteEventBytes = 0
   const recordSentWsMessage = (msg: unknown) => {
     try {
-      sentWsMessages.push(JSON.parse(JSON.stringify(msg)))
+      const copy = JSON.parse(JSON.stringify(msg))
+      ;(copy as { __sentAt?: number }).__sentAt = Date.now()
+      sentWsMessages.push(copy)
     } catch {
+      ;(msg as { __sentAt?: number }).__sentAt = Date.now()
       sentWsMessages.push(msg)
     }
     if (sentWsMessages.length > 500) sentWsMessages.shift()
@@ -185,7 +189,11 @@ export function installTestHarness(
       terminalModes.delete(terminalId)
     },
     getPerfAuditSnapshot: resolvedGetPerfAuditSnapshot,
-    getSentWsMessages: () => [...sentWsMessages],
+    getSentWsMessages: () => sentWsMessages.map((msg) => {
+      const { __sentAt, ...rest } = msg as { __sentAt?: number }
+      return rest
+    }),
+    getSentWsMessagesWithTimestamps: () => [...sentWsMessages] as Array<{ __sentAt?: number; type?: string; requestId?: string }>,
     clearSentWsMessages: () => {
       sentWsMessages.length = 0
     },

--- a/src/lib/ws-client.ts
+++ b/src/lib/ws-client.ts
@@ -10,6 +10,7 @@ import { WS_PROTOCOL_VERSION } from '@shared/ws-version'
 import type { ReadyCapabilities, ServerMessage, SessionLocator } from '@shared/ws-protocol'
 import type { TerminalInterestSnapshot } from '@/lib/terminal-interest'
 import { createLogger } from '@/lib/client-logger'
+import { getTerminalCreateStagger, type TerminalCreateStagger } from '@/lib/terminal-create-stagger'
 
 const log = createLogger('WsClient')
 
@@ -114,6 +115,11 @@ function isCreateMessage(msg: unknown): msg is CreateClientMessage {
     && candidate.requestId.length > 0
 }
 
+function isTerminalCreateMessage(msg: unknown): boolean {
+  if (!msg || typeof msg !== 'object') return false
+  return (msg as { type?: unknown }).type === 'terminal.create'
+}
+
 function isTerminalAttachMessage(msg: unknown): msg is TerminalAttachClientMessage {
   if (!msg || typeof msg !== 'object') return false
   const candidate = msg as { type?: unknown; terminalId?: unknown }
@@ -166,6 +172,7 @@ export class WsClient {
   // socket; reset on disconnect so a downgraded server is honored.
   private serverCapabilities: NonNullable<ReadyCapabilities> = {}
   private terminalInterestRevision = 0
+  private terminalCreateStagger: TerminalCreateStagger = getTerminalCreateStagger()
 
   // Bumped for every new WebSocket; each socket's handlers capture their
   // generation and no-op once superseded (a late event from an abandoned socket
@@ -207,7 +214,7 @@ export class WsClient {
       if (pendingSet.has(requestId)) continue
       this.heldCreates.delete(requestId)
       if (!this.inFlightCreates.has(requestId)) continue
-      this.sendNow(msg)
+      this.sendCreateNow(msg)
     }
   }
 
@@ -228,7 +235,7 @@ export class WsClient {
     for (const [requestId, msg] of held.entries()) {
       if (!this.inFlightCreates.has(requestId)) continue
       if (this._state === 'ready' && this.ws?.readyState === WebSocket.OPEN) {
-        this.sendNow(msg)
+        this.sendCreateNow(msg)
       } else {
         // Socket gone mid-flush: re-enter the normal pre-ready path so the
         // create is delivered exactly once on the next connection.
@@ -261,6 +268,7 @@ export class WsClient {
     this.lastInboundAt = Date.now()
     this.probeSentAt = null
     if (msg.type === 'ready') {
+      this.terminalCreateStagger.clear()
       this._serverInstanceId = typeof msg.serverInstanceId === 'string' && msg.serverInstanceId.trim()
         ? msg.serverInstanceId
         : undefined
@@ -317,7 +325,7 @@ export class WsClient {
       } else {
         for (const [requestId, createMsg] of this.preReadyCreateQueue.entries()) {
           if (!this.inFlightCreates.has(requestId)) continue
-          this.sendNow(createMsg)
+          this.sendCreateNow(createMsg)
           createRequestIdsFlushed.add(requestId)
         }
       }
@@ -353,7 +361,7 @@ export class WsClient {
             entry.lastResendEpoch = this.reconnectEpoch
             continue
           }
-          this.sendNow(entry.message)
+          this.sendCreateNow(entry.message)
           entry.lastResendEpoch = this.reconnectEpoch
         }
       }
@@ -551,6 +559,7 @@ export class WsClient {
         if (gen !== this.socketGen || this.ws !== socket) return
         this.clearReadyTimeout()
         this.clearLivenessWatch()
+        this.terminalCreateStagger.clear()
         const wasReady = this._state === 'ready'
         const closedBeforeReady = !wasReady
         this._state = 'disconnected'
@@ -631,6 +640,7 @@ export class WsClient {
 
       this.ws.onerror = () => {
         if (gen !== this.socketGen || this.ws !== socket) return
+        this.terminalCreateStagger.clear()
         // onclose will fire with details; if still connecting, reject quickly.
         if (this._state === 'connecting') {
           finishReject(new Error('WebSocket error'))
@@ -691,6 +701,7 @@ export class WsClient {
     this.clearReconnectTimer()
     this.clearReadyTimeout()
     this.clearLivenessWatch()
+    this.terminalCreateStagger.clear()
     // Bump the generation so a torn-down socket's late events are inert.
     this.socketGen += 1
     this.ws?.close()
@@ -770,6 +781,7 @@ export class WsClient {
     this.ws = null
     this._state = 'disconnected'
     this.serverCapabilities = {}
+    this.terminalCreateStagger.clear()
     this.resetReconcileHold({ requeueHeld: true })
     this.clearLivenessWatch()
     // A normal close notifies disconnectHandlers (App flips Redux
@@ -849,7 +861,7 @@ export class WsClient {
         this.heldCreates.set(msg.requestId, msg)
         return
       }
-      this.sendNow(msg)
+      this.sendCreateNow(msg)
       return
     }
 
@@ -941,6 +953,18 @@ export class WsClient {
 
   receiveMessageForTest(msg: ServerMessage): void {
     this.handleIncomingMessage(msg)
+  }
+
+  private sendCreateNow(msg: unknown) {
+    if (!isTerminalCreateMessage(msg)) {
+      this.sendNow(msg)
+      return
+    }
+    const requestId = (msg as { requestId?: string }).requestId
+    this.terminalCreateStagger.enqueue(() => {
+      if (requestId && !this.inFlightCreates.has(requestId)) return
+      this.sendNow(msg)
+    })
   }
 
   private sendNow(msg: unknown) {

--- a/test/e2e-browser/helpers/test-harness.ts
+++ b/test/e2e-browser/helpers/test-harness.ts
@@ -93,6 +93,14 @@ export class TestHarness {
     })
   }
 
+  async getSentWsMessagesWithTimestamps(): Promise<Array<{ __sentAt?: number; type?: string; requestId?: string }>> {
+    return this.page.evaluate(() => {
+      const harness = window.__FRESHELL_TEST_HARNESS__
+      if (!harness) throw new Error('Test harness not installed')
+      return harness.getSentWsMessagesWithTimestamps?.() ?? []
+    })
+  }
+
   async clearSentWsMessages(): Promise<void> {
     await this.page.evaluate(() => {
       const harness = window.__FRESHELL_TEST_HARNESS__

--- a/test/e2e-browser/playwright.config.ts
+++ b/test/e2e-browser/playwright.config.ts
@@ -358,6 +358,10 @@ export const RUST_ONLY_SPECS = [
   // against the REAL Rust server, same raw-WS second-device harness; landed
   // upstream unregistered (silent false green) — registered here.
   /sidebar-status-tier-sort-rust\.spec\.ts$/,
+  // Restore-create stagger (kata rf0v): owns its RustServer (ephemeral port)
+  // for restartAbrupt(); proves terminal.create wire sends are spaced
+  // >=400ms on reload. See docs/plans/2026-09-08-stagger-restore-launches.md
+  /restore-create-stagger-rust\.spec\.ts$/,
 ]
 
 export default defineConfig({
@@ -621,6 +625,10 @@ export default defineConfig({
         // Sidebar status-tier sort e2e pin (see the RUST_ONLY_SPECS entry + the
         // spec's doc comment; owns its RustServer on an ephemeral port).
         /sidebar-status-tier-sort-rust\.spec\.ts$/,
+        // Restore-create stagger (kata rf0v, see RUST_ONLY_SPECS entry):
+        // owns its RustServer on an ephemeral port; proves terminal.create
+        // wire sends are spaced >=400ms on reload.
+        /restore-create-stagger-rust\.spec\.ts$/,
       ],
     },
     // CONTINUITY SMOKE (pre-deploy gate): REAL freshell-server binary + REAL

--- a/test/e2e-browser/specs/restore-create-stagger-rust.spec.ts
+++ b/test/e2e-browser/specs/restore-create-stagger-rust.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Restore-create stagger invariant (kata rf0v): a client reload restoring
+ * multiple persisted terminal panes must space `terminal.create` wire sends
+ * >=400ms apart so no two agent processes spawn within the same ~100ms
+ * window (the known OpenCode/Bun concurrent-launch crash,
+ * upstream anomalyco/opencode#38366).
+ *
+ * Owns its RustServer (ephemeral port, never the user's 3001/3002). Helpers
+ * copied per per-spec-ownership convention (do NOT import across spec
+ * boundaries). Seeds `panes.defaultNewPane:'shell'` so tab-add mounts shell
+ * terminals directly (the default 'ask' creates picker panes with zero
+ * `terminal.create` sends).
+ *
+ * SETUP adaptation (same as create-protection-restore-storm-rust.spec.ts):
+ * the BOOT tab's layout is locked in by PaneLayout's initLayout at first
+ * mount, which races AHEAD of the server-settings hydration, so the first
+ * tab is a picker pane even with the 'shell' seed. We dismiss it with
+ * selectShellIfPickerShowing and gate the setup on Redux showing the
+ * hydrated 'shell' value so tabs 2..N mount terminals directly.
+ *
+ * The TerminalCreateStagger (src/lib/terminal-create-stagger.ts, wired in
+ * WsClient per Task 2) paces terminal.create wire sends at 450ms minimum
+ * intervals. This spec proves that pacing end-to-end by reading the
+ * `__sentAt` timestamps from the test harness's sentWsMessages recording.
+ */
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { test, expect } from '../helpers/fixtures.js'
+import { RustServer, type TestServerInfo } from '../helpers/rust-server.js'
+import { TestHarness } from '../helpers/test-harness.js'
+import type { Page } from '@playwright/test'
+
+const PANE_COUNT = 6
+
+function collectLeaves(node: any): any[] {
+  if (!node) return []
+  if (node.type === 'leaf') return [node]
+  if (node.type === 'split') return (node.children ?? []).flatMap(collectLeaves)
+  return []
+}
+
+async function waitForWsReady(page: Page, timeoutMs = 60_000): Promise<void> {
+  await expect(async () => {
+    const status = await page.evaluate(
+      () => (window as any).__FRESHELL_TEST_HARNESS__?.getWsReadyState())
+    expect(status).toBe('ready')
+  }).toPass({ timeout: timeoutMs })
+}
+
+/** Dismiss the initial pane-type picker by choosing the first visible shell.
+ *  (Copied donor helper: create-protection-restore-storm-rust.spec.ts.) */
+async function selectShellIfPickerShowing(page: Page): Promise<void> {
+  const picker = page.getByRole('toolbar', { name: /pane type picker/i }).last()
+  if (!(await picker.isVisible().catch(() => false))) return
+  for (const name of ['Shell', 'WSL', 'CMD', 'PowerShell', 'Bash']) {
+    const option = picker.getByRole('button', { name: new RegExp(`^${name}$`, 'i') })
+    if (await option.isVisible().catch(() => false)) {
+      await option.click({ force: true })
+      return
+    }
+  }
+}
+
+/** terminalId of every leaf across every tab (poll-friendly). */
+async function allLeafTerminalIds(harness: TestHarness): Promise<(string | null)[]> {
+  const state = await harness.getState()
+  const ids: (string | null)[] = []
+  for (const tab of state.tabs.tabs) {
+    for (const leaf of collectLeaves(state.panes.layouts[tab.id])) {
+      ids.push(leaf?.content?.terminalId ?? null)
+    }
+  }
+  return ids
+}
+
+test.describe('restore create stagger', () => {
+  test.setTimeout(300_000)
+
+  test('multiple persisted terminal panes space terminal.create sends >=400ms on reload', async ({ page, e2eServerKind }) => {
+    expect(e2eServerKind).toBe('rust')
+    const server = new RustServer({
+      env: { RUST_LOG: 'info' },
+      // Tab-add must mount shell terminals directly; the default
+      // panes.defaultNewPane:'ask' creates PICKER panes (zero creates).
+      // setupHome runs before the wizard-bypass write, which spread-preserves
+      // this seed (rust-server.ts:184-195); it re-runs on every boot, so the
+      // full-file write is idempotent. Value must be EXACT lowercase 'shell'
+      // (an invalid value silently discards the whole settings tree).
+      setupHome: async (homeDir) => {
+        const dir = path.join(homeDir, '.freshell')
+        await fs.mkdir(dir, { recursive: true })
+        await fs.writeFile(path.join(dir, 'config.json'), JSON.stringify({
+          version: 1,
+          settings: { panes: { defaultNewPane: 'shell' } },
+        }, null, 2))
+      },
+    })
+    const info: TestServerInfo = await server.start()
+    try {
+      // Belt-and-suspenders: the seed actually took (converts a silent
+      // settings-tree fallback into a crisp failure here).
+      const settingsRes = await fetch(`${info.baseUrl}/api/settings`, {
+        headers: { 'x-auth-token': info.token },
+      })
+      expect(((await settingsRes.json()) as any)?.panes?.defaultNewPane).toBe('shell')
+
+      await page.goto(`${info.baseUrl}/?token=${info.token}&e2e=1`)
+      const harness = new TestHarness(page)
+      await harness.waitForHarness()
+      await harness.waitForConnection()
+      await waitForWsReady(page)
+
+      // Gate the setup on the hydrated setting: tabs created via tab-add
+      // must mount shell terminals directly (PaneLayout reads Redux
+      // settings at initLayout time).
+      await expect.poll(async () => {
+        const settings = await harness.getSettings()
+        return settings?.panes?.defaultNewPane ?? null
+      }, { timeout: 30_000 }).toBe('shell')
+
+      // The BOOT tab's layout was locked before hydration (see file doc
+      // comment), so it is a picker pane: dismiss it into a shell terminal.
+      await selectShellIfPickerShowing(page)
+      await expect(page.locator('.xterm').first()).toBeVisible({ timeout: 30_000 })
+
+      // Create additional terminal panes via tab-add. The stagger paces
+      // each terminal.create at 450ms, so we wait for each terminal to
+      // anchor before the next tab-add.
+      const addButton = page.locator('[data-context="tab-add"]')
+      for (let i = 1; i < PANE_COUNT; i++) {
+        await addButton.click()
+        await harness.waitForTabCount(i + 1)
+        await expect.poll(async () => {
+          const ids = await allLeafTerminalIds(harness)
+          return ids.length >= i + 1 && ids.every((id) => id !== null)
+        }, { timeout: 30_000 }).toBe(true)
+      }
+
+      // Persist state (flush localStorage so the reload restores all panes).
+      await page.evaluate(() => {
+        (window as any).__FRESHELL_TEST_HARNESS__?.dispatch({ type: 'persist/flushNow' })
+      })
+
+      // Capture terminal IDs before restart — after reload, every pane
+      // must anchor with a NEW terminal ID (proves fresh creates, not
+      // stale pre-restart IDs).
+      const idsBefore = (await allLeafTerminalIds(harness)) as string[]
+      expect(idsBefore).toHaveLength(PANE_COUNT)
+
+      // --- SIGKILL + reboot on same home/port/token; reload so the client
+      // mounts every persisted tab at once (the restore thundering herd). ---
+      await server.restartAbrupt()
+      await page.reload({ waitUntil: 'domcontentloaded' })
+      await harness.waitForHarness()
+      await harness.waitForConnection()
+      await waitForWsReady(page)
+
+      // ALL panes recover: same tab count, every leaf re-anchors to a NEW
+      // live terminal. The stagger paces the restore creates at 450ms, so
+      // PANE_COUNT panes take ~PANE_COUNT*450ms to fully restore.
+      await expect.poll(() => harness.getTabCount(), { timeout: 60_000 }).toBe(PANE_COUNT)
+      await expect.poll(async () => {
+        const ids = await allLeafTerminalIds(harness)
+        return ids.length === PANE_COUNT
+          && ids.every((id) => id !== null && !idsBefore.includes(id as string))
+      }, { timeout: 120_000 }).toBe(true)
+
+      // Read sent WS messages with timestamps (only post-reload sends are
+      // captured — the harness is reinstalled fresh on page reload).
+      const sentMessages = await harness.getSentWsMessagesWithTimestamps()
+      const creates = sentMessages.filter(
+        (m: any) => m?.type === 'terminal.create',
+      ) as Array<{ __sentAt?: number; type?: string; requestId?: string }>
+
+      // Cardinality check — prevents vacuous pass (zero creates captured
+      // would make the spacing assertion trivially true).
+      expect(creates.length).toBeGreaterThanOrEqual(2)
+
+      // Assert >=400ms spacing between consecutive terminal.create wire
+      // sends. The stagger interval is 450ms; we assert >=400ms to allow
+      // for minor timer jitter while still proving the ~100ms crash window
+      // is never entered.
+      const timestamps = creates.map((m) => m.__sentAt as number)
+      for (let i = 1; i < timestamps.length; i++) {
+        const gap = timestamps[i] - timestamps[i - 1]
+        expect(
+          gap,
+          `terminal.create #${i} should be >=400ms after #${i - 1} (got ${gap}ms)`,
+        ).toBeGreaterThanOrEqual(400)
+      }
+
+      // All panes eventually anchored (no wedge) — verified by the poll
+      // above: every pane has a non-null terminal ID not in idsBefore.
+    } finally {
+      await server.stop().catch(() => {})
+    }
+  })
+})

--- a/test/setup/dom.ts
+++ b/test/setup/dom.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, vi } from 'vitest'
 import { enableMapSet } from 'immer'
 import { resetWsClientForTests } from '@/lib/ws-client'
 import { resetTerminalReleaseMarks } from '@/lib/terminal-release-marks'
+import { resetTerminalCreateStaggerForTests } from '@/lib/terminal-create-stagger'
 
 enableMapSet()
 
@@ -125,6 +126,7 @@ beforeEach(() => {
 afterEach(() => {
   resetWsClientForTests()
   resetTerminalReleaseMarks()
+  resetTerminalCreateStaggerForTests()
   errorSpy?.mockRestore()
   errorSpy = null
 

--- a/test/unit/client/lib/terminal-create-stagger.test.ts
+++ b/test/unit/client/lib/terminal-create-stagger.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TerminalCreateStagger,
+  getTerminalCreateStagger,
+  resetTerminalCreateStaggerForTests,
+} from '@/lib/terminal-create-stagger'
+
+describe('TerminalCreateStagger', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetTerminalCreateStaggerForTests()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends the first message immediately (no prior send)', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => { sent.push('a') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+  })
+
+  it('spaces subsequent sends by STAGGER_INTERVAL_MS (450ms)', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => { sent.push('a') })
+    stagger.enqueue(() => { sent.push('b') })
+    stagger.enqueue(() => { sent.push('c') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+    vi.advanceTimersByTime(450)
+    expect(sent).toEqual(['a', 'b'])
+    vi.advanceTimersByTime(450)
+    expect(sent).toEqual(['a', 'b', 'c'])
+  })
+
+  it('no two sends land within the same 100ms window', () => {
+    const stagger = new TerminalCreateStagger()
+    const timestamps: number[] = []
+    for (let i = 0; i < 5; i++) {
+      stagger.enqueue(() => { timestamps.push(Date.now()) })
+    }
+    vi.advanceTimersByTime(0)
+    vi.advanceTimersByTime(450)
+    vi.advanceTimersByTime(450)
+    vi.advanceTimersByTime(450)
+    vi.advanceTimersByTime(450)
+    expect(timestamps).toHaveLength(5)
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i] - timestamps[i - 1]).toBeGreaterThanOrEqual(450)
+    }
+  })
+
+  it('clear drops all pending sends and resets lastSendAt', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => { sent.push('a') })
+    stagger.enqueue(() => { sent.push('b') })
+    stagger.enqueue(() => { sent.push('c') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+    stagger.clear()
+    vi.advanceTimersByTime(1000)
+    expect(sent).toEqual(['a'])
+    // After clear(), lastSendAt is reset — next send goes immediately
+    stagger.enqueue(() => { sent.push('d') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a', 'd'])
+  })
+
+  it('resetForTests clears pending and resets lastSendAt', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => { sent.push('a') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+    stagger.resetForTests()
+    stagger.enqueue(() => { sent.push('b') })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a', 'b'])
+  })
+
+  it('getTerminalCreateStagger returns a singleton reset by resetTerminalCreateStaggerForTests', () => {
+    const first = getTerminalCreateStagger()
+    expect(getTerminalCreateStagger()).toBe(first)
+    resetTerminalCreateStaggerForTests()
+    expect(getTerminalCreateStagger()).not.toBe(first)
+  })
+
+  it('handles enqueue from within a send callback (pump re-entrancy)', () => {
+    const stagger = new TerminalCreateStagger()
+    const sent: string[] = []
+    stagger.enqueue(() => {
+      sent.push('a')
+      stagger.enqueue(() => { sent.push('b') })
+    })
+    vi.advanceTimersByTime(0)
+    expect(sent).toEqual(['a'])
+    vi.advanceTimersByTime(450)
+    expect(sent).toEqual(['a', 'b'])
+  })
+})

--- a/test/unit/client/lib/ws-client.reconcile.test.ts
+++ b/test/unit/client/lib/ws-client.reconcile.test.ts
@@ -116,9 +116,11 @@ describe('WsClient pane-reconcile capability', () => {
     c.send({ type: 'terminal.create', requestId: 'cr-1', mode: 'shell' } as any)
 
     await connectAndReady(c, { /* no capabilities */ })
+    vi.advanceTimersByTime(0)
     MockWebSocket.instances[0]._close(1006, 'drop-after-create')
 
     const reconnectInstance = await connectAndReady(c, { /* no capabilities */ })
+    vi.advanceTimersByTime(0)
     const creates = framesOf(reconnectInstance).filter((f) => f.type === 'terminal.create')
     expect(creates).toHaveLength(1)
   })
@@ -133,6 +135,7 @@ describe('WsClient pane-reconcile capability', () => {
 
     // Downgraded server: reconnect ready has no capabilities. Legacy replay must fire.
     const reconnectInstance = await connectAndReady(c, { /* no capabilities */ })
+    vi.advanceTimersByTime(0)
     const creates = framesOf(reconnectInstance).filter((f) => f.type === 'terminal.create')
     expect(creates).toHaveLength(1)
   })
@@ -148,6 +151,7 @@ describe('WsClient pane-reconcile capability', () => {
     expect(framesOf(instance).filter((f) => f.type === 'terminal.create')).toHaveLength(0)
 
     vi.advanceTimersByTime(RECONCILE_VERDICT_WAIT_MS + 50)
+    vi.advanceTimersByTime(0)
     const creates = framesOf(instance).filter((f) => f.type === 'terminal.create')
     expect(creates).toEqual([
       expect.objectContaining({ type: 'terminal.create', requestId: 'cr-new' }),
@@ -176,6 +180,7 @@ describe('WsClient pane-reconcile capability', () => {
 
       const instance = await connectAndReady(c, { capabilities: { paneReconcileV1: true } })
       c.setReconcilePendingCreates(['req-a'])
+      vi.advanceTimersByTime(0)
 
       const creates = framesOf(instance).filter((f) => f.type === 'terminal.create')
       expect(creates).toEqual([
@@ -190,6 +195,7 @@ describe('WsClient pane-reconcile capability', () => {
 
       c.send({ type: 'terminal.create', requestId: 'req-pending' } as any)
       c.send({ type: 'terminal.create', requestId: 'req-other' } as any)
+      vi.advanceTimersByTime(0)
 
       const creates = framesOf(instance).filter((f) => f.type === 'terminal.create')
       expect(creates).toEqual([
@@ -205,6 +211,7 @@ describe('WsClient pane-reconcile capability', () => {
       const instance = await connectAndReady(c, { capabilities: { paneReconcileV1: true } })
       c.cancelCreate('req-a')
       c.clearReconcileCreateHold()
+      vi.advanceTimersByTime(0)
 
       const creates = framesOf(instance).filter((f) => f.type === 'terminal.create')
       expect(creates.filter((f) => f.requestId === 'req-a')).toHaveLength(0)
@@ -223,6 +230,7 @@ describe('WsClient pane-reconcile capability', () => {
       expect(framesOf(instance).filter((f) => f.type === 'terminal.create')).toHaveLength(0)
 
       vi.advanceTimersByTime(RECONCILE_VERDICT_WAIT_MS + 50)
+      vi.advanceTimersByTime(0)
       const creates = framesOf(instance).filter((f) => f.type === 'terminal.create')
       expect(creates).toEqual([
         expect.objectContaining({ type: 'terminal.create', requestId: 'req-a' }),
@@ -234,6 +242,7 @@ describe('WsClient pane-reconcile capability', () => {
       c.send({ type: 'terminal.create', requestId: 'req-a' } as any)
 
       const instance = await connectAndReady(c, { /* no capabilities */ })
+      vi.advanceTimersByTime(0)
       const creates = framesOf(instance).filter((f) => f.type === 'terminal.create')
       expect(creates).toEqual([
         expect.objectContaining({ type: 'terminal.create', requestId: 'req-a' }),
@@ -251,6 +260,7 @@ describe('WsClient pane-reconcile capability', () => {
       // Downgraded server: no capability, the create flushes via the normal
       // preReadyCreateQueue path — exactly once, never a duplicate.
       const reconnectInstance = await connectAndReady(c, { /* no capabilities */ })
+      vi.advanceTimersByTime(0)
       const creates = framesOf(reconnectInstance).filter((f) => f.type === 'terminal.create')
       expect(creates).toEqual([
         expect.objectContaining({ type: 'terminal.create', requestId: 'req-a' }),

--- a/test/unit/client/lib/ws-client.test.ts
+++ b/test/unit/client/lib/ws-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { WsClient, getWsClient, resetWsClientForTests } from '../../../../src/lib/ws-client'
 import { WS_PROTOCOL_VERSION } from '../../../../shared/ws-protocol'
+import { resetTerminalCreateStaggerForTests } from '@/lib/terminal-create-stagger'
 
 class MockWebSocket {
   static OPEN = 1
@@ -142,6 +143,7 @@ describe('WsClient.connect', () => {
     MockWebSocket.instances[0]._open()
     MockWebSocket.instances[0]._message({ type: 'ready' })
     await p
+    vi.advanceTimersByTime(0)
     const flushed = MockWebSocket.instances[0].sent.map((x) => JSON.parse(x))
     expect(flushed).toContainEqual(expect.objectContaining({
       type: 'terminal.create',
@@ -163,6 +165,7 @@ describe('WsClient.connect', () => {
     MockWebSocket.instances[1]._open()
     MockWebSocket.instances[1]._message({ type: 'ready' })
     await p2
+    vi.advanceTimersByTime(0)
 
     const sent = MockWebSocket.instances[1].sent.map((x) => JSON.parse(x))
     expect(sent.filter((m) => m.type === 'terminal.create' && m.requestId === 'queued-fail-then-ready')).toHaveLength(1)
@@ -198,12 +201,14 @@ describe('WsClient.connect', () => {
     MockWebSocket.instances[0]._open()
     MockWebSocket.instances[0]._message({ type: 'ready' })
     await p1
+    vi.advanceTimersByTime(0)
     MockWebSocket.instances[0]._close(1006, 'drop-after-create')
 
     const p2 = c.connect()
     MockWebSocket.instances[1]._open()
     MockWebSocket.instances[1]._message({ type: 'ready' })
     await p2
+    vi.advanceTimersByTime(0)
 
     const sent = MockWebSocket.instances[1].sent.map((x) => JSON.parse(x))
     expect(sent.filter((m) => m.type === 'terminal.create' && m.requestId === 'reconnect-unknown-1')).toHaveLength(1)
@@ -217,6 +222,7 @@ describe('WsClient.connect', () => {
     MockWebSocket.instances[0]._open()
     MockWebSocket.instances[0]._message({ type: 'ready' })
     await p1
+    vi.advanceTimersByTime(0)
     MockWebSocket.instances[0]._message({
       type: 'terminal.created',
       requestId: 'created-before-reconnect',
@@ -247,6 +253,7 @@ describe('WsClient.connect', () => {
     MockWebSocket.instances[0]._open()
     MockWebSocket.instances[0]._message({ type: 'ready' })
     await p1
+    vi.advanceTimersByTime(0)
 
     const firstCreates = MockWebSocket.instances[0].sent
       .map((x) => JSON.parse(x))
@@ -260,6 +267,7 @@ describe('WsClient.connect', () => {
     MockWebSocket.instances[1]._open()
     MockWebSocket.instances[1]._message({ type: 'ready' })
     await p2
+    vi.advanceTimersByTime(0)
 
     const secondCreates = MockWebSocket.instances[1].sent
       .map((x) => JSON.parse(x))
@@ -280,12 +288,14 @@ describe('WsClient.connect', () => {
     MockWebSocket.instances[0]._open()
     MockWebSocket.instances[0]._message({ type: 'ready' })
     await p1
+    vi.advanceTimersByTime(0)
     MockWebSocket.instances[0]._close(1006, 'drop-after-create')
 
     const p2 = c.connect()
     MockWebSocket.instances[1]._open()
     MockWebSocket.instances[1]._message({ type: 'ready' })
     await p2
+    vi.advanceTimersByTime(0)
 
     const secondCreates = MockWebSocket.instances[1].sent
       .map((x) => JSON.parse(x))
@@ -754,5 +764,165 @@ describe('WsClient.sendTerminalInterest', () => {
       .filter((m) => m.type === 'terminal.interest')
     expect(interest).toHaveLength(1)
     expect(interest[0].revision).toBe(1)
+  })
+})
+
+describe('WsClient terminal.create stagger', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockWebSocket.instances = []
+    // @ts-expect-error - test override
+    globalThis.WebSocket = MockWebSocket
+    localStorage.setItem('freshell.auth-token', 't')
+    ;(window as any).setTimeout = globalThis.setTimeout
+    ;(window as any).clearTimeout = globalThis.clearTimeout
+    resetTerminalCreateStaggerForTests()
+  })
+
+  afterEach(() => {
+    resetWsClientForTests()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  const typesOf = (instance: MockWebSocket) =>
+    instance.sent.map((x) => JSON.parse(x))
+  const createsOf = (instance: MockWebSocket) =>
+    typesOf(instance).filter((m: any) => m.type === 'terminal.create')
+
+  it('paces terminal.create sends 450ms apart when multiple are ready', async () => {
+    const c = new WsClient('ws://example/ws')
+    const p = c.connect()
+    MockWebSocket.instances[0]._open()
+    MockWebSocket.instances[0]._message({ type: 'ready' })
+    await p
+
+    c.send({ type: 'terminal.create', requestId: 'tc-1', mode: 'shell' } as any)
+    c.send({ type: 'terminal.create', requestId: 'tc-2', mode: 'shell' } as any)
+    c.send({ type: 'terminal.create', requestId: 'tc-3', mode: 'shell' } as any)
+
+    vi.advanceTimersByTime(0)
+    expect(createsOf(MockWebSocket.instances[0]).map((m) => m.requestId)).toEqual(['tc-1'])
+
+    vi.advanceTimersByTime(450)
+    expect(createsOf(MockWebSocket.instances[0]).map((m) => m.requestId)).toEqual(['tc-1', 'tc-2'])
+
+    vi.advanceTimersByTime(450)
+    expect(createsOf(MockWebSocket.instances[0]).map((m) => m.requestId)).toEqual(['tc-1', 'tc-2', 'tc-3'])
+  })
+
+  it('non-create messages bypass the stagger (sent immediately)', async () => {
+    const c = new WsClient('ws://example/ws')
+    const p = c.connect()
+    MockWebSocket.instances[0]._open()
+    MockWebSocket.instances[0]._message({ type: 'ready' })
+    await p
+
+    c.send({ type: 'terminal.create', requestId: 'tc-1', mode: 'shell' } as any)
+    c.send({ type: 'terminal.input', terminalId: 'term-x', data: 'ls\n' } as any)
+
+    // terminal.input bypasses the stagger — sent immediately, before the
+    // terminal.create's setTimeout(0) fires.
+    const inputsBeforeAdvance = typesOf(MockWebSocket.instances[0])
+      .filter((m: any) => m.type === 'terminal.input')
+    expect(inputsBeforeAdvance).toHaveLength(1)
+
+    vi.advanceTimersByTime(0)
+    expect(createsOf(MockWebSocket.instances[0]).map((m) => m.requestId)).toEqual(['tc-1'])
+  })
+
+  it('clears the stagger on ready (no stale sends from dead socket)', async () => {
+    const c = new WsClient('ws://example/ws')
+    const p1 = c.connect()
+    MockWebSocket.instances[0]._open()
+    MockWebSocket.instances[0]._message({ type: 'ready' })
+    await p1
+
+    // Send 2 creates: 1st at t=0, 2nd at t=450 — lastSendAt is set to 450.
+    c.send({ type: 'terminal.create', requestId: 'tc-1', mode: 'shell' } as any)
+    c.send({ type: 'terminal.create', requestId: 'tc-2', mode: 'shell' } as any)
+    vi.advanceTimersByTime(450)
+    expect(createsOf(MockWebSocket.instances[0]).map((m) => m.requestId)).toEqual(['tc-1', 'tc-2'])
+
+    // Disconnect: onclose clears the stagger (lastSendAt → 0).
+    MockWebSocket.instances[0]._close(1006, 'drop')
+
+    // Reconnect: ready clears the stagger again (belt-and-suspenders).
+    const p2 = c.connect()
+    MockWebSocket.instances[1]._open()
+    MockWebSocket.instances[1]._message({ type: 'ready' })
+    await p2
+
+    // The reconnect replay re-sends tc-1 then tc-2 through the fresh stagger.
+    // Because lastSendAt was reset to 0, tc-1 sends immediately (setTimeout(0)).
+    // Without the clear, lastSendAt=450 and Date.now()=450, so elapsed=0 and
+    // tc-1 would wait 450ms instead of sending immediately.
+    vi.advanceTimersByTime(0)
+    const sentAfter0 = createsOf(MockWebSocket.instances[1])
+    expect(sentAfter0).toHaveLength(1)
+    expect(sentAfter0[0].requestId).toBe('tc-1')
+
+    vi.advanceTimersByTime(450)
+    expect(createsOf(MockWebSocket.instances[1]).map((m) => m.requestId)).toEqual(['tc-1', 'tc-2'])
+  })
+
+  it('clears the stagger on disconnect — stale timer does NOT fire on replacement socket before ready', async () => {
+    const c = new WsClient('ws://example/ws')
+    const p1 = c.connect()
+    MockWebSocket.instances[0]._open()
+    MockWebSocket.instances[0]._message({ type: 'ready' })
+    await p1
+
+    // Send 2 creates: 1st sends via setTimeout(0), 2nd arms a 450ms timer.
+    c.send({ type: 'terminal.create', requestId: 'tc-1', mode: 'shell' } as any)
+    c.send({ type: 'terminal.create', requestId: 'tc-2', mode: 'shell' } as any)
+    vi.advanceTimersByTime(0)
+    expect(createsOf(MockWebSocket.instances[0]).map((m) => m.requestId)).toEqual(['tc-1'])
+
+    // Disconnect: onclose clears the stagger, cancelling tc-2's 450ms timer.
+    MockWebSocket.instances[0]._close(1006, 'drop')
+
+    // Open a replacement socket but do NOT deliver ready yet.
+    const p2 = c.connect()
+    MockWebSocket.instances[1]._open()
+
+    // Advance past the 450ms window — the stale timer from the dead socket
+    // would fire here if the onclose clear hadn't cancelled it.
+    vi.advanceTimersByTime(450)
+    expect(createsOf(MockWebSocket.instances[1])).toHaveLength(0)
+
+    // Now deliver ready — the in-flight creates replay through the fresh stagger.
+    MockWebSocket.instances[1]._message({ type: 'ready' })
+    await p2
+
+    vi.advanceTimersByTime(0)
+    expect(createsOf(MockWebSocket.instances[1]).map((m) => m.requestId)).toContain('tc-1')
+  })
+
+  it('cancelCreate retracts a queued create — stagger callback skips the send', async () => {
+    const c = new WsClient('ws://example/ws')
+    const p = c.connect()
+    MockWebSocket.instances[0]._open()
+    MockWebSocket.instances[0]._message({ type: 'ready' })
+    await p
+
+    // Send 3 creates: 1st sends via setTimeout(0), 2nd and 3rd queue behind it.
+    c.send({ type: 'terminal.create', requestId: 'tc-1', mode: 'shell' } as any)
+    c.send({ type: 'terminal.create', requestId: 'tc-2', mode: 'shell' } as any)
+    c.send({ type: 'terminal.create', requestId: 'tc-3', mode: 'shell' } as any)
+    vi.advanceTimersByTime(0)
+    expect(createsOf(MockWebSocket.instances[0]).map((m) => m.requestId)).toEqual(['tc-1'])
+
+    // Cancel tc-2 while it is queued in the stagger (before its 450ms timer fires).
+    c.cancelCreate('tc-2')
+
+    // Advance 450ms — tc-2's stagger callback fires but skips the send
+    // (inFlightCreates no longer has tc-2).
+    vi.advanceTimersByTime(450)
+    expect(createsOf(MockWebSocket.instances[0]).map((m) => m.requestId)).toEqual(['tc-1'])
+
+    // tc-3 sends after another 450ms.
+    vi.advanceTimersByTime(450)
+    expect(createsOf(MockWebSocket.instances[0]).map((m) => m.requestId)).toEqual(['tc-1', 'tc-3'])
   })
 })


### PR DESCRIPTION
## What

Staggers `terminal.create` wire sends 450ms apart at the `WsClient.sendNow` level — the single wire-level chokepoint all create paths funnel through. This prevents the known OpenCode/Bun concurrent-launch crash (upstream anomalyco/opencode#38366) when a client reload/reconnect restores multiple persisted agent panes simultaneously.

## Why

On 2026-09-08, a phone client hit a ServerBuildCheck reload and restored 3 persisted panes in under a second. Two opencode panes spawned 93ms apart, triggering a Bun `SIGILL` crash (identical instruction address across all crashes). The fix paces restore-driven creates so no two agent processes spawn within the same ~100ms crash window.

## How

- New `TerminalCreateStagger` module (`src/lib/terminal-create-stagger.ts`) — paces sends at 450ms minimum interval using `setTimeout`
- Wired into `WsClient` at all 5 `terminal.create` send paths (direct-ready, held-creates flush, ready-handler flush, reconnect re-send, reconcile-pending release)
- `freshAgent.create` and non-create messages bypass the stagger entirely (type-filtered in `sendCreateNow`)
- Cleared on all 4 socket teardown paths (onclose, onerror, disconnect, abandonStaleSocket) + each `ready` frame
- `cancelCreate` guard skips cancelled creates when their timer fires (preserves the reconcile-verdict-fold contract from App.tsx)

## Tests

- 7 unit tests for the stagger module (timing, clear, singleton, re-entrancy)
- 5 new ws-client tests (stagger spacing, non-create bypass, disconnect clear, cancelCreate retraction, ready clear)
- Modified ~6 existing ws-client tests + reconcile tests for `setTimeout(0)` first-send behavior
- 1 new e2e spec (`restore-create-stagger-rust.spec.ts`) — persists 5+ panes, restarts server, reloads, asserts ≥400ms spacing with cardinality check and new-terminal-ID sync
- Full-suite gate PASSED

## Kata

- Fixes [rf0v](https://kata): Stagger restore-driven terminal.create launches on reload/reconnect
- Pre-existing failure [ecsx](https://kata): Sidebar.mobile.test.tsx (unrelated, on main)