### PR TITLE
fix: Sidebar search input collapses to 1 char at high --ui-scale (Electron)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -795,41 +795,40 @@ export default function Sidebar({
       </div>
 
       {/* Search */}
-      <div className="px-3 pb-3">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+      <div className="px-[12px] pb-3">
+        <div className="sidebar-search-row flex min-h-[44px] items-center gap-[4px] overflow-x-clip rounded-md bg-muted/50 focus-within:ring-1 focus-within:ring-border md:min-h-0 md:h-8">
+          <Search className="ml-[10px] h-[14px] w-[14px] shrink-0 text-muted-foreground" />
           <input
             type="text"
             placeholder="Search..."
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
             aria-busy={showSearchLoading}
-            className="w-full h-8 pl-8 pr-36 text-sm bg-muted/50 border-0 rounded-md placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-border"
+            className="min-w-0 flex-1 self-stretch border-0 bg-transparent text-sm placeholder:text-muted-foreground/60 focus:outline-none"
           />
-          <div className="absolute right-2 top-1/2 flex w-28 -translate-y-1/2 items-center justify-end gap-1">
-            {showSearchLoading ? (
-              <span
-                role="status"
-                data-testid="search-loading"
-                className="inline-flex items-center gap-1 text-xs text-muted-foreground"
-              >
-                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-                <span>Searching...</span>
-              </span>
-            ) : null}
-            {filter ? (
-              <button
-                aria-label="Clear search"
-                onClick={() => setFilter('')}
-                className="p-0.5 min-h-11 min-w-11 md:min-h-0 md:min-w-0 flex items-center justify-center rounded hover:bg-muted text-muted-foreground hover:text-foreground"
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            ) : null}
-          </div>
+          {showSearchLoading ? (
+            <span
+              role="status"
+              data-testid="search-loading"
+              className="inline-flex min-w-0 max-w-[80px] shrink items-center gap-[4px] overflow-hidden text-xs text-muted-foreground"
+            >
+              <Loader2 className="h-[14px] w-[14px] shrink-0 animate-spin" aria-hidden="true" />
+              <span className="sidebar-search-loading-text min-w-0 truncate">Searching...</span>
+            </span>
+          ) : null}
+          {filter ? (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={() => setFilter('')}
+              className="shrink-0 p-[2px] pr-[4px] min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center rounded hover:bg-muted text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-[14px] w-[14px]" />
+            </button>
+          ) : null}
         </div>
         {repoOptions.length > 0 && (
-          <div className="mt-2 flex items-center gap-1">
+          <div className="mt-[12px] flex items-center gap-1">
             <select
               aria-label="Repo filter"
               value={repoFilter}

--- a/src/index.css
+++ b/src/index.css
@@ -1538,3 +1538,21 @@ body {
     display: none; /* Chrome/Safari/Opera */
   }
 }
+
+.sidebar-search-row {
+  container-type: inline-size;
+}
+
+@container (max-width: 260px) {
+  .sidebar-search-loading-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}

--- a/test/e2e-browser/specs/sidebar.spec.ts
+++ b/test/e2e-browser/specs/sidebar.spec.ts
@@ -1,4 +1,37 @@
 import { test, expect } from '../helpers/fixtures.js'
+import type { Page } from '@playwright/test'
+
+async function setSidebarSearchLoading(page: Page, loading: boolean): Promise<void> {
+  await page.evaluate((nextLoading) => {
+    window.__FRESHELL_TEST_HARNESS__?.dispatch({
+      type: 'sessions/setSessionWindowLoading',
+      payload: {
+        surface: 'sidebar',
+        loading: nextLoading,
+        loadingKind: nextLoading ? 'search' : undefined,
+        query: 'test',
+        searchTier: 'title',
+      },
+    })
+  }, loading)
+}
+
+function measureVisibleInputContentWidth(element: HTMLInputElement): number {
+  const row = element.parentElement
+  if (!row) return 0
+  const styles = getComputedStyle(element)
+  const paddingLeft = parseFloat(styles.paddingLeft) || 0
+  const paddingRight = parseFloat(styles.paddingRight) || 0
+  const borderLeft = parseFloat(styles.borderLeftWidth) || 0
+  const borderRight = parseFloat(styles.borderRightWidth) || 0
+  const inputRect = element.getBoundingClientRect()
+  const rowRect = row.getBoundingClientRect()
+  const contentLeft = inputRect.left + paddingLeft + borderLeft
+  const contentRight = inputRect.right - paddingRight - borderRight
+  const visibleLeft = Math.max(contentLeft, rowRect.left)
+  const visibleRight = Math.min(contentRight, rowRect.right)
+  return Math.max(0, visibleRight - visibleLeft)
+}
 
 test.describe('Sidebar', () => {
   test('sidebar is visible by default', async ({ freshellPage, page }) => {
@@ -112,6 +145,188 @@ test.describe('Sidebar', () => {
     await clearButton.click()
     const value = await searchInput.inputValue()
     expect(value).toBe('')
+  })
+
+  test('search input and controls remain visible and contained with pending search at high scale', async ({ freshellPage, page }) => {
+    // terminalFontSize=32 → --ui-scale=2.0 (all rem-based sizes double).
+    // sidebar=200px is the minimum (SIDEBAR_MIN_WIDTH). At scale 2.0 the
+    // old pr-36 (9rem = 288px) exceeded the input width and collapsed the
+    // text area to ~1 char. The flex layout must guarantee usable text space
+    // even with the loading indicator and clear button visible.
+    await page.evaluate(() => {
+      window.__FRESHELL_TEST_HARNESS__?.dispatch({
+        type: 'settings/updateSettingsLocal',
+        payload: {
+          terminal: { fontSize: 32 },
+          sidebar: { width: 200, collapsed: false },
+        },
+      })
+    })
+
+    await page.waitForFunction(() => {
+      const scale = getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')
+      return parseFloat(scale) >= 2.0
+    })
+
+    const searchInput = page.getByPlaceholder('Search...')
+    await expect(searchInput).toBeVisible()
+
+    // Measure the input's visible content width. This catches the original bug
+    // where right padding consumed the text area while the input box stayed wide.
+    const emptyWidth = await searchInput.evaluate(measureVisibleInputContentWidth)
+    const inputFontSize = await searchInput.evaluate((el: HTMLInputElement) => {
+      return parseFloat(getComputedStyle(el).fontSize)
+    })
+    expect(emptyWidth).toBeGreaterThan(inputFontSize)
+
+    await searchInput.fill('test')
+    await setSidebarSearchLoading(page, true)
+
+    // Assert the loading indicator is visible (search is pending).
+    const loadingIndicator = page.getByTestId('search-loading')
+    await expect(loadingIndicator).toBeVisible({ timeout: 3_000 })
+
+    // At 200px sidebar with px-based padding, the row is ~176px, which
+    // activates the container query. Verify the loading text is visually
+    // hidden but remains accessible.
+    const loadingTextStyles = await loadingIndicator.evaluate((el) => {
+      const text = el.querySelector('.sidebar-search-loading-text')
+      if (!text) return null
+      const cs = getComputedStyle(text)
+      return {
+        position: cs.position,
+        width: cs.width,
+        clip: cs.clip,
+      }
+    })
+    expect(loadingTextStyles).not.toBeNull()
+    expect(loadingTextStyles!.position).toBe('absolute')
+    expect(loadingTextStyles!.width).toBe('1px')
+
+    // Scope this assertion because dnd-kit mounts another role="status".
+    await expect(loadingIndicator).toHaveAttribute('role', 'status')
+    const a11ySnapshot = await loadingIndicator.ariaSnapshot()
+    expect(a11ySnapshot).toContain('Searching')
+
+    const pendingWidth = await searchInput.evaluate(measureVisibleInputContentWidth)
+    expect(pendingWidth).toBeGreaterThan(inputFontSize)
+
+    const clearButton = page.getByRole('button', { name: /clear search/i })
+    await expect(clearButton).toBeVisible()
+    const rowBox = await searchInput.evaluate((el: HTMLInputElement) => {
+      const row = el.parentElement
+      if (!row) return null
+      const rect = row.getBoundingClientRect()
+      return { left: rect.left, right: rect.right }
+    })
+    const clearBox = await clearButton.boundingBox()
+    expect(rowBox).not.toBeNull()
+    expect(clearBox).not.toBeNull()
+    expect(clearBox!.x + clearBox!.width).toBeLessThanOrEqual(rowBox!.right + 1)
+
+    await setSidebarSearchLoading(page, false)
+    await expect(loadingIndicator).not.toBeVisible({ timeout: 5_000 })
+    await expect(searchInput).toHaveAttribute('aria-busy', 'false')
+
+    // After loading completes, the input content width should still be usable.
+    const settledWidth = await searchInput.evaluate(measureVisibleInputContentWidth)
+    expect(settledWidth).toBeGreaterThan(inputFontSize)
+  })
+
+  test('search input keeps usable width at high scale with default sidebar (above container query cutoff)', async ({ freshellPage, page }) => {
+    // At scale 2.0 with 288px sidebar, the row is ~264px and has room for the
+    // full loading label while retaining usable input space.
+    await page.evaluate(() => {
+      window.__FRESHELL_TEST_HARNESS__?.dispatch({
+        type: 'settings/updateSettingsLocal',
+        payload: {
+          terminal: { fontSize: 32 },
+          sidebar: { width: 288, collapsed: false },
+        },
+      })
+    })
+
+    await page.waitForFunction(() => {
+      const scale = getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')
+      return parseFloat(scale) >= 2.0
+    })
+
+    const searchInput = page.getByPlaceholder('Search...')
+    const inputFontSize = await searchInput.evaluate((el: HTMLInputElement) => {
+      return parseFloat(getComputedStyle(el).fontSize)
+    })
+
+    await searchInput.fill('test')
+    await setSidebarSearchLoading(page, true)
+
+    const loadingIndicator = page.getByTestId('search-loading')
+    await expect(loadingIndicator).toBeVisible({ timeout: 3_000 })
+
+    const loadingText = loadingIndicator.locator('.sidebar-search-loading-text')
+    await expect(loadingText).toBeVisible()
+    const loadingTextRect = await loadingText.boundingBox()
+    expect(loadingTextRect).not.toBeNull()
+    expect(loadingTextRect!.width).toBeGreaterThan(10)
+
+    const pendingWidth = await searchInput.evaluate(measureVisibleInputContentWidth)
+    expect(pendingWidth).toBeGreaterThan(inputFontSize)
+  })
+
+  test('search row contains the full mobile clear-button touch target', async ({ freshellPage, page }) => {
+    // On mobile, the search row itself must contain the clear button's full
+    // 44px touch target; relying on overflow makes the outer edges untappable.
+    await page.setViewportSize({ width: 400, height: 700 })
+
+    // On mobile, the sidebar auto-collapses; open it first
+    const showButton = page.getByRole('button', { name: /show sidebar/i })
+    await expect(showButton).toBeVisible({ timeout: 5_000 })
+    await showButton.click()
+    await page.waitForTimeout(300)
+
+    const searchInput = page.getByPlaceholder('Search...')
+    await expect(searchInput).toBeVisible({ timeout: 3_000 })
+    await searchInput.fill('test')
+    await page.waitForTimeout(200)
+
+    const clearButton = page.getByRole('button', { name: /clear search/i })
+    await expect(clearButton).toBeVisible()
+
+    // The button's layout height should be at least 44px (min-h-[44px]).
+    const buttonHeight = await clearButton.evaluate((el: HTMLButtonElement) => {
+      return el.getBoundingClientRect().height
+    })
+    expect(buttonHeight).toBeGreaterThanOrEqual(44)
+
+    // The button's layout width should also be at least 44px (min-w-[44px]).
+    const buttonWidth = await clearButton.evaluate((el: HTMLButtonElement) => {
+      return el.getBoundingClientRect().width
+    })
+    expect(buttonWidth).toBeGreaterThanOrEqual(44)
+
+    const rowBox = await searchInput.evaluate((el: HTMLInputElement) => {
+      const row = el.parentElement
+      if (!row) return null
+      const rect = row.getBoundingClientRect()
+      return { top: rect.top, bottom: rect.bottom, height: rect.height }
+    })
+    const buttonBox = await clearButton.boundingBox()
+    expect(rowBox).not.toBeNull()
+    expect(buttonBox).not.toBeNull()
+    expect(rowBox!.height).toBeGreaterThanOrEqual(44)
+    expect(buttonBox!.y).toBeGreaterThanOrEqual(rowBox!.top)
+    expect(buttonBox!.y + buttonBox!.height).toBeLessThanOrEqual(rowBox!.bottom)
+
+    // Click the formerly clipped top edge, not Playwright's default center.
+    await page.mouse.click(buttonBox!.x + buttonBox!.width / 2, buttonBox!.y + 2)
+    await expect(searchInput).toHaveValue('')
+
+    // The input itself should fill the row height on mobile so the entire
+    // row is tappable (not just the input's intrinsic font-size height).
+    await searchInput.fill('test')
+    const inputHeight = await searchInput.evaluate((el: HTMLInputElement) => {
+      return el.getBoundingClientRect().height
+    })
+    expect(inputHeight).toBeGreaterThanOrEqual(40)
   })
 
   test('sidebar empty state with isolated HOME', async ({ freshellPage, page, terminal }) => {

--- a/test/unit/client/components/Sidebar.mobile.test.tsx
+++ b/test/unit/client/components/Sidebar.mobile.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { createHash } from 'crypto'
-import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import { render, screen, cleanup, act } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import Sidebar from '@/components/Sidebar'
@@ -11,7 +10,6 @@ import connectionReducer from '@/store/connectionSlice'
 import sessionsReducer from '@/store/sessionsSlice'
 import sessionActivityReducer from '@/store/sessionActivitySlice'
 import terminalDirectoryReducer from '@/store/terminalDirectorySlice'
-import type { ProjectGroup } from '@/store/types'
 
 // Mock react-window's List component
 vi.mock('react-window', () => ({
@@ -63,20 +61,7 @@ vi.mock('@/lib/api', async () => {
   }
 })
 
-const sessionId = (label: string) => {
-  const hex = createHash('md5').update(label).digest('hex')
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`
-}
-
-function createTestStore(options?: { projects?: ProjectGroup[] }) {
-  const projects = (options?.projects ?? []).map((project) => ({
-    ...project,
-    sessions: (project.sessions ?? []).map((session) => ({
-      ...session,
-      provider: session.provider ?? 'claude',
-    })),
-  }))
-
+function createTestStore() {
   return configureStore({
     reducer: {
       settings: settingsReducer,
@@ -117,7 +102,7 @@ function createTestStore(options?: { projects?: ProjectGroup[] }) {
         paneTitles: {},
       },
       sessions: {
-        projects,
+        projects: [],
         expandedProjects: new Set<string>(),
         isLoading: false,
         error: null,
@@ -212,24 +197,5 @@ describe('Sidebar mobile touch targets', () => {
     expect(terminalNavButton.className).toMatch(/md:py-1\.5/)
     expect(terminalNavButton.className).toMatch(/min-h-11/)
     expect(terminalNavButton.className).toMatch(/md:min-h-0/)
-  })
-
-  it('search clear button has min-h-11 min-w-11 md:min-h-0 md:min-w-0 classes for mobile touch target', () => {
-    const store = createTestStore()
-    renderSidebar(store)
-
-    act(() => {
-      vi.advanceTimersByTime(100)
-    })
-
-    // Type in search to reveal clear button
-    const searchInput = screen.getByPlaceholderText('Search...')
-    fireEvent.change(searchInput, { target: { value: 'test' } })
-
-    const clearButton = screen.getByRole('button', { name: /clear search/i })
-    expect(clearButton.className).toMatch(/min-h-11/)
-    expect(clearButton.className).toMatch(/min-w-11/)
-    expect(clearButton.className).toMatch(/md:min-h-0/)
-    expect(clearButton.className).toMatch(/md:min-w-0/)
   })
 })

--- a/test/unit/client/components/Sidebar.test.tsx
+++ b/test/unit/client/components/Sidebar.test.tsx
@@ -3204,7 +3204,6 @@ describe('Sidebar Component - Session-Centric Display', () => {
       const searchLoading = screen.getByTestId('search-loading')
       expect(searchLoading).toBeInTheDocument()
       expect(searchLoading.querySelector('span:not(.sr-only)')).toHaveTextContent('Searching...')
-      expect(searchInput).toHaveClass('pr-36')
     })
 
     it('hides search chrome when clearing to browse while stale search results remain visible', async () => {


### PR DESCRIPTION
## Problem

On the Electron build (but not the web interface), the sidebar search input collapses to approximately one character wide. This happens when users set a larger terminal font size in the desktop app.

## Root Cause

The sidebar search input used an absolutely-positioned overlay (the "Searching..." indicator and clear button) with a fixed  (9rem = 144px at scale 1) right padding to reserve space for it. This padding is **rem-based** and scales with , but the sidebar width (288px) is **fixed in px** and does not scale. At  (terminalFontSize >= 24), the padding exceeded the input width, collapsing the text area to its intrinsic minimum (~1 char).

## Fix

Replace the absolute-positioned overlay + fixed padding pattern with a **flex layout** where the input and controls are flex siblings:

- **Input**:  with  and  — gets all remaining space, fills row height via flex stretch (not percentage height)
- **Chrome elements** (icon, gaps, spinner, clear button): px-based sizing so they don't scale with 
- **Loading indicator**:  to limit space consumption
- **Container query** (max-width: 260px): hides loading text visually via sr-only pattern (not ) to preserve the accessible status message while yielding space to the input at narrower sidebars
- **Search row**:  so it grows with text at high scales while providing a 44px mobile touch target
- **overflow-x-clip**: clips horizontal overflow while preserving  for the mobile touch target
- **Repo filter margin**:  (px-based) to prevent touch target overlap at small scales

## Tests

Three Playwright regression tests:
1. **200px sidebar at scale 2.0**: sets search loading via harness, verifies container query activates (sr-only styles),  attribute,  contains 'Searching', input width > font size, clear button within row bounds, settled state with loading gone
2. **288px sidebar at scale 2.0**: verifies loading text is visible ( + width > 10px, allows truncation), input width > font size
3. **Mobile**: button height AND width >= 44px, row contains button, input height >= 40px, coordinate click at button top edge clears search

## Review

Passed fresheyes independent code review.