### PR TITLE
feat(freshagent): log opencode compact drive failures server-side

### DIFF
--- a/crates/freshell-freshagent/src/opencode_ws.rs
+++ b/crates/freshell-freshagent/src/opencode_ws.rs
@@ -1857,6 +1857,21 @@ impl FreshOpencodeState {
                 &last_turn_complete_at,
             );
             if let Err(err) = result {
+                // Server-side observability (the 2026-09-11 compact incident's
+                // gap): before this WARN existed, a failed compact drive was
+                // visible ONLY as the client's "Agent error" banner — the
+                // structured log carried no trace, leaving the failure's
+                // timing and cause unrecoverable. The `never_dispatched`
+                // verdict records the delivery truth the compensation above
+                // used; `error` carries the serve error verbatim (including
+                // the transport `source()` chain, via `display_error_chain`).
+                tracing::warn!(
+                    provider = PROVIDER,
+                    session = %compact_id,
+                    never_dispatched = err.never_dispatched(),
+                    error = %err,
+                    "freshagent.opencode.compact_failed"
+                );
                 fresh_agent.broadcast(&event_frame(
                     &compact_id,
                     json!({
@@ -7961,6 +7976,13 @@ mod tests {
         /// error-after-send outcome: OpenCode ≥1.18.21's summarize runs
         /// `revertSvc.cleanup` FIRST, so this is a POSSIBLY-destroyed tail.
         Answered500,
+        /// The POST is recorded, then the connection breaks WITHOUT an answer
+        /// — the AMBIGUOUS mid-flight transport leg (the production
+        /// `ServeError::Transport` class; the 2026-09-11 compact incident's
+        /// failure shape: "error sending request for url (...)"). Delivery is
+        /// unknowable, so the tail is possibly-gone exactly like
+        /// `Answered500`.
+        MidflightTransport,
         /// The POST never exists server-side: the refusal is answered WITHOUT
         /// recording the request — modeling a connect-phase refusal before a
         /// byte left (the provably-undelivered leg).
@@ -8122,6 +8144,18 @@ mod tests {
                     Some("running"),
                     "the busy `running` snapshot must precede the summarize POST"
                 );
+                if self.summarize_outcome == SummarizeOutcome::MidflightTransport {
+                    // The request WAS recorded above (delivery is ambiguous),
+                    // then the connection broke before an answer — the exact
+                    // reqwest send()-phase failure the real transport maps to
+                    // `ServeHttpError::Ambiguous` → `ServeError::Transport`.
+                    return Box::pin(async {
+                        Err(ServeHttpError::Ambiguous(
+                            "error sending request for url (http://127.0.0.1:42579/session/ses_1/summarize?directory=%2Ftmp)"
+                                .to_string(),
+                        ))
+                    });
+                }
                 if self.summarize_outcome == SummarizeOutcome::Answered500 {
                     return Box::pin(async {
                         Ok(ServeHttpResponse::new(500, b"summarize exploded".to_vec()))
@@ -8495,6 +8529,7 @@ mod tests {
     /// bundle below.)
     #[tokio::test]
     async fn compact_summarize_answered_500_after_receipt_destroys_redo_forever() {
+        let (events, _guard) = info_capture::capture();
         let (st, http, mut rx) =
             compact_state(r#"{"model":null}"#, SummarizeOutcome::Answered500).await;
         insert_compact_session(&st, "ses_1", Some("prov-a/mdl-x")).await;
@@ -8508,6 +8543,24 @@ mod tests {
             .find(|f| is_event(f, "freshAgent.error", None))
             .expect("the failure is LOUD");
         assert_eq!(error_frame["event"]["code"], "OPENCODE_COMPACT_FAILED");
+        // The failure is observable server-side too, with the delivery verdict
+        // the compensation used (an answered 5xx is NOT provably undelivered).
+        {
+            let events = events.lock().expect("capture lock");
+            let warn = events
+                .iter()
+                .find(|e| e.message.contains("freshagent.opencode.compact_failed"))
+                .expect("an answered-5xx compact failure must be visible in server logs");
+            assert_eq!(
+                warn.fields.get("session").map(String::as_str),
+                Some("ses_1")
+            );
+            assert_eq!(
+                warn.fields.get("never_dispatched").map(String::as_str),
+                Some("false"),
+                "an answered non-2xx is an error-after-send, never provably undelivered"
+            );
+        }
         assert_eq!(
             http.summarize_requests().len(),
             1,
@@ -8540,6 +8593,90 @@ mod tests {
         );
     }
 
+    /// The AMBIGUOUS mid-flight transport leg (the 2026-09-11 production
+    /// incident class: a compact failing with "opencode serve transport
+    /// error: error sending request for url (...)"). Delivery is unknowable,
+    /// so three contracts must hold:
+    /// (a) the pane hears a LOUD `OPENCODE_COMPACT_FAILED` whose message
+    ///     carries the serve error verbatim,
+    /// (b) the failure is observable SERVER-SIDE as a structured
+    ///     `freshagent.opencode.compact_failed` WARN (session + provider +
+    ///     `never_dispatched=false` + the error) — the observability gap the
+    ///     incident exposed: before this leg existed, the only trace was the
+    ///     client banner, leaving the failure's timing and cause unrecoverable
+    ///     from `rust-server.jsonl`, and
+    /// (c) the pre-drive destroy STANDS (error-after-send ≠ tail survived —
+    ///     the same finality as `Answered500`).
+    #[tokio::test]
+    async fn compact_summarize_midflight_transport_failure_logs_and_keeps_destroy() {
+        let (events, _guard) = info_capture::capture();
+        let (st, http, mut rx) =
+            compact_state(r#"{"model":null}"#, SummarizeOutcome::MidflightTransport).await;
+        insert_compact_session(&st, "ses_1", Some("prov-a/mdl-x")).await;
+        let sink = seed_redoable_record(&st, "ses_1").await;
+
+        st.handle_compact(compact_msg("ses_1")).await;
+
+        let frames = frames_until(&mut rx, |f| is_event(f, "freshAgent.error", None)).await;
+        let error_frame = frames
+            .iter()
+            .find(|f| is_event(f, "freshAgent.error", None))
+            .expect("the failure is LOUD");
+        assert_eq!(error_frame["event"]["code"], "OPENCODE_COMPACT_FAILED");
+        assert!(
+            error_frame["event"]["message"]
+                .as_str()
+                .unwrap_or("")
+                .contains("opencode serve transport error"),
+            "the raw serve transport diagnostic crosses the wire: {error_frame}"
+        );
+        assert_eq!(
+            http.summarize_requests().len(),
+            1,
+            "the POST was recorded BEFORE the connection broke — delivery is ambiguous, not provably-refused"
+        );
+        // (b) the server-side WARN — the observability this incident motivated.
+        let events = events.lock().expect("capture lock");
+        let warn = events
+            .iter()
+            .find(|e| e.message.contains("freshagent.opencode.compact_failed"))
+            .expect(
+                "compact failures must be visible in server logs, not just the client banner",
+            );
+        assert_eq!(
+            warn.fields.get("session").map(String::as_str),
+            Some("ses_1"),
+            "the WARN names the compacted session"
+        );
+        assert_eq!(
+            warn.fields.get("provider").map(String::as_str),
+            Some("opencode"),
+            "the WARN names the provider"
+        );
+        assert_eq!(
+            warn.fields.get("never_dispatched").map(String::as_str),
+            Some("false"),
+            "a mid-flight transport break is NOT provably undelivered"
+        );
+        assert!(
+            warn.fields
+                .get("error")
+                .map(|s| s.contains("transport error"))
+                .unwrap_or(false),
+            "the WARN carries the serve error (transport chain included): {:?}",
+            warn.fields
+        );
+        drop(events);
+        // (c) compensation semantics: ambiguous delivery ⇒ the destroy stands.
+        let record = sink
+            .load_rollback(PROVIDER, "ses_1")
+            .expect("the record survives");
+        assert!(
+            record.redo_destroyed && !record.can_redo(),
+            "mid-flight transport ⇒ redo destroyed FOREVER (delivery is ambiguous, the tail is possibly gone): {record:?}"
+        );
+    }
+
     /// ep1-r3 F2's OTHER leg — the provably-UNDELIVERED dispatch: the
     /// summarize POST's connect phase refused BEFORE a byte left the client
     /// (the fake reject models "no POST was ever received"), so the serve
@@ -8547,6 +8684,7 @@ mod tests {
     /// destroy is compensated back, and redo stays valid.
     #[tokio::test]
     async fn compact_summarize_undelivered_dispatch_preserves_redo() {
+        let (events, _guard) = info_capture::capture();
         let (st, http, mut rx) =
             compact_state(r#"{"model":null}"#, SummarizeOutcome::Undelivered).await;
         insert_compact_session(&st, "ses_1", Some("prov-a/mdl-x")).await;
@@ -8567,6 +8705,24 @@ mod tests {
                 .contains("connect refused"),
             "the undelivered diagnostic crosses the wire: {error_frame}"
         );
+        // The failure is observable server-side too, with the delivery verdict
+        // the compensation used (a connect-phase refusal IS provably undelivered).
+        {
+            let events = events.lock().expect("capture lock");
+            let warn = events
+                .iter()
+                .find(|e| e.message.contains("freshagent.opencode.compact_failed"))
+                .expect("an undelivered compact failure must be visible in server logs");
+            assert_eq!(
+                warn.fields.get("session").map(String::as_str),
+                Some("ses_1")
+            );
+            assert_eq!(
+                warn.fields.get("never_dispatched").map(String::as_str),
+                Some("true"),
+                "a connect-phase refusal is provably undelivered"
+            );
+        }
         assert!(
             http.summarize_requests().is_empty(),
             "the dispatch provably never reached the serve (no POST was ever received)"

--- a/crates/freshell-opencode/src/lib.rs
+++ b/crates/freshell-opencode/src/lib.rs
@@ -50,8 +50,8 @@ pub use model::{
     FRESHOPENCODE_DEFAULT_EFFORT,
 };
 pub use serve::{
-    is_healthy_response, CreatedSession, Endpoint, EventSource, EventStreamHandle, ForkedSession,
-    OpencodeServeManager, PortAllocator, ProcessSpawner, Route, ServeConfig, ServeDeps, ServeError,
-    ServeHttp, ServeHttpError, ServeHttpRequest, ServeHttpResponse, ServeProcess, SessionSignal,
-    SpawnRequest, OPENCODE_SIDECAR_OWNERSHIP_ENV,
+    display_error_chain, is_healthy_response, CreatedSession, Endpoint, EventSource,
+    EventStreamHandle, ForkedSession, OpencodeServeManager, PortAllocator, ProcessSpawner, Route,
+    ServeConfig, ServeDeps, ServeError, ServeHttp, ServeHttpError, ServeHttpRequest,
+    ServeHttpResponse, ServeProcess, SessionSignal, SpawnRequest, OPENCODE_SIDECAR_OWNERSHIP_ENV,
 };

--- a/crates/freshell-opencode/src/serve.rs
+++ b/crates/freshell-opencode/src/serve.rs
@@ -327,6 +327,27 @@ impl std::fmt::Display for ServeHttpError {
 
 impl std::error::Error for ServeHttpError {}
 
+/// Render `err` plus every `source()` in its chain, `"; caused by: "`-joined.
+///
+/// A bare `to_string()` drops the diagnostics that pin a failure class:
+/// reqwest's top-level Display is only `"error sending request for url (...)"`
+/// while the TCP-level cause (`"connection reset by peer (os error 104)"`,
+/// `"connection closed before message completed"`) lives in the `source()`
+/// chain. [`ServeHttpError`] strings carry this rendering so WARN logs and
+/// client-visible messages preserve the full cause trail (the 2026-09-11
+/// compact incident's exact gap: the failure trigger was unrecoverable from
+/// the top-level string alone).
+pub fn display_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut rendered = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        rendered.push_str("; caused by: ");
+        rendered.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    rendered
+}
+
 /// The HTTP transport seam (`fetchFn`). One request/response round-trip. The
 /// `Err` side is a [`ServeHttpError`]: `Undelivered` ONLY for a provable
 /// connect-phase refusal (never a byte sent), `Ambiguous` for everything else
@@ -1422,6 +1443,76 @@ fn encode_path_segment(segment: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── display_error_chain (transport diagnostics preservation) ─────────────
+
+    /// A two-deep `source()` chain: top → mid → leaf.
+    #[derive(Debug)]
+    struct LeafError;
+
+    impl std::fmt::Display for LeafError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "leaf cause")
+        }
+    }
+    impl std::error::Error for LeafError {}
+
+    #[derive(Debug)]
+    struct MidError;
+
+    impl std::fmt::Display for MidError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "mid cause")
+        }
+    }
+    impl std::error::Error for MidError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&LeafError)
+        }
+    }
+
+    #[derive(Debug)]
+    struct TopError;
+
+    impl std::fmt::Display for TopError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "top message")
+        }
+    }
+    impl std::error::Error for TopError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&MidError)
+        }
+    }
+
+    /// A source-less error renders alone (no trailing separators).
+    #[derive(Debug)]
+    struct BareError;
+
+    impl std::fmt::Display for BareError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "bare message")
+        }
+    }
+    impl std::error::Error for BareError {}
+
+    #[test]
+    fn display_error_chain_appends_every_source_in_order() {
+        assert_eq!(
+            display_error_chain(&TopError),
+            "top message; caused by: mid cause; caused by: leaf cause",
+            "the whole source chain rides along, innermost last"
+        );
+    }
+
+    #[test]
+    fn display_error_chain_bare_error_renders_top_only() {
+        assert_eq!(
+            display_error_chain(&BareError),
+            "bare message",
+            "a source-less error renders exactly its own Display"
+        );
+    }
 
     #[test]
     fn healthy_response_predicate_matches_reference() {

--- a/crates/freshell-opencode/src/transport.rs
+++ b/crates/freshell-opencode/src/transport.rs
@@ -78,11 +78,16 @@ impl ServeHttp for ReqwestServeHttp {
             // proves the serve never saw the request; every other `send()`
             // failure is possibly post-send, and a `bytes()` failure is PROVABLY
             // post-send (the response headers already arrived).
+            // `display_error_chain` keeps the reqwest `source()` chain (the
+            // TCP-level cause — "connection reset by peer", "connection closed
+            // before message completed") in the string the WARN/error frames
+            // carry, so the failure class stays diagnosable post-hoc.
             let resp = builder.send().await.map_err(|e| {
+                let rendered = crate::display_error_chain(&e);
                 if e.is_connect() {
-                    crate::ServeHttpError::Undelivered(e.to_string())
+                    crate::ServeHttpError::Undelivered(rendered)
                 } else {
-                    crate::ServeHttpError::Ambiguous(e.to_string())
+                    crate::ServeHttpError::Ambiguous(rendered)
                 }
             })?;
             let status = resp.status().as_u16();
@@ -95,7 +100,7 @@ impl ServeHttp for ReqwestServeHttp {
             let bytes = resp
                 .bytes()
                 .await
-                .map_err(|e| crate::ServeHttpError::Ambiguous(e.to_string()))?;
+                .map_err(|e| crate::ServeHttpError::Ambiguous(crate::display_error_chain(&e)))?;
             Ok(ServeHttpResponse {
                 status,
                 body: bytes.to_vec(),


### PR DESCRIPTION
## Motivation (2026-09-11 production RCA)

A freshopencode `/compact` failed with `Agent error: opencode serve transport error: error sending request for url (http://127.0.0.1:42579/session/ses_…/summarize?directory=…)`. The RCA (full timeline reconstructed from systemd/journal, rust-server.jsonl, opencode.log, and opencode.db) established:

- The shared `opencode serve` sidecar stayed alive the whole time; the failed POST left **zero trace** in opencode's log/DB (never processed), and an immediate retry succeeded. No data loss.
- The failure class is the documented ambiguous mid-flight transport leg (`ServeError::Transport`, `is_connect()==false`): delivery unknowable, so the rollback compensation conservatively keeps the destroy-stands verdict — all correct.
- **The actionable gap:** the failure was visible ONLY as the client's banner. The structured server log (`rust-server.jsonl`) carried no trace, so the failure's exact second and TCP-level cause (stale-pooled-connection write break vs post-delivery response loss) were unrecoverable post-hoc.

## What this PR does

1. **WARN on compact drive failure** (`handle_compact`): structured `freshagent.opencode.compact_failed` with `session`, `provider`, the `never_dispatched` verdict (the delivery truth the compensation used), and `error` verbatim.
2. **Preserve the reqwest `source()` chain** (`display_error_chain`, wired into the real transport's `send()`/`bytes()` mappings for both `Undelivered` and `Ambiguous`): the top-level reqwest Display (`error sending request for url (...)`) drops the TCP-level cause (`connection reset by peer (os error 104)`, `connection closed before message completed`) — the exact diagnostic that would have pinned this incident's trigger.

## Test coverage

- New `SummarizeOutcome::MidflightTransport` fake outcome models the incident class (request recorded → connection breaks without an answer); the new test pins the WARN fields, the `OPENCODE_COMPACT_FAILED` frame with the raw transport diagnostic, and the destroy-stands compensation.
- The answered-5xx and provably-undelivered compact tests gain WARN assertions for their `never_dispatched` verdicts (false / true).
- `display_error_chain` unit tests: full chain rendering + bare-error rendering.

## Verification

- `cargo test --workspace`: green except one **pre-existing** failure (`codex_sidecar_reattach_e2e::prepared_codex_launch_reuses_reserved_setup_and_discards_after_adopt_failure`, "allowlisted context" assertion) which fails identically on unmodified `origin/main` — environment-dependent, unrelated to this change.
- Coordinated full suite (`npm test`) on this branch: **success** (recorded in the coordinator: `full-suite success`, commit `e87261625`).
- `cargo clippy` on both touched crates: clean.

## Notes

- The compact's inline pre-drive refusals (no-model, ledger-write refusal) are still client-banner-only; logging those symmetrically is a natural follow-up if wanted.
- Deploying this to the live 3001 server requires a restart (Rust server change) — needs explicit approval per process rules.