### PR TITLE
test(sidebar): align mobile session-row assertions with #753 denser spacing

### DIFF
--- a/test/unit/client/components/Sidebar.mobile.test.tsx
+++ b/test/unit/client/components/Sidebar.mobile.test.tsx
@@ -169,7 +169,7 @@ describe('Sidebar mobile touch targets', () => {
     vi.useRealTimers()
   })
 
-  it('session item button has py-3 md:py-2 classes for mobile touch target', async () => {
+  it('session item button has py-2 md:py-1.5 classes for mobile-first density', async () => {
     const projects: ProjectGroup[] = [
       {
         projectPath: '/home/user/project',
@@ -194,8 +194,8 @@ describe('Sidebar mobile touch targets', () => {
 
     const sessionButton = screen.getByText('Test session').closest('button')
     expect(sessionButton).not.toBeNull()
-    expect(sessionButton!.className).toMatch(/py-3/)
-    expect(sessionButton!.className).toMatch(/md:py-2/)
+    expect(sessionButton!.className).toMatch(/py-2/)
+    expect(sessionButton!.className).toMatch(/md:py-1\.5/)
   })
 
   it('nav buttons have py-2.5 md:py-1.5 and min-h-11 md:min-h-0 classes for mobile touch target', () => {


### PR DESCRIPTION
Summary:
- `Sidebar.mobile.test.tsx` still asserted the pre-#753 session-row padding (`py-3 md:py-2`); #753 intentionally tightened it to `py-2 md:py-1.5` for a denser sidebar but did not update the test, leaving `origin/main` red (every base gate / PR gate fails on it).
- This updates the two assertions and the test name to the new intended classes. Test-only change.

Evidence:
- RED on base: `npm run test:vitest -- run test/unit/client/components/Sidebar.mobile.test.tsx` failed with `expected '... py-2 md:py-1.5 ...' to match /py-3/` (also failed the clean-worktree cloud base gate at 225102808).
- GREEN after: same command passes 3/3.

Found during the pre-worktree green-base gate for the terminal Escape-key run; recorded in that run's out-of-scope findings.