### PR TITLE
feat(fresh-agent): live model convergence — freshAgent.configure + session.metadata broadcasts

### DIFF
--- a/crates/freshell-freshagent/src/claude.rs
+++ b/crates/freshell-freshagent/src/claude.rs
@@ -56,10 +56,10 @@ use tokio::sync::Mutex as TokioMutex;
 
 use freshell_protocol::{
     ErrorCode, ErrorMsg, FreshAgentApprovalRespond, FreshAgentAttach, FreshAgentCompact,
-    FreshAgentCreate, FreshAgentCreateFailed, FreshAgentCreated, FreshAgentEvent,
-    FreshAgentInterrupt, FreshAgentKill, FreshAgentKilled, FreshAgentQuestionRespond,
-    FreshAgentSend, FreshAgentSendAccepted, FreshAgentSessionMaterialized, ServerMessage,
-    SessionType,
+    FreshAgentConfigure, FreshAgentCreate, FreshAgentCreateFailed, FreshAgentCreated,
+    FreshAgentEvent, FreshAgentInterrupt, FreshAgentKill, FreshAgentKilled,
+    FreshAgentQuestionRespond, FreshAgentSend, FreshAgentSendAccepted,
+    FreshAgentSessionMaterialized, ServerMessage, SessionType,
 };
 
 use crate::{FreshAgentCreateDedup, FreshAgentCreateOutcome, SharedPaneIdentitySink};
@@ -1989,12 +1989,37 @@ impl FreshClaudeState {
                     "freshagent.claude.unsupported-settings-ignored"
                 );
             }
+            let settings_before = {
+                let guard = self.sessions.lock().await;
+                guard.get(&map_key).map(|s| {
+                    (s.configuration.settings.model.clone(), s.configuration.settings.effort.clone())
+                })
+            };
             if let Err(err) = self
                 .configure_for_send(&map_key, settings, session_type)
                 .await
             {
                 self.send_error(&request_id, "CLAUDE_SETTINGS_FAILED", &err);
                 return;
+            }
+            // A send whose settings CHANGED the live session converges every
+            // device's model surfaces (the same frame `handle_configure`
+            // emits — a device that missed the configure still lands here).
+            let settings_after = {
+                let guard = self.sessions.lock().await;
+                guard.get(&map_key).map(|s| {
+                    (s.configuration.settings.model.clone(), s.configuration.settings.effort.clone())
+                })
+            };
+            if settings_before != settings_after {
+                let (model, effort) = settings_after.unwrap_or((None, None));
+                self.broadcast(&crate::session_metadata::session_metadata_frame(
+                    PROVIDER,
+                    session_type,
+                    &session_id,
+                    model.as_deref(),
+                    effort.as_deref(),
+                ));
             }
         }
         // Task 4 review (C1b): the destroy target comes from POST-lock session
@@ -2185,6 +2210,97 @@ impl FreshClaudeState {
             .await;
         }
         applied
+    }
+
+    // ── freshAgent.configure (WS) ─────────────────────────────────────────────
+
+    /// Handle a `freshAgent.configure`: apply the carried settings to the
+    /// LIVE sidecar session NOW — model and effort through the sidecar's
+    /// configure lane (`setModel` / `applyFlagSettings`), which is a REAL
+    /// mid-conversation change (claude's settings are live, not per-send) —
+    /// then broadcast `freshAgent.session.metadata` so every device's model
+    /// surfaces converge immediately.
+    ///
+    /// Same serialization discipline as `handle_send`: the session turn lock
+    /// is held across the busy gate and the sidecar write, and
+    /// [`Self::configure_for_send`] refuses while a turn is in flight ("Wait
+    /// for the current turn to finish before changing agent settings.") —
+    /// surfaced on the pane's error banner, with the pane's staged choice
+    /// still riding the next send's configure-for-send leg.
+    pub async fn handle_configure(&self, msg: FreshAgentConfigure) {
+        let session_id = msg.session_id.clone();
+        let session_type = session_type_str(msg.session_type);
+        let request_id = msg.request_id.clone();
+
+        let (map_key, turn_lock) = loop {
+            let handles = match self.resolve_session_key(&session_id).await {
+                Some(key) => {
+                    let guard = self.sessions.lock().await;
+                    guard.get(&key).map(|s| (key, s.turn_lock.clone()))
+                }
+                None => None,
+            };
+            if let Some(handles) = handles {
+                break handles;
+            }
+            if !self.rollback_in_flight.contains(&session_id) {
+                self.send_error(&request_id, "SESSION_NOT_FOUND", "claude session not found");
+                return;
+            }
+            tokio::time::sleep(MID_ROLLBACK_PARK_TICK).await;
+        };
+        let _turn = turn_lock.lock().await;
+
+        // kata z7j7: sandbox has NO claude-side concept — log observably
+        // (id + boolean flag only), mirroring the send path's arm.
+        if msg.settings.sandbox.is_some() {
+            tracing::info!(
+                session_id = %session_id,
+                has_sandbox = true,
+                "freshagent.claude.configure-unsupported-settings-ignored"
+            );
+        }
+
+        let before = {
+            let guard = self.sessions.lock().await;
+            guard
+                .get(&map_key)
+                .map(|s| (s.configuration.settings.model.clone(), s.configuration.settings.effort.clone()))
+        };
+        if let Err(err) = self
+            .configure_for_send(&map_key, &msg.settings, session_type)
+            .await
+        {
+            // The refusal/failure is user-facing session state (busy turn,
+            // sidecar death): the pane banner is the surface, on every device.
+            self.emit_fresh_agent_error(
+                &session_id,
+                session_type,
+                "CLAUDE_SETTINGS_FAILED",
+                &err,
+            );
+            return;
+        }
+        let after = {
+            let guard = self.sessions.lock().await;
+            guard
+                .get(&map_key)
+                .map(|s| (s.configuration.settings.model.clone(), s.configuration.settings.effort.clone()))
+        };
+        if before == after {
+            // Idempotent configure: nothing to converge.
+            return;
+        }
+        let (model, effort) = after.unwrap_or((None, None));
+        // Broadcast keyed at the CLIENT-ADDRESSED id (the id the configure
+        // named): the client's fold resolves the sessions-map entry by it.
+        self.broadcast(&crate::session_metadata::session_metadata_frame(
+            PROVIDER,
+            session_type,
+            &session_id,
+            model.as_deref(),
+            effort.as_deref(),
+        ));
     }
 
     // ── freshAgent.approval.respond / question.respond / compact (WS, Task 2) ─────────
@@ -5903,16 +6019,20 @@ pub(crate) mod tests {
     }
 
     /// Bounded drain of the broadcast receiver until a `freshAgent.event` envelope with
-    /// the given INNER type arrives (mirrors [`await_claude_created`]'s 15s shape).
+    /// the given INNER type arrives (mirroring [`await_claude_created`]'s shape, with a
+    /// 45s dead-man budget: the awaited frames are near-instant under normal load, and
+    /// only full-crate 96-way-parallel starvation delays them — 15s was observed to
+    /// starve intermittently on the shared dev box (pre-existing flake, pinned on an
+    /// unmodified checkout); 45s keeps the dead-man switch while riding out contention).
     async fn await_frame_of_inner_type(
         rx: &mut tokio::sync::broadcast::Receiver<String>,
         inner_type: &str,
     ) -> Value {
-        tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        tokio::time::timeout(std::time::Duration::from_secs(45), async {
             loop {
                 let frame: Value = match rx.recv().await {
                     // Under host load the bounded drain can fall behind the
-                    // 64-frame bus: re-sync and keep waiting (the 15s budget
+                    // 64-frame bus: re-sync and keep waiting (the 45s budget
                     // stays the dead-man switch); `Closed` surfaces through
                     // the same deadline as a lost sender.
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
@@ -15074,5 +15194,202 @@ rl.on('line', (line) => {
             "the ledger holds NO row at all afterward — not even an empty record"
         );
         drop(env);
+    }
+
+    // ── freshAgent.configure: live model convergence ─────────────────────────
+
+    fn configure_msg(session_id: &str, model: Option<&str>, effort: Option<&str>) -> FreshAgentConfigure {
+        FreshAgentConfigure {
+            provider: freshell_protocol::AgentProvider::Claude,
+            session_id: session_id.to_string(),
+            session_type: SessionType::Freshclaude,
+            cwd: None,
+            request_id: Some("req-configure".to_string()),
+            settings: freshell_protocol::FreshAgentSendSettings {
+                cwd: None,
+                model: model.map(|m| m.to_string()),
+                permission_mode: None,
+                sandbox: None,
+                effort: effort.map(|e| e.to_string()),
+            },
+        }
+    }
+
+    async fn drain(rx: &mut tokio::sync::broadcast::Receiver<String>) -> Vec<Value> {
+        let mut out = Vec::new();
+        while let Ok(frame) = rx.try_recv() {
+            out.push(serde_json::from_str(&frame).expect("frames are JSON"));
+        }
+        out
+    }
+
+    /// A configure applies the settings to the LIVE sidecar session (the fake
+    /// mirrors the real configure lane: setModel + the sdk.configured receipt)
+    /// and broadcasts `freshAgent.session.metadata` so every device's model
+    /// surfaces converge. The ledger row's settings re-snapshot through the
+    /// existing adopt_session_init leg configure_for_send performs.
+    #[tokio::test]
+    async fn configure_applies_settings_and_broadcasts_session_metadata() {
+        let _env_guard = CLAUDE_ENV_LOCK.lock().await;
+        let env = FakeClaudeSidecarEnv::install();
+        let (state, rx) = state_with_bus();
+        let mut rx = rx;
+        state
+            .handle_create(dedup_create_msg("configure-live"), None)
+            .await;
+        let created = await_claude_created(&mut rx, "configure-live").await;
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        state
+            .handle_configure(configure_msg(&session_id, Some("opus[1m]"), Some("high")))
+            .await;
+
+        // The configure lane reached the sidecar…
+        let frames = env.respond_log_frames(1).await;
+        assert_eq!(frames[0]["type"], json!("configure"));
+        assert_eq!(frames[0]["settings"]["model"], json!("opus[1m]"));
+
+        // …the session record holds the applied pair…
+        let (record_model, record_effort) = {
+            let guard = state.sessions.lock().await;
+            let session = guard.values().find(|s| s.sidecar_session_id == session_id).expect("session");
+            (
+                session.configuration.settings.model.clone(),
+                session.configuration.settings.effort.clone(),
+            )
+        };
+        assert_eq!(record_model.as_deref(), Some("opus[1m]"));
+        assert_eq!(record_effort.as_deref(), Some("high"));
+
+        // …and the metadata broadcast converges every device's surfaces, keyed
+        // at the CLIENT-ADDRESSED id.
+        let frames = drain(&mut rx).await;
+        let metadata = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata")
+            .expect("a metadata frame is broadcast");
+        assert_eq!(metadata["provider"], json!("claude"));
+        assert_eq!(metadata["sessionType"], json!("freshclaude"));
+        assert_eq!(metadata["sessionId"], json!(session_id));
+        assert_eq!(metadata["event"]["model"], json!("opus[1m]"));
+        assert_eq!(metadata["event"]["effort"], json!("high"));
+    }
+
+    /// The fake sidecar's scripted refusal (model 'unavailable') surfaces on
+    /// the pane-banner error channel with the session's flavour, and NO
+    /// metadata converges a value the live session never took.
+    #[tokio::test]
+    async fn a_refused_configure_surfaces_the_banner_error_and_converges_nothing() {
+        let _env_guard = CLAUDE_ENV_LOCK.lock().await;
+        let env = FakeClaudeSidecarEnv::install();
+        let (state, rx) = state_with_bus();
+        let mut rx = rx;
+        state
+            .handle_create(dedup_create_msg("configure-refused"), None)
+            .await;
+        let created = await_claude_created(&mut rx, "configure-refused").await;
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        state
+            .handle_configure(configure_msg(&session_id, Some("unavailable"), None))
+            .await;
+        let _ = env.respond_log_frames(1).await;
+
+        let frames = drain(&mut rx).await;
+        let error = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.error")
+            .expect("the refusal surfaces a freshAgent.error frame");
+        assert_eq!(error["event"]["code"], json!("CLAUDE_SETTINGS_FAILED"));
+        assert_eq!(error["sessionType"], json!("freshclaude"));
+        assert_eq!(error["sessionId"], json!(session_id));
+        assert!(
+            !frames.iter().any(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata"),
+            "a refused configure never converges"
+        );
+    }
+
+    /// An idempotent configure (the sidecar applied the same pair already in
+    /// the record) stays silent on the bus.
+    #[tokio::test]
+    async fn an_idempotent_configure_broadcasts_no_metadata() {
+        let _env_guard = CLAUDE_ENV_LOCK.lock().await;
+        let env = FakeClaudeSidecarEnv::install();
+        let (state, rx) = state_with_bus();
+        let mut rx = rx;
+        state
+            .handle_create(dedup_create_msg("configure-idem"), None)
+            .await;
+        let created = await_claude_created(&mut rx, "configure-idem").await;
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        state
+            .handle_configure(configure_msg(&session_id, Some("opus[1m]"), None))
+            .await;
+        let first = env.respond_log_frames(1).await;
+        assert_eq!(first[0]["settings"]["model"], json!("opus[1m]"));
+        let frames = drain(&mut rx).await;
+        assert_eq!(
+            frames
+                .iter()
+                .filter(|f| f["type"] == "freshAgent.event"
+                    && f["event"]["type"] == "freshAgent.session.metadata")
+                .count(),
+            1,
+            "the first (changing) configure broadcasts exactly one metadata frame"
+        );
+
+        state
+            .handle_configure(configure_msg(&session_id, Some("opus[1m]"), None))
+            .await;
+        // The second configure is a pure no-op: configure_for_send
+        // short-circuits before any sidecar write (the respond log stays at
+        // one frame), and no metadata converges.
+        let frames = drain(&mut rx).await;
+        assert!(
+            !frames.iter().any(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata"),
+            "an idempotent configure converges nothing"
+        );
+    }
+
+    /// A settings-bearing send that CHANGES the live session converges the
+    /// metadata broadcast too (the send-time configure_for_send leg): a
+    /// device that missed the configure still lands here.
+    #[tokio::test]
+    async fn a_settings_changing_send_broadcasts_session_metadata() {
+        let _env_guard = CLAUDE_ENV_LOCK.lock().await;
+        let env = FakeClaudeSidecarEnv::install();
+        let (state, rx) = state_with_bus();
+        let mut rx = rx;
+        state
+            .handle_create(dedup_create_msg("configure-send"), None)
+            .await;
+        let created = await_claude_created(&mut rx, "configure-send").await;
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        let mut send = send_msg(&session_id, "carries a new model");
+        send.settings = Some(freshell_protocol::FreshAgentSendSettings {
+            cwd: None,
+            model: Some("opus[1m]".to_string()),
+            effort: Some("high".to_string()),
+            permission_mode: None,
+            sandbox: None,
+        });
+        state.handle_send(send).await;
+        let _ = env.respond_log_frames(1).await;
+
+        let frames = drain(&mut rx).await;
+        let metadata = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata")
+            .expect("a settings-changing send broadcasts metadata");
+        assert_eq!(metadata["sessionId"], json!(session_id));
+        assert_eq!(metadata["event"]["model"], json!("opus[1m]"));
+        assert_eq!(metadata["event"]["effort"], json!("high"));
     }
 }

--- a/crates/freshell-freshagent/src/codex.rs
+++ b/crates/freshell-freshagent/src/codex.rs
@@ -68,10 +68,10 @@ use freshell_codex::{
     CODEX_SIDECAR_OWNERSHIP_ENV,
 };
 use freshell_protocol::{
-    ErrorCode, ErrorMsg, FreshAgentAttach, FreshAgentCompact, FreshAgentCreate,
-    FreshAgentCreateFailed, FreshAgentCreated, FreshAgentEvent, FreshAgentFork, FreshAgentForked,
-    FreshAgentInterrupt, FreshAgentKill, FreshAgentKilled, FreshAgentSend,
-    FreshAgentSessionMaterialized, ServerMessage, SessionLocator,
+    ErrorCode, ErrorMsg, FreshAgentAttach, FreshAgentCompact, FreshAgentConfigure,
+    FreshAgentCreate, FreshAgentCreateFailed, FreshAgentCreated, FreshAgentEvent,
+    FreshAgentFork, FreshAgentForked, FreshAgentInterrupt, FreshAgentKill, FreshAgentKilled,
+    FreshAgentSend, FreshAgentSessionMaterialized, ServerMessage, SessionLocator,
 };
 use freshell_terminal::FrameSink;
 
@@ -1761,7 +1761,9 @@ impl FreshCodexState {
 
         // Only persist choices once the provider has accepted them. Failed sends
         // keep the previous working settings for resume and retry.
+        let mut settings_changed = false;
         if let Some(session) = self.sessions.lock().await.get_mut(&session_id) {
+            settings_changed = session.model != model || session.effort != effort;
             session.model = model.clone();
             session.effort = effort.clone();
             session.cwd = turn_cwd.clone();
@@ -1782,6 +1784,20 @@ impl FreshCodexState {
             None,
         )
         .await;
+
+        // A send whose settings CHANGED the session record converges every
+        // device's model surfaces (the same frame `handle_configure` emits —
+        // a device that missed the configure still lands here). Keyed at the
+        // client-addressed id, the same stamp the accepted frame below uses.
+        if settings_changed {
+            self.broadcast(&crate::session_metadata::session_metadata_frame(
+                PROVIDER,
+                SESSION_TYPE,
+                &session_id,
+                Some(model.as_str()),
+                effort.as_deref(),
+            ));
+        }
 
         // DIAG-01: the turn was accepted by the sidecar -- session_id + turn
         // id only, never the submitted text/prompt.
@@ -1818,6 +1834,111 @@ impl FreshCodexState {
             terminal_id: None,
             live_terminal_id: None,
         }));
+    }
+
+    // ── freshAgent.configure (WS) ────────────────────────────────────────────
+
+    /// Handle a `freshAgent.configure`: record the carried settings as the
+    /// session's NEXT-turn settings (codex's advertised `per-send` scope —
+    /// each `turn/start` carries model/effort/sandbox/approvalPolicy itself),
+    /// re-snapshot the durable binding row, and broadcast
+    /// `freshAgent.session.metadata` so every device's model surfaces converge
+    /// immediately. Explicit choices win over the stored values, exactly like
+    /// `handle_send`'s settings merge; the effort is wire-validated up front
+    /// so the record never holds a value the next turn could not send.
+    ///
+    /// No busy refusal: recording mid-turn is safe — the in-flight turn keeps
+    /// the parameters it already started with, and the next turn picks up the
+    /// recorded pair (the `per-send` contract). `INVALID_SESSION_ID` for an
+    /// unknown session surfaces on the pane's error banner.
+    pub async fn handle_configure(&self, msg: FreshAgentConfigure) {
+        let session_id = msg.session_id.clone();
+        let stored = {
+            let sessions = self.sessions.lock().await;
+            sessions.get(&session_id).map(|s| {
+                (
+                    s.model.clone(),
+                    s.effort.clone(),
+                    s.sandbox.clone(),
+                    s.permission_mode.clone(),
+                    s.cwd.clone(),
+                )
+            })
+        };
+        let Some((stored_model, stored_effort, stored_sandbox, stored_permission, stored_cwd)) =
+            stored
+        else {
+            self.emit_fresh_agent_error(
+                &session_id,
+                "INVALID_SESSION_ID",
+                "codex session not found",
+            );
+            return;
+        };
+
+        let settings = &msg.settings;
+        let mut model = settings
+            .model
+            .clone()
+            .unwrap_or_else(|| stored_model.clone());
+        let effort = settings.effort.clone().or_else(|| stored_effort.clone());
+        let mut sandbox = settings
+            .sandbox
+            .map(sandbox_wire_value)
+            .or_else(|| stored_sandbox.clone());
+        let mut permission_mode = settings
+            .permission_mode
+            .clone()
+            .or_else(|| stored_permission.clone());
+        if let Err(error) = normalize_codex_permission(&mut permission_mode, &mut sandbox) {
+            self.emit_fresh_agent_error(&session_id, "INVALID_PERMISSION_MODE", &error);
+            return;
+        }
+        // Re-normalize on configure (the same idempotent pass send applies).
+        model = normalize_freshcodex_model(Some(&model));
+        let effort = normalize_freshcodex_effort(Some(&model), effort.as_deref());
+        if let Err(err) = to_codex_reasoning_effort(effort.as_deref()) {
+            self.emit_fresh_agent_error(&session_id, "INVALID_EFFORT", &err.to_string());
+            return;
+        }
+
+        let settings_changed =
+            stored_model != model || stored_effort != effort || stored_sandbox != sandbox
+                || stored_permission != permission_mode;
+        if !settings_changed {
+            // Idempotent configure: nothing to converge.
+            return;
+        }
+        if let Some(session) = self.sessions.lock().await.get_mut(&session_id) {
+            session.model = model.clone();
+            session.effort = effort.clone();
+            session.sandbox = sandbox.clone();
+            session.permission_mode = permission_mode.clone();
+        }
+        self.record_codex_binding(
+            &session_id,
+            None,
+            &model,
+            sandbox.as_deref(),
+            permission_mode.as_deref(),
+            effort.as_deref(),
+            stored_cwd.as_deref(),
+            None,
+            // A settings record is not a new browser assertion — conn-less
+            // (the ledger merge keeps the row's prior stamps).
+            None,
+        )
+        .await;
+
+        // Broadcast keyed at the CLIENT-ADDRESSED id: the client's fold
+        // resolves the sessions-map entry by it.
+        self.broadcast(&crate::session_metadata::session_metadata_frame(
+            PROVIDER,
+            SESSION_TYPE,
+            &session_id,
+            Some(model.as_str()),
+            effort.as_deref(),
+        ));
     }
 
     // ── freshAgent.interrupt (WS) ────────────────────────────────────────────
@@ -17413,5 +17534,238 @@ pub(crate) mod tests {
             json!(100),
             "a stale provider basis never beats the record floor (the client monotonic watermark holds)"
         );
+    }
+
+    // ── freshAgent.configure: live model convergence ─────────────────────────
+
+    fn configure_msg(session_id: &str, model: Option<&str>, effort: Option<&str>) -> FreshAgentConfigure {
+        FreshAgentConfigure {
+            provider: freshell_protocol::AgentProvider::Codex,
+            session_id: session_id.to_string(),
+            session_type: freshell_protocol::SessionType::Freshcodex,
+            cwd: None,
+            request_id: Some("req-configure".to_string()),
+            settings: freshell_protocol::FreshAgentSendSettings {
+                cwd: None,
+                model: model.map(|m| m.to_string()),
+                permission_mode: None,
+                sandbox: None,
+                effort: effort.map(|e| e.to_string()),
+            },
+        }
+    }
+
+    /// Insert the lightest possible live session record (no sidecar, no
+    /// consumer): a channel-transport client + the sleep-child watcher
+    /// `insert_session_for_test` drives.
+    async fn inserted_session(
+        st: &FreshCodexState,
+        thread_id: &str,
+    ) -> std::sync::Arc<CodexAppServerClient> {
+        let (transport, _peer) = freshell_codex::new_channel_transport();
+        let (client, _notifs) = CodexAppServerClient::connect(transport);
+        let client = Arc::new(client);
+        st.insert_session_for_test(thread_id, client.clone(), None).await;
+        client
+    }
+
+    async fn drain(rx: &mut tokio::sync::broadcast::Receiver<String>) -> Vec<Value> {
+        let mut out = Vec::new();
+        while let Ok(frame) = rx.try_recv() {
+            out.push(serde_json::from_str(&frame).expect("frames are JSON"));
+        }
+        out
+    }
+
+    /// A configure records the normalized pair on the session record (the next
+    /// turn's per-send settings — codex's advertised scope) and broadcasts
+    /// `freshAgent.session.metadata` so every device's model surfaces converge.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn configure_records_the_pair_and_broadcasts_session_metadata() {
+        let (st, rx) = state_with_bus();
+        let mut rx = rx;
+        inserted_session(&st, "thread-cfg").await;
+
+        st.handle_configure(configure_msg("thread-cfg", Some("gpt-5.6-luna"), Some("high")))
+            .await;
+
+        let (model, effort) = {
+            let sessions = st.sessions.lock().await;
+            let session = sessions.get("thread-cfg").expect("session tracked");
+            (session.model.clone(), session.effort.clone())
+        };
+        assert_eq!(model, "gpt-5.6-luna");
+        assert_eq!(effort.as_deref(), Some("high"));
+
+        let frames = drain(&mut rx).await;
+        let metadata = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata")
+            .expect("a metadata frame is broadcast");
+        assert_eq!(metadata["provider"], json!("codex"));
+        assert_eq!(metadata["sessionType"], json!("freshcodex"));
+        assert_eq!(metadata["sessionId"], json!("thread-cfg"));
+        assert_eq!(metadata["event"]["model"], json!("gpt-5.6-luna"));
+        assert_eq!(metadata["event"]["effort"], json!("high"));
+    }
+
+    /// An unknown-menu effort clamps to the model's menu default (the same
+    /// two-stage normalization `handle_send` applies), and the broadcast
+    /// carries the CLAMPED value — the record never holds a raw pick.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn configure_normalizes_the_effort_before_recording_it() {
+        let (st, rx) = state_with_bus();
+        let mut rx = rx;
+        inserted_session(&st, "thread-cfg-clamp").await;
+
+        st.handle_configure(configure_msg("thread-cfg-clamp", None, Some("bogus")))
+            .await;
+
+        let effort = {
+            let sessions = st.sessions.lock().await;
+            sessions
+                .get("thread-cfg-clamp")
+                .expect("session tracked")
+                .effort
+                .clone()
+        };
+        assert_eq!(
+            effort.as_deref(),
+            Some("max"),
+            "an unknown-menu effort clamps to gpt-5.3-codex-spark's default"
+        );
+        let frames = drain(&mut rx).await;
+        let metadata = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata")
+            .expect("a metadata frame is broadcast");
+        assert_eq!(metadata["event"]["effort"], json!("max"));
+    }
+
+    /// An idempotent configure (same effective pair) stays silent on the bus.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_idempotent_configure_broadcasts_no_metadata() {
+        let (st, rx) = state_with_bus();
+        let mut rx = rx;
+        inserted_session(&st, "thread-cfg-idem").await;
+
+        st.handle_configure(configure_msg("thread-cfg-idem", Some("gpt-5.6-luna"), Some("high")))
+            .await;
+        let first = drain(&mut rx).await;
+        assert_eq!(
+            first
+                .iter()
+                .filter(|f| f["type"] == "freshAgent.event"
+                    && f["event"]["type"] == "freshAgent.session.metadata")
+                .count(),
+            1
+        );
+
+        st.handle_configure(configure_msg("thread-cfg-idem", Some("gpt-5.6-luna"), Some("high")))
+            .await;
+        let second = drain(&mut rx).await;
+        assert!(
+            !second.iter().any(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata"),
+            "an idempotent configure converges nothing"
+        );
+    }
+
+    /// An unknown session answers the pane-banner `freshAgent.error`
+    /// (INVALID_SESSION_ID), never a metadata frame.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn configure_for_an_unknown_session_answers_invalid_session_id() {
+        let (st, rx) = state_with_bus();
+        let mut rx = rx;
+
+        st.handle_configure(configure_msg("thread-nope", Some("gpt-5.6-luna"), None))
+            .await;
+
+        let frames = drain(&mut rx).await;
+        let error = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.error")
+            .expect("the unknown session surfaces a freshAgent.error frame");
+        assert_eq!(error["event"]["code"], json!("INVALID_SESSION_ID"));
+        assert!(
+            !frames.iter().any(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata"),
+            "no metadata converges for an unknown session"
+        );
+    }
+
+    /// A send whose settings CHANGE the session record broadcasts the metadata
+    /// convergence frame at the turn-accept apply site (the same frame
+    /// `handle_configure` emits — a device that missed the configure still
+    /// lands here); a send with UNCHANGED settings stays silent.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_send_with_changed_settings_broadcasts_session_metadata() {
+        let _guard = ENV_LOCK.lock().await;
+        configure_fake_codex_cmd("{}");
+        let (st, mut rx) = state_with_bus();
+
+        let thread_id = create_real_fake_session(&st, &mut rx).await;
+
+        let send_with_settings = |text: &str, model: &str, effort: &str| FreshAgentSend {
+            provider: freshell_protocol::AgentProvider::Codex,
+            session_id: thread_id.clone(),
+            session_type: freshell_protocol::SessionType::Freshcodex,
+            text: text.to_string(),
+            cwd: None,
+            images: None,
+            request_id: None,
+            settings: Some(freshell_protocol::FreshAgentSendSettings {
+                cwd: None,
+                model: Some(model.to_string()),
+                permission_mode: None,
+                sandbox: None,
+                effort: Some(effort.to_string()),
+            }),
+        };
+
+        // First send carries the initial pair.
+        st.handle_send(send_with_settings("one", "gpt-5.6-luna", "high"))
+            .await;
+        let first = collect_frames_until(
+            &mut rx,
+            std::time::Duration::from_secs(5),
+            |f| f["type"] == "freshAgent.send.accepted",
+        )
+        .await;
+        assert!(first.matched, "the fake app-server accepts the turn");
+
+        // Second send CHANGES the pair: the apply site must converge.
+        st.handle_send(send_with_settings("two", "gpt-5.6-sol", "low"))
+            .await;
+        let second = collect_frames_until(
+            &mut rx,
+            std::time::Duration::from_secs(5),
+            |f| {
+                f["type"] == "freshAgent.event"
+                    && f["event"]["type"] == "freshAgent.session.metadata"
+            },
+        )
+        .await;
+        assert!(
+            second.matched,
+            "a settings-changing send broadcasts metadata: {:?}",
+            second.frames
+        );
+        let metadata = second
+            .frames
+            .iter()
+            .rev()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata")
+            .expect("the metadata frame");
+        assert_eq!(metadata["sessionId"], json!(thread_id));
+        assert_eq!(metadata["event"]["model"], json!("gpt-5.6-sol"));
+        assert_eq!(metadata["event"]["effort"], json!("low"));
+
+        std::env::remove_var("CODEX_CMD");
+        std::env::remove_var("FAKE_CODEX_APP_SERVER_BEHAVIOR");
     }
 }

--- a/crates/freshell-freshagent/src/lib.rs
+++ b/crates/freshell-freshagent/src/lib.rs
@@ -49,6 +49,7 @@ pub mod pane_ops;
 mod pane_resize;
 pub mod rollback_record;
 pub mod session_lease;
+pub mod session_metadata;
 pub mod snapshot;
 pub mod spawn_gate;
 pub(crate) mod summary;

--- a/crates/freshell-freshagent/src/opencode_ws.rs
+++ b/crates/freshell-freshagent/src/opencode_ws.rs
@@ -69,10 +69,11 @@ use freshell_opencode::{
     SdkProviderEvent, ServeError, SessionSignal, SnapshotStatus,
 };
 use freshell_protocol::{
-    ErrorCode, ErrorMsg, FreshAgentAttach, FreshAgentCompact, FreshAgentCreate,
-    FreshAgentCreateFailed, FreshAgentCreated, FreshAgentEvent, FreshAgentFork, FreshAgentForked,
-    FreshAgentInterrupt, FreshAgentKill, FreshAgentKilled, FreshAgentSend, FreshAgentSendAccepted,
-    FreshAgentSessionMaterialized, ServerMessage, SessionLocator,
+    ErrorCode, ErrorMsg, FreshAgentAttach, FreshAgentCompact, FreshAgentConfigure,
+    FreshAgentCreate, FreshAgentCreateFailed, FreshAgentCreated, FreshAgentEvent,
+    FreshAgentFork, FreshAgentForked, FreshAgentInterrupt, FreshAgentKill, FreshAgentKilled,
+    FreshAgentSend, FreshAgentSendAccepted, FreshAgentSessionMaterialized, ServerMessage,
+    SessionLocator,
 };
 use freshell_terminal::FrameSink;
 
@@ -1102,6 +1103,8 @@ impl FreshOpencodeState {
             durable_id
         };
 
+        let previous_model = session.model.clone();
+        let previous_effort = session.effort.clone();
         session.model = model.clone();
         session.effort = effort.clone();
 
@@ -1127,8 +1130,21 @@ impl FreshOpencodeState {
                     effort: session.effort.clone(),
                     cwd: session.cwd.clone(),
                 },
-            })
-            .await;
+             })
+             .await;
+         }
+
+        // A send whose settings CHANGED the session record converges every
+        // device's model surfaces (the same frame `handle_configure` emits —
+        // a device that missed the configure still lands here).
+        if previous_model != model || previous_effort != effort {
+            self.broadcast(&crate::session_metadata::session_metadata_frame(
+                PROVIDER,
+                SESSION_TYPE,
+                &busy_session_id,
+                model.as_deref(),
+                effort.as_deref(),
+            ));
         }
 
         let real_id = acked_session_id.clone();
@@ -1183,6 +1199,110 @@ impl FreshOpencodeState {
             handle: turn_task,
             compact_settled_rx: None,
         });
+    }
+
+    // ── freshAgent.configure (WS) ────────────────────────────────────────────
+
+    /// Handle a `freshAgent.configure`: apply the carried settings to the LIVE
+    /// session record NOW (they ride the next turn's prompt body — opencode's
+    /// advertised `per-send` setting scope), refresh the durable binding row's
+    /// settings when the session has materialized, and broadcast
+    /// `freshAgent.session.metadata` so every device's model surfaces converge
+    /// immediately. Model/effort are normalized PURELY from the carried
+    /// settings — the same rule `handle_send` applies (`normalizeOpencodeInput`:
+    /// a settings object that omits model CLEARS it) — so a configure is
+    /// exactly "what the next send would have carried", minus the turn.
+    ///
+    /// sandbox/permissionMode have NO opencode wire concept: logged
+    /// observably, never silently dropped (kata z7j7, same as the send path).
+    /// No busy refusal: recording mid-turn is safe — the in-flight turn keeps
+    /// the model it already prompted with, and the next turn picks up the new
+    /// pair (the `per-send` contract).
+    pub async fn handle_configure(&self, msg: FreshAgentConfigure) {
+        let session_id = msg.session_id.clone();
+        let session_arc = {
+            let guard = self.sessions.lock().await;
+            guard.get(&session_id).cloned()
+        };
+        let Some(session_arc) = session_arc else {
+            self.emit_fresh_agent_error(
+                &session_id,
+                "INVALID_SESSION_ID",
+                "opencode session not found",
+            );
+            return;
+        };
+
+        let mut session = session_arc.lock().await;
+        // The killed/close-pending gates (the same refusals `handle_send`
+        // applies): a configure for a pane that is going away must never
+        // re-assert a ledger row the kill is retiring.
+        if session.killed.load(Ordering::SeqCst) || session.close_pending > 0 {
+            drop(session);
+            self.emit_fresh_agent_error(
+                &session_id,
+                "INVALID_SESSION_ID",
+                "opencode session not found",
+            );
+            return;
+        }
+
+        if msg.settings.sandbox.is_some() || msg.settings.permission_mode.is_some() {
+            tracing::info!(
+                session_id = %session_id,
+                has_sandbox = msg.settings.sandbox.is_some(),
+                has_permission_mode = msg.settings.permission_mode.is_some(),
+                "freshagent.opencode.configure-unsupported-settings-ignored"
+            );
+        }
+
+        let model = normalize_opencode_model(msg.settings.model.as_deref());
+        let effort = normalize_opencode_effort(model.as_deref(), msg.settings.effort.as_deref());
+        let changed = session.model != model || session.effort != effort;
+        if !changed {
+            // Idempotent configure: nothing to converge.
+            return;
+        }
+        session.model = model.clone();
+        session.effort = effort.clone();
+
+        // Materialized sessions re-snapshot the binding row's settings (the
+        // same per-send refresh `handle_send` performs — durable before the
+        // broadcast). A configure for a placeholder has no row yet; the
+        // materialization write will carry the staged pair.
+        let durable_id = session.real_session_id.clone();
+        let provenance = session.provenance.clone();
+        let cwd = session.cwd.clone();
+        drop(session);
+        if let Some(durable_id) = durable_id {
+            self.record_binding_row(crate::identity_sink::FreshAgentBindingUpsert {
+                provider: PROVIDER.into(),
+                session_id: durable_id,
+                mode: SESSION_TYPE.into(),
+                create_request_id: None,
+                resolves_pending: None,
+                supersedes: None,
+                provenance: provenance.into(),
+                settings: crate::identity_sink::FreshAgentSettings {
+                    model: model.clone(),
+                    sandbox: None,
+                    permission_mode: None,
+                    effort: effort.clone(),
+                    cwd,
+                },
+            })
+            .await;
+        }
+
+        // Broadcast keyed at the CLIENT-ADDRESSED id (the id the configure
+        // named): the client's fold resolves the sessions-map entry by it.
+        self.broadcast(&crate::session_metadata::session_metadata_frame(
+            PROVIDER,
+            SESSION_TYPE,
+            &session_id,
+            model.as_deref(),
+            effort.as_deref(),
+        ));
     }
 
     /// Reconcile liveness probe (campaign §4.3, Task 13): is this id tracked
@@ -11588,5 +11708,282 @@ mod tests {
             !record.can_redo(),
             "the new chain is fully restored; the frozen rows stay ledger-only"
         );
+    }
+
+    // ── freshAgent.configure: live model convergence ─────────────────────────
+
+    fn configure_msg(session_id: &str, model: Option<&str>, effort: Option<&str>) -> FreshAgentConfigure {
+        FreshAgentConfigure {
+            provider: AgentProvider::Opencode,
+            session_id: session_id.to_string(),
+            session_type: SessionType::Freshopencode,
+            cwd: None,
+            request_id: Some("req-configure".to_string()),
+            settings: freshell_protocol::FreshAgentSendSettings {
+                cwd: None,
+                model: model.map(|m| m.to_string()),
+                permission_mode: None,
+                sandbox: None,
+                effort: effort.map(|e| e.to_string()),
+            },
+        }
+    }
+
+    fn send_msg_with_settings(
+        session_id: &str,
+        text: &str,
+        model: Option<&str>,
+        effort: Option<&str>,
+    ) -> FreshAgentSend {
+        FreshAgentSend {
+            provider: AgentProvider::Opencode,
+            session_id: session_id.to_string(),
+            session_type: SessionType::Freshopencode,
+            text: text.to_string(),
+            cwd: None,
+            images: None,
+            request_id: Some(format!("req-{text}")),
+            settings: Some(freshell_protocol::FreshAgentSendSettings {
+                cwd: None,
+                model: model.map(|m| m.to_string()),
+                permission_mode: None,
+                sandbox: None,
+                effort: effort.map(|e| e.to_string()),
+            }),
+        }
+    }
+
+    /// Drain every frame currently buffered on the bus.
+    async fn drain(rx: &mut tokio::sync::broadcast::Receiver<String>) -> Vec<serde_json::Value> {
+        let mut out = Vec::new();
+        while let Ok(frame) = rx.try_recv() {
+            out.push(serde_json::from_str(&frame).expect("frames are JSON"));
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn configure_records_the_pair_and_broadcasts_session_metadata() {
+        let (tx, rx) = tokio::sync::broadcast::channel::<String>(64);
+        let fresh_agent = FreshAgentState::new(Arc::new("tok".to_string()), Arc::new(tx));
+        let (manager, _killed) = started_manager().await;
+        fresh_agent.set_manager_for_test(manager).await;
+        let st = FreshOpencodeState::new(fresh_agent);
+
+        st.handle_create(create_msg("req-cfg-live"), None).await;
+        let placeholder = "freshopencode-req-cfg-live";
+        let mut rx = rx;
+
+        st.handle_configure(configure_msg(placeholder, Some("prov/mdl-b"), Some("low")))
+            .await;
+
+        // The session record holds the staged pair…
+        let sessions = st.sessions.lock().await;
+        let session = sessions.get(placeholder).expect("session tracked").lock().await;
+        assert_eq!(session.model.as_deref(), Some("prov/mdl-b"));
+        assert_eq!(session.effort.as_deref(), Some("low"));
+        drop(session);
+        drop(sessions);
+
+        // …and the metadata broadcast converges every device's surfaces,
+        // keyed at the CLIENT-ADDRESSED id (the placeholder here).
+        let frames = drain(&mut rx).await;
+        let metadata = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata")
+            .expect("a metadata frame is broadcast");
+        assert_eq!(metadata["provider"], json!("opencode"));
+        assert_eq!(metadata["sessionType"], json!("freshopencode"));
+        assert_eq!(metadata["sessionId"], json!(placeholder));
+        assert_eq!(metadata["event"]["sessionId"], json!(placeholder));
+        assert_eq!(metadata["event"]["model"], json!("prov/mdl-b"));
+        assert_eq!(metadata["event"]["effort"], json!("low"));
+    }
+
+    #[tokio::test]
+    async fn an_idempotent_configure_broadcasts_no_metadata() {
+        let (tx, rx) = tokio::sync::broadcast::channel::<String>(64);
+        let fresh_agent = FreshAgentState::new(Arc::new("tok".to_string()), Arc::new(tx));
+        let (manager, _killed) = started_manager().await;
+        fresh_agent.set_manager_for_test(manager).await;
+        let st = FreshOpencodeState::new(fresh_agent);
+        let mut rx = rx;
+
+        st.handle_create(create_msg("req-cfg-idem"), None).await;
+        let placeholder = "freshopencode-req-cfg-idem";
+        st.handle_configure(configure_msg(placeholder, Some("prov/mdl-b"), None))
+            .await;
+        let first = drain(&mut rx).await;
+        assert_eq!(
+            first
+                .iter()
+                .filter(|f| f["type"] == "freshAgent.event"
+                    && f["event"]["type"] == "freshAgent.session.metadata")
+                .count(),
+            1,
+            "the first (changing) configure broadcasts exactly one metadata frame"
+        );
+
+        // Same values again: nothing changed, nothing converges, no frame.
+        st.handle_configure(configure_msg(placeholder, Some("prov/mdl-b"), None))
+            .await;
+        let second = drain(&mut rx).await;
+        assert!(
+            !second.iter().any(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata"),
+            "an idempotent configure stays silent on the bus"
+        );
+    }
+
+    #[tokio::test]
+    async fn configure_for_an_unknown_session_answers_invalid_session_id() {
+        let (tx, rx) = tokio::sync::broadcast::channel::<String>(64);
+        let fresh_agent = FreshAgentState::new(Arc::new("tok".to_string()), Arc::new(tx));
+        let st = FreshOpencodeState::new(fresh_agent);
+        let mut rx = rx;
+
+        st.handle_configure(configure_msg("freshopencode-nope", Some("prov/mdl-b"), None))
+            .await;
+
+        let frames = drain(&mut rx).await;
+        let error = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.error")
+            .expect("the unknown session surfaces a freshAgent.error frame");
+        assert_eq!(error["event"]["code"], json!("INVALID_SESSION_ID"));
+        assert_eq!(error["sessionId"], json!("freshopencode-nope"));
+    }
+
+    #[tokio::test]
+    async fn configure_on_a_killed_session_is_refused_before_any_side_effect() {
+        let (tx, rx) = tokio::sync::broadcast::channel::<String>(64);
+        let fresh_agent = FreshAgentState::new(Arc::new("tok".to_string()), Arc::new(tx));
+        let (manager, _killed) = started_manager().await;
+        fresh_agent.set_manager_for_test(manager).await;
+        let st = FreshOpencodeState::new(fresh_agent);
+        let fake = std::sync::Arc::new(crate::identity_sink::FakeIdentitySink::default());
+        st.set_identity_sink(fake.clone());
+
+        st.handle_create(create_msg("req-cfg-killed"), None).await;
+        let placeholder = "freshopencode-req-cfg-killed";
+        let session_arc = {
+            let sessions = st.sessions.lock().await;
+            sessions.get(placeholder).expect("session tracked").clone()
+        };
+        session_arc.lock().await.killed.store(true, Ordering::SeqCst);
+        let mut rx = rx;
+
+        st.handle_configure(configure_msg(placeholder, Some("prov/mdl-b"), None))
+            .await;
+
+        let frames = drain(&mut rx).await;
+        let error = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.error")
+            .expect("the killed session refuses with an error frame");
+        assert_eq!(error["event"]["code"], json!("INVALID_SESSION_ID"));
+        // The record is untouched: no metadata, no binding write.
+        assert!(
+            !frames.iter().any(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata"),
+            "a refused configure never converges a dying session"
+        );
+        assert!(fake.bindings.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_send_with_changed_settings_broadcasts_session_metadata() {
+        let (tx, rx) = tokio::sync::broadcast::channel::<String>(64);
+        let fresh_agent = FreshAgentState::new(Arc::new("tok".to_string()), Arc::new(tx));
+        let (manager, _killed) = started_manager().await;
+        fresh_agent.set_manager_for_test(manager).await;
+        let st = FreshOpencodeState::new(fresh_agent);
+        let fake = std::sync::Arc::new(crate::identity_sink::FakeIdentitySink::default());
+        st.set_identity_sink(fake.clone());
+        let mut rx = rx;
+
+        st.handle_create(create_msg("req-cfg-send"), None).await;
+        let placeholder = "freshopencode-req-cfg-send";
+
+        // First send carries the initial pair (materializes + records)…
+        st.handle_send(send_msg_with_settings(placeholder, "one", Some("prov/mdl-a"), Some("high")))
+            .await;
+        let _ = drain(&mut rx).await;
+
+        // …the second send CHANGES the pair: the accepted-turn apply path must
+        // converge the metadata broadcast, keyed at the durable id the pane now
+        // holds (the same stamp the accepted frame uses).
+        st.handle_send(send_msg_with_settings(placeholder, "two", Some("prov/mdl-b"), Some("low")))
+            .await;
+        let frames = drain(&mut rx).await;
+        let metadata = frames
+            .iter()
+            .find(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata")
+            .expect("a settings-changing send broadcasts metadata");
+        assert_eq!(metadata["event"]["model"], json!("prov/mdl-b"));
+        assert_eq!(metadata["event"]["effort"], json!("low"));
+        assert!(
+            metadata["sessionId"].as_str().unwrap().starts_with("ses_"),
+            "post-materialization broadcasts key at the durable id"
+        );
+
+        // A send with UNCHANGED settings adds no second metadata frame.
+        st.handle_send(send_msg_with_settings(placeholder, "three", Some("prov/mdl-b"), Some("low")))
+            .await;
+        let frames = drain(&mut rx).await;
+        assert!(
+            !frames.iter().any(|f| f["type"] == "freshAgent.event"
+                && f["event"]["type"] == "freshAgent.session.metadata"),
+            "an unchanged-settings send stays silent"
+        );
+    }
+
+    #[tokio::test]
+    async fn configure_on_a_materialized_session_re_snapshots_the_binding_row() {
+        let (tx, rx) = tokio::sync::broadcast::channel::<String>(64);
+        let fresh_agent = FreshAgentState::new(Arc::new("tok".to_string()), Arc::new(tx));
+        let (manager, _killed) = started_manager().await;
+        fresh_agent.set_manager_for_test(manager).await;
+        let st = FreshOpencodeState::new(fresh_agent);
+        let fake = std::sync::Arc::new(crate::identity_sink::FakeIdentitySink::default());
+        st.set_identity_sink(fake.clone());
+        let mut rx = rx;
+
+        st.handle_create(create_msg("req-cfg-row"), None).await;
+        let placeholder = "freshopencode-req-cfg-row";
+        st.handle_send(send_msg_with_settings(placeholder, "one", Some("prov/mdl-a"), Some("high")))
+            .await;
+        let _ = drain(&mut rx).await;
+        let durable = {
+            let sessions = st.sessions.lock().await;
+            let session_arc = sessions.get(placeholder).expect("tracked").clone();
+            drop(sessions);
+            let session = session_arc.lock().await;
+            session.real_session_id.clone().expect("materialized")
+        };
+
+        st.handle_configure(configure_msg(&durable, Some("prov/mdl-b"), Some("low")))
+            .await;
+        let frames = drain(&mut rx).await;
+        assert!(
+            frames
+                .iter()
+                .any(|f| f["type"] == "freshAgent.event"
+                    && f["event"]["type"] == "freshAgent.session.metadata"
+                    && f["event"]["model"] == json!("prov/mdl-b")),
+            "the durable-id configure converges too"
+        );
+        let bindings = fake.bindings.lock().unwrap();
+        let last = bindings
+            .iter()
+            .rev()
+            .find(|b| b.session_id == durable)
+            .expect("a binding row re-snapshot");
+        assert_eq!(last.settings.model.as_deref(), Some("prov/mdl-b"));
+        assert_eq!(last.settings.effort.as_deref(), Some("low"));
     }
 }

--- a/crates/freshell-freshagent/src/session_metadata.rs
+++ b/crates/freshell-freshagent/src/session_metadata.rs
@@ -1,0 +1,106 @@
+//! # freshell-freshagent :: session_metadata — the live-settings convergence frame
+//!
+//! The `freshAgent.session.metadata` broadcast is the ONE wire event that keeps
+//! every device's model surfaces (status-strip chip, gear popover, tooltips) in
+//! sync with the LIVE session's effective settings. The frame and the client
+//! fold have existed since the protocol's first cut — but no server ever
+//! EMITTED it, so a model change staged on one device never propagated to the
+//! session record (or any other device), leaving the chip showing stale
+//! session truth (the codex snapshot-settings mask) or a raw init id with no
+//! label (the claude init mask).
+//!
+//! Emission sites (every place the LIVE session's effective model/effort can
+//! change — see the per-slice `handle_configure` and `handle_send`):
+//!
+//! * `freshAgent.configure` — the client's model dialog / settings popover
+//!   committing a change to a LIVE session. Claude/kilroy apply it for real
+//!   through the sidecar's configure lane (`setModel` et al.); codex and
+//!   opencode record it as the next turn's per-send settings (their advertised
+//!   `per-send` scope).
+//! * `freshAgent.send` carrying settings that CHANGE the session record — the
+//!   turn-accept apply path (codex/opencode) or the sidecar configure-for-send
+//!   path (claude). A device that missed the configure still converges here.
+//!
+//! The event ALWAYS states the post-apply effective pair: `model` and `effort`
+//! are serialized as strings, with JSON `null` meaning "explicitly no value"
+//! (e.g. opencode's Default thinking row clears effort; an opencode configure
+//! with no model clears the model). An ABSENT key is "no statement" — the
+//! client keeps whatever it has — which is exactly what an older server's
+//! silence degrades to.
+//!
+//! The envelope is stamped with the CLIENT-ADDRESSED session id (the id the
+//! configure/send named), never an internal alias: the client's fold resolves
+//! the sessions-map entry by that id, and alias-aware resolution (claude's
+//! placeholder ↔ durable cli_index) is a server-side concern.
+
+use freshell_protocol::{FreshAgentEvent, ServerMessage};
+use serde_json::json;
+
+/// Build the `freshAgent.event { freshAgent.session.metadata }` broadcast.
+///
+/// `model` / `effort` are the post-apply EFFECTIVE values the event states
+/// (`None` serializes as JSON null — an explicit clear). Broadcast only on an
+/// actual change: the slices diff their session record around the apply.
+pub fn session_metadata_frame(
+    provider: &str,
+    session_type: &str,
+    session_id: &str,
+    model: Option<&str>,
+    effort: Option<&str>,
+) -> ServerMessage {
+    ServerMessage::FreshAgentEvent(FreshAgentEvent {
+        event: json!({
+            "type": "freshAgent.session.metadata",
+            "sessionId": session_id,
+            "model": model,
+            "effort": effort,
+        }),
+        provider: provider.to_string(),
+        session_id: session_id.to_string(),
+        session_type: session_type.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_frame_states_the_effective_pair_with_explicit_nulls() {
+        let frame = session_metadata_frame(
+            "codex",
+            "freshcodex",
+            "thread-1",
+            Some("gpt-5.6-luna"),
+            None,
+        );
+        let ServerMessage::FreshAgentEvent(inner) = &frame else {
+            panic!("metadata rides the freshAgent.event envelope");
+        };
+        assert_eq!(inner.provider, "codex");
+        assert_eq!(inner.session_type, "freshcodex");
+        assert_eq!(inner.session_id, "thread-1");
+        assert_eq!(inner.event["type"], "freshAgent.session.metadata");
+        assert_eq!(inner.event["sessionId"], "thread-1");
+        assert_eq!(inner.event["model"], "gpt-5.6-luna");
+        // An explicit clear serializes as null, never as an absent key.
+        assert_eq!(inner.event["effort"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn metadata_frame_survives_a_wire_roundtrip() {
+        let frame = session_metadata_frame(
+            "opencode",
+            "freshopencode",
+            "ses_1",
+            Some("prov/mdl"),
+            Some("low"),
+        );
+        let wire = serde_json::to_string(&frame).expect("serializes");
+        let back: serde_json::Value = serde_json::from_str(&wire).expect("parses");
+        assert_eq!(back["type"], "freshAgent.event");
+        assert_eq!(back["event"]["type"], "freshAgent.session.metadata");
+        assert_eq!(back["event"]["model"], "prov/mdl");
+        assert_eq!(back["event"]["effort"], "low");
+    }
+}

--- a/crates/freshell-protocol/src/client_messages.rs
+++ b/crates/freshell-protocol/src/client_messages.rs
@@ -1,4 +1,4 @@
-//! Client → server messages (`ClientMessage`, 39 discriminants).
+//! Client → server messages (`ClientMessage`, 40 discriminants).
 //!
 //! These are the Zod-validated inbound surface. Deserialization is
 //! accept-and-strip (no `deny_unknown_fields`), mirroring the runtime.
@@ -86,6 +86,15 @@ pub enum ClientMessage {
     FreshAgentSend(FreshAgentSend),
     #[serde(rename = "freshAgent.interrupt")]
     FreshAgentInterrupt(FreshAgentInterrupt),
+    /// `freshAgent.configure` — apply settings (model / effort / permission
+    /// mode / sandbox) to a LIVE session without sending a message, so every
+    /// device's model surfaces converge immediately. The server broadcasts
+    /// `freshAgent.session.metadata` with the new effective settings; a
+    /// refused configure surfaces as the session-scoped `freshAgent.error`
+    /// (e.g. changing model mid-turn on claude). Additive: older servers
+    /// accept-and-strip the frame (degrading to staged-at-next-send).
+    #[serde(rename = "freshAgent.configure")]
+    FreshAgentConfigure(FreshAgentConfigure),
     #[serde(rename = "freshAgent.compact")]
     FreshAgentCompact(FreshAgentCompact),
     #[serde(rename = "freshAgent.approval.respond")]
@@ -112,7 +121,7 @@ pub enum ClientMessage {
 
 /// The exact `type` discriminants of every client→server message, in the frozen
 /// inventory's order. This is the T0 conformance checklist.
-pub const CLIENT_MESSAGE_TYPES: [&str; 40] = [
+pub const CLIENT_MESSAGE_TYPES: [&str; 41] = [
     "amplifier.activity.list",
     "claude.activity.list",
     "client.diagnostic",
@@ -123,6 +132,7 @@ pub const CLIENT_MESSAGE_TYPES: [&str; 40] = [
     "freshAgent.approval.respond",
     "freshAgent.attach",
     "freshAgent.compact",
+    "freshAgent.configure",
     "freshAgent.create",
     "freshAgent.fork",
     "freshAgent.interrupt",
@@ -779,6 +789,22 @@ pub struct FreshAgentInterrupt {
     pub session_type: SessionType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+}
+
+/// `freshAgent.configure` payload — the settings mirror [`FreshAgentSendSettings`]
+/// (model / effort / permission mode / sandbox / cwd), applied to the LIVE
+/// session instead of riding the next send.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FreshAgentConfigure {
+    pub provider: AgentProvider,
+    pub session_id: String,
+    pub session_type: SessionType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    pub settings: FreshAgentSendSettings,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/freshell-protocol/src/lib.rs
+++ b/crates/freshell-protocol/src/lib.rs
@@ -37,7 +37,7 @@ pub use settings::*;
 pub const WS_PROTOCOL_VERSION: u32 = 10;
 
 /// Every `type` discriminant the protocol speaks, both directions, sorted.
-/// (39 client→server + 63 server→client = 102.)
+/// (40 client→server + 64 server→client = 105.)
 pub fn all_message_types() -> Vec<&'static str> {
     let mut types: Vec<&'static str> = client_messages::CLIENT_MESSAGE_TYPES
         .iter()

--- a/crates/freshell-protocol/tests/inventory.rs
+++ b/crates/freshell-protocol/tests/inventory.rs
@@ -31,12 +31,12 @@ fn client_types_match_inventory_exactly() {
     let inv = inventory();
     assert_eq!(
         inv["clientToServer"]["count"].as_u64(),
-        Some(40),
-        "inventory declares 40 client→server types"
+        Some(41),
+        "inventory declares 41 client→server types"
     );
     let expected = json_type_set(&inv["clientToServer"]["types"]);
     let actual: BTreeSet<String> = CLIENT_MESSAGE_TYPES.iter().map(|s| s.to_string()).collect();
-    assert_eq!(actual.len(), 40, "crate declares 40 client types (no dups)");
+    assert_eq!(actual.len(), 41, "crate declares 41 client types (no dups)");
     assert_eq!(
         actual, expected,
         "CLIENT_MESSAGE_TYPES must equal the frozen inventory (no missing/extra)"
@@ -61,14 +61,14 @@ fn server_types_match_inventory_exactly() {
 }
 
 #[test]
-fn combined_surface_is_104() {
+fn combined_surface_is_105() {
     let all = all_message_types();
-    assert_eq!(all.len(), 104, "40 client + 64 server = 104 discriminants");
+    assert_eq!(all.len(), 105, "41 client + 64 server = 105 discriminants");
     // sorted + unique
     let unique: BTreeSet<&str> = all.iter().copied().collect();
     assert_eq!(
         unique.len(),
-        104,
+        105,
         "no discriminant collides across directions"
     );
 }

--- a/crates/freshell-ws/src/terminal.rs
+++ b/crates/freshell-ws/src/terminal.rs
@@ -1296,6 +1296,35 @@ async fn handle_client_text(
             }
             true
         }
+        // `freshAgent.configure`: apply settings (model / effort / permission
+        // mode / sandbox) to a LIVE session without a turn, converging every
+        // device's model surfaces via the `freshAgent.session.metadata`
+        // broadcast. Same provider routing as send/interrupt/kill — detached
+        // tasks, never blocking the connection's select loop (a claude
+        // configure awaits the sidecar's configure RPC). `amplifier` has no
+        // fresh-agent runtime: dropped, same as its send arm.
+        ClientMessage::FreshAgentConfigure(configure) => {
+            if is_codex_provider(configure.provider) {
+                let fresh_codex = state.fresh_codex.clone();
+                tokio::spawn(
+                    async move { fresh_codex.handle_configure(configure).await }
+                        .instrument(tracing::Span::current()),
+                );
+            } else if configure.provider == freshell_protocol::AgentProvider::Claude {
+                let fresh_claude = state.fresh_claude.clone();
+                tokio::spawn(
+                    async move { fresh_claude.handle_configure(configure).await }
+                        .instrument(tracing::Span::current()),
+                );
+            } else if configure.provider == freshell_protocol::AgentProvider::Opencode {
+                let fresh_opencode = state.fresh_opencode.clone();
+                tokio::spawn(
+                    async move { fresh_opencode.handle_configure(configure).await }
+                        .instrument(tracing::Span::current()),
+                );
+            }
+            true
+        }
         ClientMessage::FreshAgentKill(kill) => {
             if is_codex_provider(kill.provider) {
                 let fresh_codex = state.fresh_codex.clone();

--- a/port/contract/ws-message-inventory.json
+++ b/port/contract/ws-message-inventory.json
@@ -1,6 +1,6 @@
 {
   "clientToServer": {
-    "count": 40,
+    "count": 41,
     "types": [
       "amplifier.activity.list",
       "claude.activity.list",
@@ -12,6 +12,7 @@
       "freshAgent.approval.respond",
       "freshAgent.attach",
       "freshAgent.compact",
+      "freshAgent.configure",
       "freshAgent.create",
       "freshAgent.fork",
       "freshAgent.interrupt",

--- a/port/contract/ws-protocol.schema.json
+++ b/port/contract/ws-protocol.schema.json
@@ -2,7 +2,7 @@
   "description": "Auto-generated from shared/ws-protocol.ts. DO NOT EDIT BY HAND. Regenerate with `npm run contract:generate`. Each entry in `schemas` is a self-contained JSON Schema for one exported Zod schema. The wire contract is frozen for the Rust port — changing it is out of scope.",
   "generator": "port/contract/generate-ws-contract.ts",
   "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
-  "schemaCount": 82,
+  "schemaCount": 83,
   "schemas": {
     "AmplifierActivityListResponseSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2036,6 +2036,81 @@
             "cwd": {
               "type": "string"
             },
+            "provider": {
+              "enum": [
+                "claude",
+                "codex",
+                "opencode"
+              ],
+              "type": "string"
+            },
+            "requestId": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "sessionId": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "sessionType": {
+              "enum": [
+                "freshclaude",
+                "freshcodex",
+                "kilroy",
+                "freshopencode"
+              ],
+              "type": "string"
+            },
+            "settings": {
+              "additionalProperties": false,
+              "properties": {
+                "cwd": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "effort": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "model": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "permissionMode": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sandbox": {
+                  "enum": [
+                    "read-only",
+                    "workspace-write",
+                    "danger-full-access"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "const": "freshAgent.configure",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "sessionId",
+            "sessionType",
+            "provider",
+            "settings"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cwd": {
+              "type": "string"
+            },
             "instructions": {
               "minLength": 1,
               "type": "string"
@@ -3312,6 +3387,81 @@
             "cwd": {
               "type": "string"
             },
+            "provider": {
+              "enum": [
+                "claude",
+                "codex",
+                "opencode"
+              ],
+              "type": "string"
+            },
+            "requestId": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "sessionId": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "sessionType": {
+              "enum": [
+                "freshclaude",
+                "freshcodex",
+                "kilroy",
+                "freshopencode"
+              ],
+              "type": "string"
+            },
+            "settings": {
+              "additionalProperties": false,
+              "properties": {
+                "cwd": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "effort": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "model": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "permissionMode": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sandbox": {
+                  "enum": [
+                    "read-only",
+                    "workspace-write",
+                    "danger-full-access"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "const": "freshAgent.configure",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "sessionId",
+            "sessionType",
+            "provider",
+            "settings"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cwd": {
+              "type": "string"
+            },
             "instructions": {
               "minLength": 1,
               "type": "string"
@@ -3727,6 +3877,82 @@
         "sessionId",
         "sessionType",
         "provider"
+      ],
+      "type": "object"
+    },
+    "FreshAgentConfigureSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cwd": {
+          "type": "string"
+        },
+        "provider": {
+          "enum": [
+            "claude",
+            "codex",
+            "opencode"
+          ],
+          "type": "string"
+        },
+        "requestId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionType": {
+          "enum": [
+            "freshclaude",
+            "freshcodex",
+            "kilroy",
+            "freshopencode"
+          ],
+          "type": "string"
+        },
+        "settings": {
+          "additionalProperties": false,
+          "properties": {
+            "cwd": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "effort": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "model": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "permissionMode": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "sandbox": {
+              "enum": [
+                "read-only",
+                "workspace-write",
+                "danger-full-access"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type": {
+          "const": "freshAgent.configure",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "sessionId",
+        "sessionType",
+        "provider",
+        "settings"
       ],
       "type": "object"
     },

--- a/server/fresh-agent/adapters/claude/adapter.ts
+++ b/server/fresh-agent/adapters/claude/adapter.ts
@@ -172,6 +172,23 @@ export function createClaudeFreshAgentAdapter(deps: ClaudeFreshAgentAdapterDeps)
       return send
     },
 
+    async configure(sessionId, input) {
+      // Serialize with in-flight sends (the same pendingSends chain `send`
+      // rides): configureSession's own busy gate refuses mid-turn changes, and
+      // the chain closes the check-then-set window against a concurrent send's
+      // own configure leg. The bridge's applied-change metadata broadcast
+      // converges every subscribed device.
+      const prior = pendingSends.get(sessionId) ?? Promise.resolve()
+      const configure = prior.then(async () => {
+        await deps.sdkBridge.configureSession(sessionId, input.settings ?? {})
+      })
+      const settled = configure.catch(() => {}).finally(() => {
+        if (pendingSends.get(sessionId) === settled) pendingSends.delete(sessionId)
+      })
+      pendingSends.set(sessionId, settled)
+      return await configure
+    },
+
     interrupt(sessionId) {
       mapMissingResult(
         deps.sdkBridge.interrupt(sessionId),

--- a/server/fresh-agent/adapters/codex/adapter.ts
+++ b/server/fresh-agent/adapters/codex/adapter.ts
@@ -1128,6 +1128,37 @@ export function createCodexFreshAgentAdapter(deps: {
       return { requestId, submittedTurnId }
     },
 
+    /** Apply settings to the LIVE thread record without a turn (codex's
+     * per-send scope: the NEXT turn/start carries the recorded pair). Merges
+     * + normalizes exactly like `send`'s settings leg, then emits the
+     * `sdk.session.metadata` convergence event to every subscribed listener.
+     * No busy refusal: the in-flight turn keeps the parameters it started
+     * with, and the next turn picks up the recorded pair. */
+    async configure(sessionId, input) {
+      const settings: Partial<FreshAgentCreateRequest> = {
+        ...settingsByThread.get(sessionId),
+        ...input.settings,
+      }
+      const model = normalizeFreshAgentModel(settings.sessionType ?? 'freshcodex', 'codex', settings.model)
+      settings.model = model
+      settings.effort = normalizeFreshAgentEffort(settings.sessionType ?? 'freshcodex', 'codex', model, settings.effort)
+      // Wire-validate up front so the record never holds an unsendable value.
+      toCodexReasoningEffort(settings.effort)
+      if (Object.keys(settings).length > 0) {
+        settingsByThread.set(sessionId, settings)
+      }
+      const listeners = deadmanListenersByThread.get(sessionId)
+      if (!listeners) return
+      for (const listener of listeners) {
+        listener({
+          type: 'sdk.session.metadata',
+          sessionId,
+          model: settings.model,
+          effort: settings.effort,
+        })
+      }
+    },
+
     async interrupt(sessionId) {
       const runtime = await ensureRuntime(sessionId, settingsByThread.get(sessionId))
       if (!runtime.interruptTurn) {

--- a/server/fresh-agent/adapters/opencode/adapter.ts
+++ b/server/fresh-agent/adapters/opencode/adapter.ts
@@ -1092,6 +1092,32 @@ export function createOpencodeFreshAgentAdapter(options: CreateOpencodeFreshAgen
       return await sendForState(state, { text: input.text, settings: input.settings })
     },
 
+    /** Apply settings to the LIVE session record without a turn (opencode's
+     * per-send scope: the NEXT prompt_async body carries the recorded pair).
+     * Mirrors `materializeOrSend`'s settings-merge semantics (present settings
+     * normalize over the record; an absent key keeps the stored value), then
+     * emits the `sdk.session.metadata` convergence event so every subscribed
+     * device's model surfaces update immediately. No busy refusal: recording
+     * mid-turn is safe — the in-flight turn keeps the pair it prompted with. */
+    async configure(sessionId, input) {
+      const state = requireState(sessionId)
+      const settings = (input.settings ?? {}) as Partial<FreshAgentCreateRequest>
+      const normalized = input.settings
+        ? normalizeOpencodeInput({ requestId: state.placeholderId, sessionType: 'freshopencode', provider: 'opencode', ...settings } as FreshAgentCreateRequest)
+        : undefined
+      const model = normalized?.model ?? state.model
+      const effort = normalized?.effort ?? state.effort
+      if (state.model === model && state.effort === effort) return
+      state.model = model
+      state.effort = effort
+      state.events.emit('event', {
+        type: 'sdk.session.metadata',
+        sessionId,
+        model: state.model,
+        effort: state.effort,
+      })
+    },
+
     async interrupt(sessionId) {
       const state = requireState(sessionId)
       // Mark before aborting so the in-flight send (parked on onceIdle) sees the abort and

--- a/server/fresh-agent/observability.ts
+++ b/server/fresh-agent/observability.ts
@@ -63,6 +63,17 @@ export type FreshAgentObservabilityEvent =
     errorCode?: string
   }
   | {
+    kind: 'fresh_agent_configure'
+    sessionType: string
+    provider: string
+    sessionIdHash: string
+    cwdHash?: string
+    requestId?: string
+    outcome: 'ok' | 'failed'
+    errorCode?: string
+    durationMs?: number
+  }
+  | {
     kind: 'fresh_agent_attach'
     sessionType: string
     provider: string

--- a/server/fresh-agent/runtime-adapter.ts
+++ b/server/fresh-agent/runtime-adapter.ts
@@ -67,9 +67,9 @@ export interface FreshAgentRuntimeAdapter {
   send?(sessionId: string, input: { requestId?: string; text: string; images?: FreshAgentInputImage[]; settings?: FreshAgentCreateRequest }): Promise<FreshAgentSendResult> | FreshAgentSendResult
   /** Apply settings (model / effort / permissionMode / sandbox) to the LIVE
    * session without sending a message, converging every subscribed device's
-   * model surfaces via the adapter-emitted `sdk.session.metadata` event.
-   * Adapters without a live-settings lane surface the standard unsupported
-   * capability error. */
+   * model surfaces via the adapter-emitted session-metadata event (the
+   * normalized `freshAgent.session.metadata` frame). Adapters without a
+   * live-settings lane surface the standard unsupported capability error. */
   configure?(sessionId: string, input: { settings?: FreshAgentCreateRequest }): Promise<void> | void
   interrupt?(sessionId: string): Promise<void> | void
   compact?(sessionId: string, input?: { instructions?: string }): Promise<void> | void

--- a/server/fresh-agent/runtime-adapter.ts
+++ b/server/fresh-agent/runtime-adapter.ts
@@ -65,6 +65,12 @@ export interface FreshAgentRuntimeAdapter {
    * emitter) and rebind subscriptions. Undefined when the session is unknown. */
   sessionStateGeneration?(sessionId: string): number | undefined
   send?(sessionId: string, input: { requestId?: string; text: string; images?: FreshAgentInputImage[]; settings?: FreshAgentCreateRequest }): Promise<FreshAgentSendResult> | FreshAgentSendResult
+  /** Apply settings (model / effort / permissionMode / sandbox) to the LIVE
+   * session without sending a message, converging every subscribed device's
+   * model surfaces via the adapter-emitted `sdk.session.metadata` event.
+   * Adapters without a live-settings lane surface the standard unsupported
+   * capability error. */
+  configure?(sessionId: string, input: { settings?: FreshAgentCreateRequest }): Promise<void> | void
   interrupt?(sessionId: string): Promise<void> | void
   compact?(sessionId: string, input?: { instructions?: string }): Promise<void> | void
   kill?(sessionId: string): Promise<boolean> | boolean

--- a/server/fresh-agent/runtime-manager.ts
+++ b/server/fresh-agent/runtime-manager.ts
@@ -307,7 +307,8 @@ export class FreshAgentRuntimeManager {
   }
 
   /** Apply session settings to the LIVE session without a turn. The adapter's
-   * own `sdk.session.metadata` emission converges every subscribed device's
+   * own session-metadata emission (the normalized
+   * `freshAgent.session.metadata` frame) converges every subscribed device's
    * model surfaces; a refusal (e.g. changing model mid-turn on claude) throws
    * and surfaces through the handler's session-scoped error path. */
   async configure(locator: FreshAgentSessionLocator, input: { settings?: FreshAgentCreateRequest }) {

--- a/server/fresh-agent/runtime-manager.ts
+++ b/server/fresh-agent/runtime-manager.ts
@@ -306,6 +306,18 @@ export class FreshAgentRuntimeManager {
     await record.adapter.interrupt(locator.sessionId)
   }
 
+  /** Apply session settings to the LIVE session without a turn. The adapter's
+   * own `sdk.session.metadata` emission converges every subscribed device's
+   * model surfaces; a refusal (e.g. changing model mid-turn on claude) throws
+   * and surfaces through the handler's session-scoped error path. */
+  async configure(locator: FreshAgentSessionLocator, input: { settings?: FreshAgentCreateRequest }) {
+    const record = await this.requireOrRecoverSession(locator)
+    if (!record.adapter.configure) {
+      throw new FreshAgentUnsupportedCapabilityError(`Configure is not supported for ${record.sessionType}`)
+    }
+    await record.adapter.configure(locator.sessionId, input)
+  }
+
   async compact(locator: FreshAgentSessionLocator, input?: { instructions?: string }) {
     const record = await this.requireOrRecoverSession(locator)
     if (!record.adapter.compact) {

--- a/server/fresh-agent/sdk-events.ts
+++ b/server/fresh-agent/sdk-events.ts
@@ -23,8 +23,8 @@ export type FreshAgentProviderEvent =
     sessionId: string
     sessionRef?: { provider: string; sessionId: string }
   }
-  | { type: 'freshAgent.session.init'; sessionId: string; cliSessionId?: string; model?: string; cwd?: string; tools?: Array<{ name: string }> }
-  | { type: 'freshAgent.session.metadata'; sessionId: string; cliSessionId?: string; model?: string; cwd?: string; tools?: Array<{ name: string }> }
+  | { type: 'freshAgent.session.init'; sessionId: string; cliSessionId?: string; model?: string; effort?: string; cwd?: string; tools?: Array<{ name: string }> }
+  | { type: 'freshAgent.session.metadata'; sessionId: string; cliSessionId?: string; model?: string; effort?: string; cwd?: string; tools?: Array<{ name: string }> }
   | { type: 'freshAgent.assistant'; sessionId: string; content: ContentBlock[]; model?: string; usage?: Usage }
   | { type: 'freshAgent.stream'; sessionId: string; event: unknown; parentToolUseId?: string | null }
   | { type: 'freshAgent.result'; sessionId: string; result?: string; durationMs?: number; costUsd?: number; usage?: Usage }

--- a/server/sdk-bridge-types.ts
+++ b/server/sdk-bridge-types.ts
@@ -68,9 +68,9 @@ export type SdkServerMessage =
     streamingActive?: boolean
     streamingText?: string
   }
-  | { type: 'sdk.session.init'; sessionId: string; cliSessionId?: string; model?: string; cwd?: string; tools?: Array<{ name: string }> }
+  | { type: 'sdk.session.init'; sessionId: string; cliSessionId?: string; model?: string; effort?: string; cwd?: string; tools?: Array<{ name: string }> }
   | { type: 'sdk.session.changed'; sessionId: string; reason?: string }
-  | { type: 'sdk.session.metadata'; sessionId: string; cliSessionId?: string; model?: string; cwd?: string; tools?: Array<{ name: string }> }
+  | { type: 'sdk.session.metadata'; sessionId: string; cliSessionId?: string; model?: string; effort?: string; cwd?: string; tools?: Array<{ name: string }> }
   | { type: 'sdk.assistant'; sessionId: string; content: ContentBlock[]; model?: string; usage?: Usage }
   | { type: 'sdk.stream'; sessionId: string; event: unknown; parentToolUseId?: string | null }
   | { type: 'sdk.result'; sessionId: string; result?: string; durationMs?: number; costUsd?: number; usage?: Usage }

--- a/server/sdk-bridge.ts
+++ b/server/sdk-bridge.ts
@@ -959,6 +959,19 @@ export class SdkBridge extends EventEmitter {
         await sp.query.setPermissionMode(requested.permissionMode as Parameters<SdkQuery['setPermissionMode']>[0])
         state.permissionMode = requested.permissionMode
       }
+      // Live-settings convergence: every applied change broadcasts the
+      // session's effective model/effort (normalized downstream to
+      // `freshAgent.session.metadata`), so every subscribed device's model
+      // surfaces update immediately — a configure AND a settings-carrying
+      // send both land here.
+      if (modelChanged || effortChanged) {
+        this.broadcastToSession(sessionId, {
+          type: 'sdk.session.metadata',
+          sessionId,
+          model: state.model,
+          effort: state.effort,
+        })
+      }
     } catch (err) {
       log.warn({ sessionId, err }, 'Claude session settings update failed; message not sent')
       throw err

--- a/server/ws-handler.ts
+++ b/server/ws-handler.ts
@@ -90,11 +90,12 @@ import {
   TerminalKillSchema,
   CodingCliInputSchema,
   CodingCliKillSchema,
-  FreshAgentCreateSchema,
-  FreshAgentAttachSchema,
-  FreshAgentSendSchema,
-  FreshAgentInterruptSchema,
-  FreshAgentCompactSchema,
+      FreshAgentCreateSchema,
+      FreshAgentAttachSchema,
+      FreshAgentSendSchema,
+      FreshAgentInterruptSchema,
+      FreshAgentConfigureSchema,
+      FreshAgentCompactSchema,
   FreshAgentApprovalRespondSchema,
   FreshAgentQuestionRespondSchema,
   FreshAgentKillSchema,
@@ -156,6 +157,7 @@ type FreshAgentRuntimeManagerLike = {
    * generation means the state's emitter was recreated and subscriptions must rebind. */
   sessionStateGeneration?: (locator: any) => number | undefined
   send?: (locator: any, input: any) => Promise<FreshAgentSendResult> | FreshAgentSendResult
+  configure?: (locator: any, input: { settings?: any }) => Promise<void> | void
   interrupt?: (locator: any) => Promise<void> | void
   compact?: (locator: any, input?: { instructions?: string }) => Promise<void> | void
   resolveApproval?: (locator: any, requestId: string | number, decision: Record<string, unknown>) => Promise<void> | void
@@ -870,6 +872,7 @@ export class WsHandler {
       FreshAgentAttachSchema,
       FreshAgentSendSchema,
       FreshAgentInterruptSchema,
+      FreshAgentConfigureSchema,
       FreshAgentCompactSchema,
       FreshAgentApprovalRespondSchema,
       FreshAgentQuestionRespondSchema,
@@ -3867,6 +3870,46 @@ export class WsHandler {
             errorCode: this.freshAgentErrorCode(error),
           })
           this.sendError(ws, { code: 'INTERNAL_ERROR', message: errorMessage(error) })
+        }
+        return
+      }
+
+      case 'freshAgent.configure': {
+        // Apply settings (model / effort / permissionMode / sandbox) to the
+        // LIVE session without a turn. Success converges every subscribed
+        // device through the adapter's `freshAgent.session.metadata` event;
+        // a refusal (e.g. changing model mid-turn on claude) surfaces on the
+        // pane's session-scoped error banner — parity with the Rust slice.
+        const manager = this.freshAgentRuntimeManager
+        const locator = this.freshAgentLocatorFromMessage(m)
+        if (!manager?.configure) {
+          this.sendError(ws, { code: 'INTERNAL_ERROR', message: this.freshAgentUnavailableMessage() })
+          return
+        }
+        if (!await this.waitForFreshAgentAuthorization(ws, state, locator, m.requestId)) return
+        const startedAt = Date.now()
+        try {
+          await manager.configure(locator, { settings: m.settings })
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_configure',
+            ...this.freshAgentIdentityFields(locator),
+            ...(m.requestId ? { requestId: m.requestId } : {}),
+            outcome: 'ok',
+            durationMs: Date.now() - startedAt,
+          })
+        } catch (error) {
+          recordFreshAgentObservabilityEvent({
+            kind: 'fresh_agent_configure',
+            ...this.freshAgentIdentityFields(locator),
+            ...(m.requestId ? { requestId: m.requestId } : {}),
+            outcome: 'failed',
+            errorCode: this.freshAgentErrorCode(error),
+            durationMs: Date.now() - startedAt,
+          })
+          this.safeSend(ws, this.freshAgentEventMessage(locator, makeFreshAgentProviderErrorEvent(locator.sessionId, {
+            code: this.freshAgentErrorCode(error),
+            message: errorMessage(error),
+          })))
         }
         return
       }

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -813,6 +813,33 @@ export const FreshAgentInterruptSchema = z.object({
   cwd: z.string().optional(),
 })
 
+/** `freshAgent.configure` — apply session settings (model / effort /
+ * permissionMode / sandbox) to a LIVE session without sending a message, so
+ * every device's model surfaces converge immediately. Claude/kilroy apply
+ * for real through the sidecar's configure lane (setModel et al.); codex and
+ * opencode record the choice as the next turn's per-send settings (their
+ * advertised `per-send` scope). Every provider broadcasts
+ * `freshAgent.session.metadata` with the new effective settings; a refused
+ * or failed configure surfaces as the session-scoped `freshAgent.error`
+ * banner (e.g. changing model mid-turn on claude). Additive: an older server
+ * ignores the frame (accept-and-strip), degrading to the staged-at-next-send
+ * behavior. */
+export const FreshAgentConfigureSchema = z.object({
+  type: z.literal('freshAgent.configure'),
+  requestId: z.string().min(1).optional(),
+  sessionId: z.string().min(1),
+  sessionType: z.enum(['freshclaude', 'freshcodex', 'kilroy', 'freshopencode']),
+  provider: z.enum(['claude', 'codex', 'opencode']),
+  cwd: z.string().optional(),
+  settings: z.object({
+    cwd: z.string().min(1).optional(),
+    model: z.string().min(1).optional(),
+    permissionMode: z.string().min(1).optional(),
+    sandbox: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
+    effort: z.string().trim().min(1).optional(),
+  }),
+})
+
 export const FreshAgentCompactSchema = z.object({
   type: z.literal('freshAgent.compact'),
   sessionId: z.string().min(1),
@@ -890,6 +917,7 @@ export const FreshAgentClientMessageSchema = z.discriminatedUnion('type', [
   FreshAgentAttachSchema,
   FreshAgentSendSchema,
   FreshAgentInterruptSchema,
+  FreshAgentConfigureSchema,
   FreshAgentCompactSchema,
   FreshAgentApprovalRespondSchema,
   FreshAgentQuestionRespondSchema,
@@ -1027,6 +1055,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   FreshAgentAttachSchema,
   FreshAgentSendSchema,
   FreshAgentInterruptSchema,
+  FreshAgentConfigureSchema,
   FreshAgentCompactSchema,
   FreshAgentApprovalRespondSchema,
   FreshAgentQuestionRespondSchema,

--- a/src/components/fresh-agent/FreshAgentModelDialog.tsx
+++ b/src/components/fresh-agent/FreshAgentModelDialog.tsx
@@ -5,6 +5,7 @@ import type { FreshAgentPaneContent } from '@/store/paneTypes'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { mergePaneContent } from '@/store/panesSlice'
 import { saveServerSettingsPatch } from '@/store/settingsThunks'
+import { sendFreshAgentConfigure } from '@/lib/fresh-agent-configure'
 import { getFreshAgentModelCapabilities } from '@/lib/api'
 import {
   capFreshAgentModelSourceRows,
@@ -369,6 +370,17 @@ export function FreshAgentModelDialog({
           : {}),
       },
     }))
+    // Apply the change to the LIVE session too (fire-and-forget): the server
+    // answers with the freshAgent.session.metadata broadcast that converges
+    // the lower-left chip — and every other device's surfaces — immediately,
+    // instead of the next message's send-time settings carrying it. Pre-create
+    // panes (no sessionId) stage only, exactly as before. An ABSENT effort key
+    // is the explicit Default row (opencode clears the variant; the per-send
+    // providers keep the session's current effort).
+    sendFreshAgentConfigure(paneId, paneContent, {
+      model: model.id,
+      ...(level ? { effort: level } : {}),
+    })
     void dispatch(saveServerSettingsPatch({
       freshAgent: {
         providers: {
@@ -384,7 +396,7 @@ export function FreshAgentModelDialog({
       if (level) recordFreshAgentModelLevelUse(mruProvider, { modelId: model.id, level, cwdKey })
     }
     onClose()
-  }, [capabilities, highlightedModel, highlightedLevelRow, mruProvider, dispatch, tabId, paneId, sessionType, cwdKey, paneContent.provider, onClose])
+  }, [capabilities, highlightedModel, highlightedLevelRow, mruProvider, dispatch, tabId, paneId, sessionType, cwdKey, paneContent, onClose])
 
   const canCommit = Boolean(capabilities && highlightedModel && highlightedLevelRow)
 

--- a/src/components/fresh-agent/FreshAgentSettingsButton.tsx
+++ b/src/components/fresh-agent/FreshAgentSettingsButton.tsx
@@ -5,6 +5,7 @@ import type { FreshAgentPaneContent } from '@/store/paneTypes'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { mergePaneContent } from '@/store/panesSlice'
 import { saveServerSettingsPatch } from '@/store/settingsThunks'
+import { sendFreshAgentConfigure } from '@/lib/fresh-agent-configure'
 import {
   FRESH_AGENT_MODEL_OPTIONS_BY_SESSION_TYPE,
   getEffectiveFreshAgentEffort,
@@ -368,20 +369,20 @@ export function FreshAgentSettingsButton({
                                 nextModel,
                                 paneContent.effort,
                               )
-                            dispatch(mergePaneContent({
-                              tabId,
-                              paneId,
-                              updates: {
-                                model: nextModel,
-                                // Stamp the picked row's display label for the
-                                // status-strip chip (id-paired; a later model
-                                // change without a stamp can never mislabel).
-                                // A label echoing the raw id is not a display
-                                // name (e.g. opencode's no-name fallback): skip.
-                                ...(nextRow && nextRow.label !== nextModel
-                                  ? { modelLabel: { modelId: nextModel, label: nextRow.label } }
-                                  : {}),
-                                effort: nextEffort,
+                          dispatch(mergePaneContent({
+                            tabId,
+                            paneId,
+                            updates: {
+                              model: nextModel,
+                              // Stamp the picked row's display label for the
+                              // status-strip chip (id-paired; a later model
+                              // change without a stamp can never mislabel).
+                              // A label echoing the raw id is not a display
+                              // name (e.g. opencode's no-name fallback): skip.
+                              ...(nextRow && nextRow.label !== nextModel
+                                ? { modelLabel: { modelId: nextModel, label: nextRow.label } }
+                                : {}),
+                              effort: nextEffort,
                               // Stamp the switched-to row's known levels
                               // (static or probed) so effort normalization
                               // clamps against THEM — never re-derived from
@@ -393,6 +394,14 @@ export function FreshAgentSettingsButton({
                                 : undefined,
                             },
                           }))
+                          // Apply to the LIVE session (fire-and-forget): the
+                          // server's freshAgent.session.metadata broadcast
+                          // converges every device's model surfaces now, not
+                          // at the next message.
+                          sendFreshAgentConfigure(paneId, paneContent, {
+                            model: nextModel,
+                            ...(nextEffort ? { effort: nextEffort } : {}),
+                          })
                           persistProviderDefaults({
                             modelSelection: { kind: 'exact', modelId: nextModel },
                             ...(nextEffort ? { effort: nextEffort } : {}),
@@ -424,6 +433,10 @@ export function FreshAgentSettingsButton({
                       paneId,
                       updates: { effort: nextEffort },
                     }))
+                    // Apply to the LIVE session (fire-and-forget): the
+                    // metadata broadcast converges the chip's effort tooltip
+                    // on every device now.
+                    sendFreshAgentConfigure(paneId, paneContent, { effort: nextEffort })
                     persistProviderDefaults({ effort: nextEffort })
                   }}
                 >
@@ -475,6 +488,12 @@ export function FreshAgentSettingsButton({
                       paneId,
                       updates: { permissionMode: nextPermissionMode },
                     }))
+                    // Apply to the LIVE session (fire-and-forget): claude
+                    // takes it for real through the configure lane; codex
+                    // records it for the next turn.
+                    sendFreshAgentConfigure(paneId, paneContent, {
+                      permissionMode: nextPermissionMode,
+                    })
                     persistProviderDefaults({ defaultPermissionMode: nextPermissionMode })
                   }}
                 >

--- a/src/components/fresh-agent/FreshAgentView.tsx
+++ b/src/components/fresh-agent/FreshAgentView.tsx
@@ -14,6 +14,7 @@ import type { PaneReconcileRequest } from '@shared/ws-protocol'
 import { useAppDispatch, useAppSelector, useAppStore } from '@/store/hooks'
 import { usePaneFocusAdoption } from '@/hooks/usePaneFocusAdoption'
 import { getWsClient, RECONCILE_VERDICT_WAIT_MS } from '@/lib/ws-client'
+import { sendSuppressedAwareFreshAgentFrame } from '@/lib/fresh-agent-configure'
 import { KILL_ACK_TIMEOUT_MESSAGE, KILL_FAILED_MESSAGE, sendFreshAgentKillAndAwait } from '@/lib/kill-ack'
 import { createLogger } from '@/lib/client-logger'
 import { api, getFreshAgentModelCapabilities, getFreshAgentThreadSnapshot, setSessionMetadata } from '@/lib/api'
@@ -790,13 +791,18 @@ export function FreshAgentView({
   // ≤520px collapse favors the short form: drop a trailing "(1M context)"-style
   // parenthetical (raw ids carry none and pass through unchanged).
   const stripModelLabelShort = stripModelLabel?.replace(/\s*\([^)]*\)\s*$/, '') || stripModelLabel
-  // Tooltip carries the live session's effort when the runtime reports one
-  // (opencode snapshot.settings.effort), else the effort the pane was
-  // created/resumed with — the tooltip words the SESSION's effort; the model
-  // id it labels is the live one.
+  // Tooltip carries the live session's effort when the runtime reports one:
+  // the session-metadata event's fold first (fresher than any REST snapshot by
+  // construction — it lands the instant a configure/turn changes the live
+  // pair, with null meaning an explicit clear), else the REST snapshot's
+  // settings.effort, else the effort the pane was created/resumed with — the
+  // tooltip words the SESSION's effort; the model id it labels is the live one.
+  const stripEffort = agentSession?.effort !== undefined
+    ? agentSession.effort
+    : snapshot?.settings?.effort ?? getEffectiveFreshAgentEffort(paneContent, providerDefaults)
   const stripModelTooltip = !stripModelId
     ? 'model not set'
-    : `${stripModelId} · effort ${snapshot?.settings?.effort ?? getEffectiveFreshAgentEffort(paneContent, providerDefaults) ?? 'Default'}`
+    : `${stripModelId} · effort ${stripEffort ?? 'Default'}`
   const contextSessionId = freshAgentContextSessionId(paneContent, agentSession)
   const [usageTick, forceUsageTick] = useReducer((tick: number) => tick + 1, 0)
   const usageRefreshDispatchedRef = useRef(false)
@@ -1002,17 +1008,11 @@ export function FreshAgentView({
   currentAutoTitleIdentityRef.current = autoTitleIdentity
 
   const sendFreshAgentMessage = useCallback((message: Record<string, unknown>) => {
-    const suppressed = typeof window !== 'undefined'
-      && (
-        window.__FRESHELL_TEST_HARNESS__?.isAllFreshAgentNetworkEffectsSuppressed?.() === true
-        || window.__FRESHELL_TEST_HARNESS__?.isFreshAgentNetworkEffectsSuppressed?.(paneId) === true
-      )
-    if (suppressed) {
-      window.__FRESHELL_TEST_HARNESS__?.recordSentWsMessage?.(message)
-      return
-    }
-    ws.send(message as never)
-  }, [paneId, ws])
+    // The shared suppression-aware send seam (fresh-agent-configure.ts): a
+    // suppressed frame goes to the e2e harness's sent-message spy, never the
+    // wire — identical to every other freshAgent.* frame this view sends.
+    sendSuppressedAwareFreshAgentFrame(paneId, message)
+  }, [paneId])
 
   const releasePendingRebind = useCallback(() => {
     const release = pendingRebindReleaseRef.current

--- a/src/lib/fresh-agent-configure.ts
+++ b/src/lib/fresh-agent-configure.ts
@@ -1,0 +1,73 @@
+/**
+ * The `freshAgent.configure` send lane — applying a committed model / effort /
+ * permission-mode / sandbox change to the LIVE session so every device's model
+ * surfaces converge immediately (the server answers with the
+ * `freshAgent.session.metadata` broadcast, plus a session-scoped
+ * `freshAgent.error` banner frame when the provider refuses, e.g. changing the
+ * model mid-turn on claude).
+ *
+ * Shared by the model+thinking dialog commit, the settings-gear popover's
+ * model radio / thinking select / permission-mode select, and FreshAgentView's
+ * own frame senders: one suppression-aware send path. The e2e harness's
+ * per-pane/all-panes network-effect suppression is honored IDENTICALLY to
+ * every other freshAgent.* frame the view sends (a suppressed send is recorded
+ * to the harness's sent-message spy and never hits the wire).
+ */
+
+import { getWsClient } from '@/lib/ws-client'
+import type { FreshAgentPaneContent } from '@/store/paneTypes'
+
+/** The `freshAgent.configure` settings payload — the same per-field shape
+ * `freshAgent.send.settings` carries (all optional; an absent key means "no
+ * statement", so the caller states ONLY what changed). */
+export type FreshAgentConfigureSettings = {
+  model?: string
+  effort?: string
+  permissionMode?: string
+  sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access'
+}
+
+/** The suppression-aware fresh-agent frame send (mirrors the view's own
+ * `sendFreshAgentMessage` seam — suppressed frames go to the harness spy,
+ * never the wire). */
+export function sendSuppressedAwareFreshAgentFrame(
+  paneId: string,
+  message: Record<string, unknown>,
+): void {
+  const suppressed = typeof window !== 'undefined'
+    && (
+      window.__FRESHELL_TEST_HARNESS__?.isAllFreshAgentNetworkEffectsSuppressed?.() === true
+      || window.__FRESHELL_TEST_HARNESS__?.isFreshAgentNetworkEffectsSuppressed?.(paneId) === true
+    )
+  if (suppressed) {
+    window.__FRESHELL_TEST_HARNESS__?.recordSentWsMessage?.(message)
+    return
+  }
+  getWsClient().send(message)
+}
+
+/**
+ * Fire-and-forget `freshAgent.configure`: only a pane with a LIVE session
+ * (sessionId set) can apply settings — pre-create panes stage on the pane
+ * content and the next `freshAgent.send` carries them, exactly as before.
+ * The settings object states ONLY the fields the caller changed; an absent
+ * effort key is the picker's explicit Default row (opencode clears it; the
+ * per-send providers keep the session's current value).
+ */
+export function sendFreshAgentConfigure(
+  paneId: string,
+  paneContent: FreshAgentPaneContent,
+  settings: FreshAgentConfigureSettings,
+): void {
+  if (!paneContent.sessionId) return
+  const frame = {
+    type: 'freshAgent.configure',
+    requestId: `cfg-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    sessionId: paneContent.sessionId,
+    sessionType: paneContent.sessionType,
+    provider: paneContent.provider,
+    settings,
+  }
+  sendSuppressedAwareFreshAgentFrame(paneId, frame)
+}
+

--- a/src/lib/fresh-agent-ws.ts
+++ b/src/lib/fresh-agent-ws.ts
@@ -257,7 +257,8 @@ export function handleFreshAgentTransportEvent(dispatch: AppDispatch, msg: Fresh
       dispatch(sessionInit({
         ...locator,
         cliSessionId: event.cliSessionId as string | undefined,
-        model: event.model as string | undefined,
+        model: event.model as string | null | undefined,
+        effort: event.effort as string | null | undefined,
         cwd: event.cwd as string | undefined,
         tools: event.tools as Array<{ name: string }> | undefined,
       }))
@@ -266,7 +267,8 @@ export function handleFreshAgentTransportEvent(dispatch: AppDispatch, msg: Fresh
       dispatch(sessionMetadataReceived({
         ...locator,
         cliSessionId: event.cliSessionId as string | undefined,
-        model: event.model as string | undefined,
+        model: event.model as string | null | undefined,
+        effort: event.effort as string | null | undefined,
         cwd: event.cwd as string | undefined,
         tools: event.tools as Array<{ name: string }> | undefined,
       }))

--- a/src/store/freshAgentSlice.ts
+++ b/src/store/freshAgentSlice.ts
@@ -232,7 +232,8 @@ const freshAgentSlice = createSlice({
 
     sessionInit(state, action: PayloadAction<SessionMutationPayload & {
       cliSessionId?: string
-      model?: string
+      model?: string | null
+      effort?: string | null
       cwd?: string
       tools?: Array<{ name: string }>
     }>) {
@@ -240,6 +241,7 @@ const freshAgentSlice = createSlice({
       if (!session) return
       session.cliSessionId = action.payload.cliSessionId
       session.model = action.payload.model
+      session.effort = action.payload.effort
       session.cwd = action.payload.cwd
       session.tools = action.payload.tools
       session.awaitingDurableHistory = action.payload.cliSessionId ? false : session.awaitingDurableHistory
@@ -250,7 +252,8 @@ const freshAgentSlice = createSlice({
 
     sessionMetadataReceived(state, action: PayloadAction<SessionMutationPayload & {
       cliSessionId?: string
-      model?: string
+      model?: string | null
+      effort?: string | null
       cwd?: string
       tools?: Array<{ name: string }>
     }>) {
@@ -267,7 +270,13 @@ const freshAgentSlice = createSlice({
         session.cliSessionId = metadataCliSessionId
         session.historySessionId = metadataCliSessionId
       }
-      session.model = action.payload.model ?? session.model
+      // Live-settings convergence (`freshAgent.session.metadata`): a stated
+      // model/effort (string OR explicit null — a clear) REPLACES the session
+      // record; an ABSENT key is "no statement" and keeps whatever is there.
+      // The server always states both keys on a metadata frame, so the chip
+      // and the effort tooltip track the live session exactly.
+      if (action.payload.model !== undefined) session.model = action.payload.model
+      if (action.payload.effort !== undefined) session.effort = action.payload.effort
       session.cwd = action.payload.cwd ?? session.cwd
       session.tools = action.payload.tools ?? session.tools
       if (metadataCliSessionId && !wouldDowngradeSnapshotIdentity) {

--- a/src/store/freshAgentTypes.ts
+++ b/src/store/freshAgentTypes.ts
@@ -60,7 +60,13 @@ export type FreshAgentSessionState = FreshAgentSessionLocator & {
   historyRevision?: number
   cliSessionId?: string
   cwd?: string
-  model?: string
+  model?: string | null
+  /** The LIVE session's thinking level, folded from
+   * `freshAgent.session.metadata` (string), JSON null (an explicit clear —
+   * e.g. opencode's Default row), or absent while no metadata ever stated
+   * it. The status-strip tooltip prefers it over the REST snapshot's
+   * settings.effort: the event is fresher by construction. */
+  effort?: string | null
   tools?: Array<{ name: string }>
   turns: FreshAgentTurn[]
   historyItems: FreshAgentTurn[]

--- a/test/e2e-browser/playwright.config.ts
+++ b/test/e2e-browser/playwright.config.ts
@@ -260,6 +260,9 @@ export const RUST_ONLY_SPECS = [
   // P1.13 (Lane B4 Task 14): per-provider settings survive restart + codex
   // crash memory-loss banner. Imports RustServer directly for restartAbrupt().
   /freshagent-settings-resume-rust\.spec\.ts$/,
+  // Fresh-agent live model convergence (raw-WS configure + session.metadata
+  // broadcasts per provider fixture). Rust-only (see RUST_ONLY_SPECS entry).
+  /freshagent-live-model-convergence-rust\.spec\.ts$/,
   // Task 6 (the-usual/freshagent-sessionref-regression): REST fresh-agent
   // `sessionRef` resume (durable + placeholder→durable via the pane ledger,
   // loud 4xx failures) + the tabs.sync registry placeholder clamp. Imports
@@ -556,6 +559,12 @@ export default defineConfig({
         // codex crash memory-loss banner. Imports RustServer directly for
         // restartAbrupt().
         /freshagent-settings-resume-rust\.spec\.ts$/,
+        // Fresh-agent live model convergence: owns per-test RustServers
+        // (fake opencode serve + fake claude sidecar) proving
+        // freshAgent.configure broadcasts freshAgent.session.metadata and the
+        // next turn carries the configured pair. Rust-only (raw-WS against
+        // the owned server; see the RUST_ONLY_SPECS entry).
+        /freshagent-live-model-convergence-rust\.spec\.ts$/,
         // Task 6 (see the RUST_ONLY_SPECS entry): REST fresh-agent resume +
         // registry placeholder clamp. Imports RustServer for restartAbrupt().
         /fresh-agent-rest-resume-rust\.spec\.ts$/,

--- a/test/e2e-browser/specs/freshagent-live-model-convergence-rust.spec.ts
+++ b/test/e2e-browser/specs/freshagent-live-model-convergence-rust.spec.ts
@@ -1,0 +1,349 @@
+// FRESHAGENT LIVE MODEL CONVERGENCE — end-to-end proof that a model change
+// committed on a LIVE session converges immediately through the server:
+//
+//   1. opencode: `freshAgent.configure` records the pair on the live session
+//      and broadcasts `freshAgent.session.metadata` with the effective model +
+//      effort; the NEXT turn's prompt_async body carries the configured pair
+//      (`{providerID, modelID}` object + the `variant` string field). An
+//      idempotent configure stays silent on the bus.
+//   2. claude: `freshAgent.configure` applies for real through the sidecar's
+//      configure lane (the fake's sdk.configured receipt) and broadcasts the
+//      metadata frame; the sidecar request log records the configure.
+//
+// The codex lane's wire contract is pinned in-crate
+// (crates/freshell-freshagent/src/codex.rs configure tests against the real
+// fake app-server) — the e2e app-server fixture path used by sibling specs
+// is stale, so no codex leg here.
+//
+// Rust-only: raw-WS + owned RustServer per test (the rust-chromium project).
+// The client-side UI halves (dialog commit → configure frame; metadata fold →
+// the lower-left chip flips over a stale snapshot) are pinned in the legacy
+// project's freshopencode-model-picker.spec.ts.
+//
+// Donors: boot/env plumbing + WsCapture + seedWallConfig from
+// freshagent-settings-resume-rust.spec.ts (copied per this suite's
+// per-spec-ownership convention).
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import WebSocket from 'ws'
+import { test, expect } from '../helpers/fixtures.js'
+import { RustServer } from '../helpers/rust-server.js'
+import { WS_PROTOCOL_VERSION } from '../../../shared/ws-version.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const CLAUDE_FIXTURE = path.resolve(__dirname, '../fixtures/fake-claude-sidecar.mjs')
+const OPENCODE_FIXTURE = path.resolve(__dirname, '../fixtures/fake-opencode.cjs')
+
+/** Raw node-side WS client with a real hello handshake and a frame buffer
+ * (donor: freshagent-settings-resume-rust.spec.ts's WsCapture). */
+class WsCapture {
+  private ws: WebSocket
+  readonly frames: any[] = []
+  private opened: Promise<void>
+
+  constructor(baseUrl: string, token: string) {
+    const wsUrl = `${baseUrl.replace(/^http/, 'ws')}/ws`
+    this.ws = new WebSocket(wsUrl)
+    this.opened = new Promise((resolve, reject) => {
+      this.ws.on('open', () => {
+        this.ws.send(JSON.stringify({ type: 'hello', protocolVersion: WS_PROTOCOL_VERSION, token }))
+        resolve()
+      })
+      this.ws.on('error', reject)
+    })
+    this.ws.on('message', (data) => {
+      try {
+        this.frames.push(JSON.parse(String(data)))
+      } catch {
+        // non-JSON frames are not part of this protocol; ignore
+      }
+    })
+  }
+
+  async ready(): Promise<void> {
+    await this.opened
+    await this.waitFor((f) => f.type === 'ready', 10_000, 'ready')
+  }
+
+  async waitFor(pred: (frame: any) => boolean, timeoutMs: number, label: string): Promise<any> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      const hit = this.frames.find(pred)
+      if (hit) return hit
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    throw new Error(`WsCapture: timed out waiting for ${label}`)
+  }
+
+  send(frame: unknown): void {
+    this.ws.send(JSON.stringify(frame))
+  }
+
+  close(): void {
+    try {
+      this.ws.close()
+    } catch {
+      // already closed
+    }
+  }
+}
+
+/** `PATCH /api/settings` — flip the shared `settings.freshAgent.enabled` gate
+ * the fresh-agent WS dispatch requires. */
+async function enableFreshAgent(baseUrl: string, token: string): Promise<void> {
+  const res = await fetch(`${baseUrl}/api/settings`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json', 'x-auth-token': token },
+    body: JSON.stringify({ freshAgent: { enabled: true } }),
+  })
+  if (!res.ok) {
+    throw new Error(`PATCH /api/settings failed: ${res.status} ${await res.text()}`)
+  }
+}
+
+/** Parse a JSONL file, tolerating absence (returns []). */
+function readJsonl(filePath: string): any[] {
+  if (!fs.existsSync(filePath)) return []
+  return fs
+    .readFileSync(filePath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l))
+}
+
+/** Idempotent .freshell/config.json seed (setupHome re-runs on every boot). */
+function seedWallConfig(input: {
+  providers: string[]
+  freshAgent?: boolean
+}): (homeDir: string) => Promise<void> {
+  return async (homeDir: string) => {
+    const freshellDir = path.join(homeDir, '.freshell')
+    await fsp.mkdir(freshellDir, { recursive: true })
+    await fsp.writeFile(
+      path.join(freshellDir, 'config.json'),
+      JSON.stringify(
+        {
+          version: 1,
+          settings: {
+            codingCli: { enabledProviders: input.providers },
+            ...(input.freshAgent ? { freshAgent: { enabled: true } } : {}),
+          },
+        },
+        null,
+        2,
+      ),
+    )
+  }
+}
+
+test.describe('fresh-agent live model convergence (rust)', () => {
+  test('opencode: configure broadcasts session metadata and the next turn carries the pair', async ({ e2eServerKind }) => {
+    test.setTimeout(180_000)
+    expect(e2eServerKind).toBe('rust')
+    const sharedRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'fa-conv-opencode-'))
+    const binDir = path.join(sharedRoot, 'bin')
+    const auditLogPath = path.join(sharedRoot, 'opencode-audit.jsonl')
+    const projectDir = path.join(sharedRoot, 'proj')
+    await fsp.mkdir(projectDir, { recursive: true })
+    // Install the fake as an executable named `opencode` and point
+    // OPENCODE_CMD at it (serve.rs ServeConfig) — donor:
+    // freshagent-settings-resume-rust.spec.ts.
+    await fsp.mkdir(binDir, { recursive: true })
+    const fakeOpencode = path.join(binDir, 'opencode')
+    await fsp.copyFile(OPENCODE_FIXTURE, fakeOpencode)
+    await fsp.chmod(fakeOpencode, 0o755)
+    const server = new RustServer({
+      env: {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        OPENCODE_CMD: fakeOpencode,
+        FAKE_OPENCODE_AUDIT_LOG: auditLogPath,
+      },
+      setupHome: seedWallConfig({ providers: ['opencode'], freshAgent: true }),
+    })
+    let ws: WsCapture | null = null
+    try {
+      const info = await server.start()
+      await enableFreshAgent(info.baseUrl, info.token)
+      ws = new WsCapture(info.baseUrl, info.token)
+      await ws.ready()
+
+      // Create + materialize with the INITIAL pair.
+      ws.send({
+        type: 'freshAgent.create',
+        requestId: 'req-conv-open-1',
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        model: 'fakeprov/model-a',
+        effort: 'high',
+        cwd: projectDir,
+      })
+      const created = await ws.waitFor(
+        (f) => f.type === 'freshAgent.created' && f.requestId === 'req-conv-open-1',
+        30_000,
+        'freshAgent.created (opencode)',
+      )
+      const placeholderId = created.sessionId as string
+      ws.send({
+        type: 'freshAgent.send',
+        requestId: 'send-conv-1',
+        sessionId: placeholderId,
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        text: 'convergence first turn',
+      })
+      const materialized = await ws.waitFor(
+        (f) => f.type === 'freshAgent.session.materialized' && f.previousSessionId === placeholderId,
+        30_000,
+        'freshAgent.session.materialized',
+      )
+      const sesId = materialized.sessionId as string
+
+      // ── the live-settings convergence lane ──────────────────────────────
+      ws.send({
+        type: 'freshAgent.configure',
+        requestId: 'cfg-conv-1',
+        sessionId: sesId,
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        settings: { model: 'fakeprov/model-b', effort: 'low' },
+      })
+      const metadata = await ws.waitFor(
+        (f) =>
+          f.type === 'freshAgent.event'
+          && f.sessionId === sesId
+          && f.event?.type === 'freshAgent.session.metadata',
+        30_000,
+        'freshAgent.session.metadata',
+      )
+      expect(metadata.sessionType).toBe('freshopencode')
+      expect(metadata.provider).toBe('opencode')
+      expect(metadata.event.sessionId).toBe(sesId)
+      expect(metadata.event.model).toBe('fakeprov/model-b')
+      expect(metadata.event.effort).toBe('low')
+
+      // The NEXT turn's prompt body carries the configured pair.
+      ws.send({
+        type: 'freshAgent.send',
+        requestId: 'send-conv-2',
+        sessionId: sesId,
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        text: 'convergence second turn',
+      })
+      await expect
+        .poll(
+          () => readJsonl(auditLogPath).filter((e) => e.event === 'prompt_async').length,
+          { timeout: 30_000 },
+        )
+        .toBeGreaterThan(1)
+      const prompts = readJsonl(auditLogPath).filter((e) => e.event === 'prompt_async')
+      const last = prompts[prompts.length - 1]
+      expect(last.sessionId).toBe(sesId)
+      expect(last.body?.model, 'the configured model rides the next turn').toEqual({ providerID: 'fakeprov', modelID: 'model-b' })
+      expect(last.body?.variant, 'the configured effort rides the next turn (wire field: variant)').toBe('low')
+
+      // An idempotent configure converges nothing: no second metadata frame.
+      const metadataFramesBefore = ws.frames.filter(
+        (f) => f.type === 'freshAgent.event' && f.event?.type === 'freshAgent.session.metadata',
+      ).length
+      ws.send({
+        type: 'freshAgent.configure',
+        requestId: 'cfg-conv-2',
+        sessionId: sesId,
+        sessionType: 'freshopencode',
+        provider: 'opencode',
+        settings: { model: 'fakeprov/model-b', effort: 'low' },
+      })
+      await new Promise((r) => setTimeout(r, 2_000))
+      const metadataFramesAfter = ws.frames.filter(
+        (f) => f.type === 'freshAgent.event' && f.event?.type === 'freshAgent.session.metadata',
+      ).length
+      expect(metadataFramesAfter).toBe(metadataFramesBefore)
+    } finally {
+      ws?.close()
+      await server.stop().catch(() => {})
+      await fsp.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('claude: configure applies through the sidecar lane and broadcasts session metadata', async ({ e2eServerKind }) => {
+    test.setTimeout(180_000)
+    expect(e2eServerKind).toBe('rust')
+    const sharedRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'fa-conv-claude-'))
+    const sidecarLogPath = path.join(sharedRoot, 'sidecar-requests.jsonl')
+    const projectDir = path.join(sharedRoot, 'proj')
+    await fsp.mkdir(projectDir, { recursive: true })
+    const server = new RustServer({
+      env: {
+        FRESHELL_CLAUDE_SIDECAR: CLAUDE_FIXTURE,
+        FAKE_CLAUDE_SIDECAR_LOG: sidecarLogPath,
+      },
+      setupHome: seedWallConfig({ providers: ['claude'], freshAgent: true }),
+    })
+    let ws: WsCapture | null = null
+    try {
+      const info = await server.start()
+      await enableFreshAgent(info.baseUrl, info.token)
+      ws = new WsCapture(info.baseUrl, info.token)
+      await ws.ready()
+
+      ws.send({
+        type: 'freshAgent.create',
+        requestId: 'req-conv-claude-1',
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        model: 'opus-x',
+        cwd: projectDir,
+      })
+      const created = await ws.waitFor(
+        (f) => f.type === 'freshAgent.created' && f.requestId === 'req-conv-claude-1',
+        30_000,
+        'freshAgent.created (claude)',
+      )
+      const sessionId = created.sessionId as string
+
+      // The live-settings convergence lane: the sidecar applies the configure
+      // for real (setModel + applyFlagSettings through the fake's receipt)…
+      ws.send({
+        type: 'freshAgent.configure',
+        requestId: 'cfg-conv-claude-1',
+        sessionId,
+        sessionType: 'freshclaude',
+        provider: 'claude',
+        settings: { model: 'sonnet', effort: 'low' },
+      })
+      const metadata = await ws.waitFor(
+        (f) =>
+          f.type === 'freshAgent.event'
+          && f.sessionId === sessionId
+          && f.event?.type === 'freshAgent.session.metadata',
+        30_000,
+        'freshAgent.session.metadata',
+      )
+      expect(metadata.sessionType).toBe('freshclaude')
+      expect(metadata.event.model).toBe('sonnet')
+      expect(metadata.event.effort).toBe('low')
+
+      // …and the sidecar request log proves the configure reached the runtime.
+      await expect
+        .poll(
+          () => readJsonl(sidecarLogPath).filter((e) => e.msg?.type === 'configure').length,
+          { timeout: 30_000 },
+        )
+        .toBeGreaterThan(0)
+      const configureRequest = readJsonl(sidecarLogPath).find((e) => e.msg?.type === 'configure')
+      expect(configureRequest.msg.sessionId).toBe(sessionId)
+      expect(configureRequest.msg.settings.model).toBe('sonnet')
+      expect(configureRequest.msg.settings.effort).toBe('low')
+    } finally {
+      ws?.close()
+      await server.stop().catch(() => {})
+      await fsp.rm(sharedRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+})

--- a/test/e2e-browser/specs/freshopencode-model-picker.spec.ts
+++ b/test/e2e-browser/specs/freshopencode-model-picker.spec.ts
@@ -342,6 +342,81 @@ test.describe('Freshopencode model + thinking selector', () => {
     expect(levelMru).toContain('"low"')
   })
 
+  test('a commit sends freshAgent.configure and the metadata broadcast flips the chip over the stale snapshot', async ({
+    freshellPage,
+    page,
+    harness,
+    terminal,
+  }) => {
+    await terminal.waitForTerminal()
+    const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), 'freshell-model-selector-converge-'))
+
+    await routeCatalog(page, CATALOG)
+    await routeThreads(page)
+    await routeFileApis(page, cwd)
+    await enableFreshClientsAndOpencode(page)
+    await createFreshopencodePane(page, cwd)
+
+    const chip = (label: string) => page.getByRole('button', { name: `Model: ${label} — change model` })
+
+    // The stubbed snapshot reports the PRE-change model in settings.model —
+    // the stale live-session term the chip prefers over the staged pick (the
+    // exact mask the live servers used to trap the chip on).
+    await expect(chip('GLM 5.2')).toBeVisible({ timeout: 15_000 })
+
+    // Commit DeepSeek V4 Pro · low through the shared dialog.
+    const settings = await openFreshAgentSettings(page)
+    await settings.getByRole('button', { name: /Change/ }).click()
+    const dialog = page.getByRole('dialog', { name: 'Model and thinking level' })
+    await expect(dialog).toBeVisible({ timeout: 10_000 })
+    await dialog.getByRole('searchbox', { name: 'Filter models' }).fill('deepseek')
+    await dialog.getByRole('option', { name: /DeepSeek V4 Pro/ }).click()
+    // Keyboard to the low row (the same in-column flow the first test uses):
+    // preselect lands on the model's highest level ('high'), ArrowUp → 'low'.
+    await page.keyboard.press('ArrowRight')
+    await page.keyboard.press('ArrowUp')
+    await expect(dialog.getByRole('button', { name: 'Use DeepSeek V4 Pro · low' })).toBeVisible()
+    await page.keyboard.press('Enter')
+    await expect(dialog).toHaveCount(0)
+
+    // The commit ALSO applies the pick to the LIVE session: the
+    // freshAgent.configure frame went out on the wire (the pane's network
+    // effects are suppressed to the spy, so read it there).
+    const sent = (await harness.getSentWsMessages()) as Array<Record<string, unknown>>
+    const configure = sent.find((m) => m?.type === 'freshAgent.configure')
+    expect(configure, 'the commit must send freshAgent.configure').toBeTruthy()
+    expect(configure).toMatchObject({
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      settings: { model: 'deepseek/deepseek-v4-pro', effort: 'low' },
+    })
+
+    // Before the server answers, the chip still shows the stale snapshot's
+    // live model — the staged pick is masked by the (stale) session truth.
+    await expect(chip('GLM 5.2')).toBeVisible({ timeout: 5_000 })
+
+    // The server's freshAgent.session.metadata broadcast states the applied
+    // pair: the chip flips IMMEDIATELY, over the stale snapshot term.
+    await harness.receiveWsMessage({
+      type: 'freshAgent.event',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      sessionId: 'ses_e2e',
+      event: {
+        type: 'freshAgent.session.metadata',
+        sessionId: 'ses_e2e',
+        model: 'deepseek/deepseek-v4-pro',
+        effort: 'low',
+      },
+    })
+    await expect(chip('DeepSeek V4 Pro')).toBeVisible({ timeout: 10_000 })
+    await expect(chip('DeepSeek V4 Pro')).toHaveAttribute(
+      'title',
+      'deepseek/deepseek-v4-pro · effort low',
+    )
+    await expect(chip('GLM 5.2')).toHaveCount(0)
+  })
+
   test('/model in the composer opens the same dialog', async ({
     freshellPage,
     page,

--- a/test/unit/client/components/fresh-agent/FreshAgentModelDialog.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentModelDialog.test.tsx
@@ -16,6 +16,11 @@ const saveServerSettingsPatchSpy = vi.hoisted(() => vi.fn((patch: unknown) => ({
 })))
 
 const getFreshAgentModelCapabilitiesSpy = vi.hoisted(() => vi.fn())
+const wsSendSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({ send: wsSendSpy }),
+}))
 
 vi.mock('@/store/settingsThunks', () => ({
   saveServerSettingsPatch: (patch: unknown) => saveServerSettingsPatchSpy(patch),
@@ -227,6 +232,7 @@ function seedLevelMru(entries: Array<{ modelId: string; level: string; cwdKey: s
 
 beforeEach(() => {
   saveServerSettingsPatchSpy.mockClear()
+  wsSendSpy.mockClear()
   getFreshAgentModelCapabilitiesSpy.mockReset()
   getFreshAgentModelCapabilitiesSpy.mockResolvedValue(catalogResponse)
   window.localStorage.removeItem('freshopencode.modelMru.v2')
@@ -437,6 +443,18 @@ describe('FreshAgentModelDialog (freshopencode)', () => {
     expect(modelMru[0]).toMatchObject({ id: 'kimi-for-coding/kimi-k3' })
     const levelMru = JSON.parse(window.localStorage.getItem('freshopencode.modelLevelMru.v1') ?? '[]')
     expect(levelMru).toEqual([expect.objectContaining({ modelId: 'kimi-for-coding/kimi-k3', level: 'max', cwdKey: '/repo/project-a' })])
+
+    // The commit ALSO applies the pick to the LIVE session: the
+    // freshAgent.configure frame carries the picked model + level so the
+    // server's metadata broadcast converges the chip (and every other
+    // device's surfaces) immediately.
+    expect(wsSendSpy).toHaveBeenCalledTimes(1)
+    const configure = wsSendSpy.mock.calls[0][0]
+    expect(configure.type).toBe('freshAgent.configure')
+    expect(configure.sessionId).toBe('thread-dialog')
+    expect(configure.sessionType).toBe('freshopencode')
+    expect(configure.provider).toBe('opencode')
+    expect(configure.settings).toEqual({ model: 'kimi-for-coding/kimi-k3', effort: 'max' })
   })
 
   it('commits the Default row as no effort: clears pane effort and provider default effort, and records no level', async () => {
@@ -466,6 +484,29 @@ describe('FreshAgentModelDialog (freshopencode)', () => {
     expect(window.localStorage.getItem('freshopencode.modelLevelMru.v1')).toBeNull()
     const modelMru = JSON.parse(window.localStorage.getItem('freshopencode.modelMru.v2') ?? '[]')
     expect(modelMru[0]).toMatchObject({ id: 'deepseek/deepseek-chat' })
+
+    // The Default commit's configure carries NO effort key — the explicit
+    // "no variant" statement opencode resolves as a clear.
+    expect(wsSendSpy).toHaveBeenCalledTimes(1)
+    const configure = wsSendSpy.mock.calls[0][0]
+    expect(configure.type).toBe('freshAgent.configure')
+    expect(configure.settings).toEqual({ model: 'deepseek/deepseek-chat' })
+  })
+
+
+  it('sends no freshAgent.configure for a pre-create pane (no live session yet)', async () => {
+    const store = createStore()
+    seedFreshopencodePane(store, { sessionId: undefined, status: 'creating' })
+
+    renderDialog(store, { open: true, onClose: () => {} })
+
+    fireEvent.click(await screen.findByRole('option', { name: /Kimi K3/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use Kimi K3 · max' }))
+
+    // Staging + the next send's settings still carry the pick; the live-apply
+    // lane has nothing to apply to and stays silent.
+    expect(paneContent(store).model).toBe('kimi-for-coding/kimi-k3')
+    expect(wsSendSpy).not.toHaveBeenCalled()
   })
 
   it('drives highlight with keyboard: arrows move in-column, ←→ switch columns, Enter commits, Escape cancels', async () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentSettingsButton.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentSettingsButton.test.tsx
@@ -16,6 +16,11 @@ const saveServerSettingsPatchSpy = vi.hoisted(() => vi.fn((patch: unknown) => ({
 const getFreshAgentModelCapabilitiesSpy = vi.hoisted(() => vi.fn())
 
 const getFreshAgentThreadSnapshotSpy = vi.hoisted(() => vi.fn())
+const wsSendSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/ws-client', () => ({
+  getWsClient: () => ({ send: wsSendSpy }),
+}))
 
 vi.mock('@/store/settingsThunks', () => ({
   saveServerSettingsPatch: (patch: unknown) => saveServerSettingsPatchSpy(patch),
@@ -195,6 +200,7 @@ function renderButton(store: ReturnType<typeof createStore>) {
 
 beforeEach(() => {
   saveServerSettingsPatchSpy.mockClear()
+  wsSendSpy.mockClear()
   getFreshAgentModelCapabilitiesSpy.mockReset()
   getFreshAgentModelCapabilitiesSpy.mockResolvedValue(CATALOG_RESPONSE)
   getFreshAgentThreadSnapshotSpy.mockReset()
@@ -499,8 +505,17 @@ describe('FreshAgentSettingsButton', () => {
     // the picked row's display label goes to the status-strip chip via the
     // id-paired stamp (catalog-only ids would otherwise flash their raw id)
     expect(content.modelLabel).toEqual({ modelId: 'sonnet', label: 'Sonnet' })
-  })
 
+    // The radio commit ALSO applies the pick to the LIVE session: the
+    // freshAgent.configure frame converges every device's model surfaces
+    // immediately (claude applies it for real through its configure lane).
+    expect(wsSendSpy).toHaveBeenCalledTimes(1)
+    const configure = wsSendSpy.mock.calls[0][0]
+    expect(configure.type).toBe('freshAgent.configure')
+    expect(configure.sessionId).toBe('thread-settings')
+    expect(configure.provider).toBe('claude')
+    expect(configure.settings).toEqual({ model: 'sonnet', effort: 'alpha' })
+  })
   it('stamps no modelLabel when the switched-to probed row\'s label echoes its raw id', async () => {
     getFreshAgentModelCapabilitiesSpy.mockResolvedValue({
       ok: true as const,

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -6919,32 +6919,45 @@ describe('snapshot scheduler integration (zrrj)', () => {
   })
 
   it('coalesces a burst of freshopencode session.changed events across sibling panes into one snapshot GET', async () => {
-    const store = createStore()
-    const broadcast = captureWsBroadcast()
-    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(freshopencodeSnapshot('done', 10))
+    // Wall-clock debounce plus waitFor's 1s deadline races CPU contention
+    // under parallel suites (the 429 sibling's note): advance the actual
+    // scheduler/React timers deterministically.
+    vi.useFakeTimers()
+    try {
+      const store = createStore()
+      const broadcast = captureWsBroadcast()
+      apiMock.getFreshAgentThreadSnapshot.mockResolvedValue(freshopencodeSnapshot('done', 10))
 
-    store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: schedulerPaneContent('req-sched-a') }))
-    store.dispatch(initLayout({ tabId: 'tab-2', paneId: 'pane-2', content: schedulerPaneContent('req-sched-b') }))
-    render(
-      <Provider store={store}>
-        <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
-        <StoreBackedFreshAgentView tabId="tab-2" paneId="pane-2" />
-      </Provider>,
-    )
-    // Let the identity fetches (immediate + trailing coalesce for the sibling)
-    // fully settle before measuring the burst.
-    await waitFor(() => expect(screen.getAllByText('done').length).toBeGreaterThan(0))
-    await flushMs(400)
-    apiMock.getFreshAgentThreadSnapshot.mockClear()
+      store.dispatch(initLayout({ tabId: 'tab-1', paneId: 'pane-1', content: schedulerPaneContent('req-sched-a') }))
+      store.dispatch(initLayout({ tabId: 'tab-2', paneId: 'pane-2', content: schedulerPaneContent('req-sched-b') }))
+      render(
+        <Provider store={store}>
+          <StoreBackedFreshAgentView tabId="tab-1" paneId="pane-1" />
+          <StoreBackedFreshAgentView tabId="tab-2" paneId="pane-2" />
+        </Provider>,
+      )
+      // Let the identity fetches (immediate + trailing coalesce for the
+      // sibling) fully settle before measuring the burst.
+      await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+      await act(async () => { await vi.advanceTimersByTimeAsync(SNAPSHOT_DEBOUNCE_MS) })
+      await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+      expect(screen.getAllByText('done').length).toBeGreaterThan(0)
+      apiMock.getFreshAgentThreadSnapshot.mockClear()
 
-    for (let i = 0; i < 10; i += 1) {
-      broadcast(sessionChanged())
+      for (let i = 0; i < 10; i += 1) {
+        broadcast(sessionChanged())
+      }
+
+      // Exactly one trailing GET shared by both panes, not one per event/pane.
+      await act(async () => { await vi.advanceTimersByTimeAsync(SNAPSHOT_DEBOUNCE_MS) })
+      expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1)
+      // A further full window stays silent: the burst coalesced into that one
+      // trailing GET.
+      await act(async () => { await vi.advanceTimersByTimeAsync(SNAPSHOT_DEBOUNCE_MS) })
+      expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
     }
-
-    // Exactly one trailing GET shared by both panes, not one per event/pane.
-    await waitFor(() => expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1))
-    await flushMs(400)
-    expect(apiMock.getFreshAgentThreadSnapshot).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the last good snapshot visible and stops fetching during 429 backoff', async () => {

--- a/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
+++ b/test/unit/client/components/fresh-agent/FreshAgentView.test.tsx
@@ -5,7 +5,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import panesReducer from '@/store/panesSlice'
 import settingsReducer, { previewServerSettingsPatch, updateSettingsLocal } from '@/store/settingsSlice'
 import sessionsReducer, { applySessionsPatch, applyContextUsageExtras } from '@/store/sessionsSlice'
-import freshAgentReducer, { sessionInit, setSessionStatus, markSessionLost } from '@/store/freshAgentSlice'
+import freshAgentReducer, { sessionInit, sessionMetadataReceived, setSessionStatus, markSessionLost } from '@/store/freshAgentSlice'
 import tabsReducer from '@/store/tabsSlice'
 import connectionReducer from '@/store/connectionSlice'
 import { FreshAgentView, IDLE_INCOMPLETE_MAX_RETRIES } from '@/components/fresh-agent/FreshAgentView'
@@ -7872,6 +7872,147 @@ describe('FreshAgentView session status strip', () => {
     // The tooltip carries the LIVE model id and its session effort — the pane
     // was created with 'high', and no live snapshot effort overrides it.
     expect(chip).toHaveAttribute('title', 'claude-live-99 · effort high')
+  })
+
+  it('the chip follows the model a fresh session.metadata frame states, over a stale REST snapshot', async () => {
+    apiMock.getFreshAgentModelCapabilities.mockResolvedValue({
+      ok: true,
+      sessionType: 'freshclaude',
+      runtimeProvider: 'claude',
+      status: 'fresh',
+      fetchedAt: 1_000,
+      models: [{
+        id: 'claude-live-99',
+        displayName: 'Live Ninety Nine',
+        provider: 'claude',
+        supportsEffort: true,
+        supportedEffortLevels: ['low', 'high'],
+        supportsAdaptiveThinking: true,
+      }],
+    })
+    // The REST snapshot still reports the PRE-change model: the chip must not
+    // be trapped on it once the server has stated the live pair via metadata.
+    apiMock.getFreshAgentThreadSnapshot.mockResolvedValue({
+      status: 'idle',
+      summary: 'summary',
+      capabilities: { send: true, interrupt: true, fork: true },
+      turns: [],
+      settings: { model: 'claude-live-99', effort: 'low' },
+    } as never)
+    const store = createStore()
+    store.dispatch(sessionInit({
+      sessionId: CLAUDE_THREAD_ID,
+      sessionType: 'freshclaude',
+      provider: 'claude',
+      model: 'claude-live-99',
+    }))
+    render(
+      <Provider store={store}>
+        <FreshAgentView
+          tabId="tab-1"
+          paneId="pane-1"
+          paneContent={{
+            kind: 'fresh-agent',
+            sessionType: 'freshclaude',
+            provider: 'claude',
+            createRequestId: 'req-strip-metadata-model',
+            sessionId: CLAUDE_THREAD_ID,
+            status: 'connected',
+            model: 'opus[1m]',
+            effort: 'high',
+          }}
+        />
+      </Provider>,
+    )
+
+    // The chip starts on the live (init) model.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Model: Live Ninety Nine — change model' })).toBeInTheDocument()
+    })
+
+    // The live pair changed server-side (a configure or a settings-carrying
+    // send applied it) and the metadata broadcast states the new truth: the
+    // chip flips IMMEDIATELY — the stale snapshot term never masks it.
+    store.dispatch(sessionMetadataReceived({
+      sessionId: CLAUDE_THREAD_ID,
+      sessionType: 'freshclaude',
+      provider: 'claude',
+      model: 'opus[1m]',
+      effort: 'high',
+    }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Model: Claude Opus 5 (1M context) — change model' })).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: 'Model: Live Ninety Nine — change model' })).toBeNull()
+    // The tooltip effort follows the metadata fold (not the snapshot's stale
+    // 'low').
+    expect(screen.getByRole('button', { name: 'Model: Claude Opus 5 (1M context) — change model' }))
+      .toHaveAttribute('title', 'opus[1m] · effort high')
+  })
+
+  it('an explicit-null metadata effort clears the chip tooltip back to Default', async () => {
+    apiMock.getFreshAgentModelCapabilities.mockResolvedValue({
+      ok: true,
+      sessionType: 'freshopencode',
+      runtimeProvider: 'opencode',
+      status: 'fresh',
+      fetchedAt: 1_000,
+      models: [{
+        id: 'opencode-go/glm-5.2',
+        displayName: 'GLM 5.2',
+        provider: 'opencode',
+        source: { id: 'opencode-go', displayName: 'OpenCode Go' },
+        supportsEffort: true,
+        supportedEffortLevels: ['low', 'high'],
+        supportsAdaptiveThinking: true,
+      }],
+    })
+    const store = createStore()
+    store.dispatch(sessionInit({
+      sessionId: 'ses_metadata_null',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      model: 'opencode-go/glm-5.2',
+      effort: 'high',
+    }))
+    render(
+      <Provider store={store}>
+        <FreshAgentView
+          tabId="tab-1"
+          paneId="pane-1"
+          paneContent={{
+            kind: 'fresh-agent',
+            sessionType: 'freshopencode',
+            provider: 'opencode',
+            createRequestId: 'req-strip-metadata-null',
+            sessionId: 'ses_metadata_null',
+            status: 'connected',
+            model: 'opencode-go/glm-5.2',
+            effort: 'high',
+          }}
+        />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Model: GLM 5.2 — change model' })).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Model: GLM 5.2 — change model' }))
+      .toHaveAttribute('title', 'opencode-go/glm-5.2 · effort high')
+
+    // The Default-row commit clears the variant: metadata states effort null
+    // and the tooltip words the SESSION's cleared effort, not a stale 'high'.
+    store.dispatch(sessionMetadataReceived({
+      sessionId: 'ses_metadata_null',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      model: 'opencode-go/glm-5.2',
+      effort: null,
+    }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Model: GLM 5.2 — change model' }))
+        .toHaveAttribute('title', 'opencode-go/glm-5.2 · effort Default')
+    })
   })
 
   it('uses the REST snapshot\'s settings.model when no session-init model exists (restored/MCP panes)', async () => {

--- a/test/unit/client/fresh-agent-ws.test.ts
+++ b/test/unit/client/fresh-agent-ws.test.ts
@@ -66,4 +66,85 @@ describe('fresh-agent websocket public contract', () => {
     expect(session.lastErrorCode).toBe('KILL_FAILED')
     expect(session.lastError).toContain('still be running')
   })
+  // ── freshAgent.session.metadata: the live-settings convergence fold ─────────
+
+  function seedLiveSession(store: ReturnType<typeof configureStore<{ freshAgent: typeof freshAgentReducer }>>) {
+    handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.event',
+      sessionId: 'thread-1',
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      event: {
+        type: 'freshAgent.session.init',
+        sessionId: 'thread-1',
+        cliSessionId: 'thread-1',
+        model: 'gpt-5.6-luna',
+        effort: 'high',
+        cwd: '/repo',
+      },
+    })
+  }
+
+  it('folds a session.metadata frame into the live model + effort', () => {
+    const store = configureStore({
+      reducer: { freshAgent: freshAgentReducer },
+    })
+    seedLiveSession(store)
+
+    expect(handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.event',
+      sessionId: 'thread-1',
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      event: {
+        type: 'freshAgent.session.metadata',
+        sessionId: 'thread-1',
+        model: 'gpt-5.6-sol',
+        effort: 'low',
+      },
+    })).toBe(true)
+    const session = store.getState().freshAgent.sessions['freshcodex:codex:thread-1']
+    expect(session.model).toBe('gpt-5.6-sol')
+    expect(session.effort).toBe('low')
+  })
+
+  it('folds an explicit-null metadata as a CLEAR, and absent keys as no-statement', () => {
+    const store = configureStore({
+      reducer: { freshAgent: freshAgentReducer },
+    })
+    seedLiveSession(store)
+
+    // Null states "explicitly no value" (e.g. opencode's Default thinking row):
+    // the clear must REPLACE, not fall through to the stale prior.
+    expect(handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.event',
+      sessionId: 'thread-1',
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      event: {
+        type: 'freshAgent.session.metadata',
+        sessionId: 'thread-1',
+        model: 'gpt-5.6-sol',
+        effort: null,
+      },
+    })).toBe(true)
+    let session = store.getState().freshAgent.sessions['freshcodex:codex:thread-1']
+    expect(session.model).toBe('gpt-5.6-sol')
+    expect(session.effort).toBeNull()
+
+    // Absent keys are "no statement": nothing changes.
+    expect(handleFreshAgentMessage(store.dispatch, {
+      type: 'freshAgent.event',
+      sessionId: 'thread-1',
+      sessionType: 'freshcodex',
+      provider: 'codex',
+      event: {
+        type: 'freshAgent.session.metadata',
+        sessionId: 'thread-1',
+      },
+    })).toBe(true)
+    session = store.getState().freshAgent.sessions['freshcodex:codex:thread-1']
+    expect(session.model).toBe('gpt-5.6-sol')
+    expect(session.effort).toBeNull()
+  })
 })

--- a/test/unit/client/store/storage-migration.fresh-agent.test.ts
+++ b/test/unit/client/store/storage-migration.fresh-agent.test.ts
@@ -348,7 +348,13 @@ describe('storage-migration fresh-agent', () => {
     module.runStorageMigration()
     const elapsedMs = performance.now() - startedAt
 
-    expect(elapsedMs).toBeLessThan(500)
+    // Contention-tolerant budget: the migration measures ~10-50ms unloaded,
+    // but this suite runs 96-way-parallel on a box many agents share — a
+    // wall-clock budget tight enough to catch the O(n)→O(n²) class (~100x,
+    // seconds-to-minutes at 1000 leaves) without failing on CPU starvation
+    // (observed at ~2-3s while sibling agents' vitest runs hold the cores;
+    // also observed failing on an unmodified checkout under the same load).
+    expect(elapsedMs).toBeLessThan(5_000)
     expect(localStorage.getItem(LAYOUT_KEY)).not.toContain('"agent-chat"')
     expect(localStorage.getItem(LAYOUT_KEY)).toContain('"fresh-agent"')
   })

--- a/test/unit/server/fresh-agent/claude-adapter.test.ts
+++ b/test/unit/server/fresh-agent/claude-adapter.test.ts
@@ -25,6 +25,45 @@ describe('Claude fresh-agent adapter', () => {
     expect(order).toEqual(['configure:opus', 'first', 'configure:sonnet', 'second'])
   })
 
+  it('applies a configure through the bridge, serialized behind an in-flight send', async () => {
+    let release!: () => void
+    const firstSend = new Promise<void>((resolve) => { release = resolve })
+    const order: string[] = []
+    const sdkBridge = {
+      configureSession: vi.fn(async (_id: string, settings: { model?: string }) => {
+        order.push(`configure:${settings.model}`)
+        if (settings.model === 'opus') await firstSend
+      }),
+      sendUserMessage: vi.fn((_id: string, text: string) => { order.push(text); return true }),
+    }
+    const adapter = createClaudeFreshAgentAdapter({ sdkBridge: sdkBridge as any })
+    const send = adapter.send?.('session', { text: 'first', settings: { requestId: 'a', sessionType: 'freshclaude', model: 'opus' } })
+    const configure = adapter.configure?.('session', { settings: { model: 'sonnet' } as any })
+    await Promise.resolve()
+    // The configure parks behind the in-flight send's own configure leg —
+    // the bridge's busy gate never sees an interleaved settings change.
+    expect(order).toEqual(['configure:opus'])
+    release()
+    await Promise.all([send, configure])
+    expect(order).toEqual(['configure:opus', 'first', 'configure:sonnet'])
+    expect(sdkBridge.configureSession).toHaveBeenCalledWith('session', { model: 'sonnet' })
+  })
+
+  it('a failed configure rejects and leaves the chain usable for the next send', async () => {
+    const sdkBridge = {
+      configureSession: vi.fn()
+        .mockRejectedValueOnce(new Error('Wait for the current turn to finish before changing agent settings.'))
+        .mockResolvedValueOnce(undefined),
+      sendUserMessage: vi.fn().mockReturnValue(true),
+    }
+    const adapter = createClaudeFreshAgentAdapter({ sdkBridge: sdkBridge as any })
+    await expect(adapter.configure?.('session', { settings: { model: 'sonnet' } as any }))
+      .rejects.toThrow(/current turn/i)
+    // The failure must not wedge the pendingSends chain: the next send runs.
+    await adapter.send?.('session', { text: 'still works' })
+    expect(sdkBridge.sendUserMessage).toHaveBeenCalledWith('session', 'still works', undefined)
+  })
+
   it('applies settings before sending and leaves the message unsent if configuration fails', async () => {
     const order: string[] = []
     const sdkBridge = {

--- a/test/unit/server/fresh-agent/codex-adapter.test.ts
+++ b/test/unit/server/fresh-agent/codex-adapter.test.ts
@@ -1985,4 +1985,78 @@ describe('wedged-sidecar deadman (quiet window)', () => {
       vi.useRealTimers()
     }
   })
+  // ── freshAgent.configure: live model convergence ─────────────────────────
+  describe('configure (live settings)', () => {
+    function makeConfigureStubRuntime() {
+      const runtime = {
+        startThread: vi.fn(),
+        resumeThread: vi.fn(),
+        startTurn: vi.fn().mockResolvedValue({ turnId: 'turn-1' }),
+        interruptTurn: vi.fn(),
+        onThreadLifecycle: vi.fn(() => vi.fn()),
+        onTurnStarted: vi.fn(() => vi.fn()),
+        onTurnCompleted: vi.fn(() => vi.fn()),
+        onExit: vi.fn(() => vi.fn()),
+        readThread: vi.fn().mockResolvedValue({ thread: { ...makeCodexThread('thread-1'), status: { type: 'idle' } }, turns: [] }),
+        listThreadTurns: vi.fn().mockResolvedValue({ turns: [], nextCursor: null, revision: 7 }),
+        readThreadTurn: vi.fn().mockResolvedValue(null),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      }
+      return runtime
+    }
+
+    it('records the normalized pair and emits sdk.session.metadata to subscribed listeners', async () => {
+      const runtime = makeConfigureStubRuntime()
+      const adapter = createCodexFreshAgentAdapter({ runtime: runtime as any })
+      const listener = vi.fn()
+      await adapter.subscribe?.('thread-1', listener)
+
+      // 'xhigh' is the menu alias for the wire 'max' level: the recorded pair
+      // (and the emitted event) states the MENU value, exactly like send.
+      await adapter.configure?.('thread-1', {
+        settings: { sessionType: 'freshcodex', model: 'gpt-5.6-luna', effort: 'xhigh' } as any,
+      })
+
+      expect(listener).toHaveBeenCalledWith({
+        type: 'sdk.session.metadata',
+        sessionId: 'thread-1',
+        model: 'gpt-5.6-luna',
+        effort: 'max',
+      })
+
+      // The NEXT send carries the recorded pair on its turn/start.
+      await adapter.send?.('thread-1', { requestId: 'req-next', text: 'hello' } as any)
+      expect(runtime.startTurn).toHaveBeenCalledWith(expect.objectContaining({
+        model: 'gpt-5.6-luna',
+        effort: 'xhigh',
+      }))
+    })
+
+    it('keeps the stored pair when a configure states no model or effort', async () => {
+      const runtime = makeConfigureStubRuntime()
+      runtime.startThread = vi.fn().mockResolvedValue({ threadId: 'thread-new-1' })
+      const adapter = createCodexFreshAgentAdapter({ runtime: runtime as any })
+      await adapter.create?.({ requestId: 'c', sessionType: 'freshcodex', model: 'gpt-5.6-sol', effort: 'low' } as any)
+      const listener = vi.fn()
+      await adapter.subscribe?.('thread-new-1', listener)
+
+      // A permission-mode-only configure records the permission and keeps the
+      // model/effort; the emitted metadata states the FULL effective pair so
+      // every subscribed device converges on one truth.
+      await adapter.configure?.('thread-new-1', {
+        settings: { permissionMode: 'never' } as any,
+      })
+      expect(listener).toHaveBeenCalledWith({
+        type: 'sdk.session.metadata',
+        sessionId: 'thread-new-1',
+        model: 'gpt-5.6-sol',
+        effort: 'low',
+      })
+      await adapter.send?.('thread-new-1', { requestId: 'req-next', text: 'hello' } as any)
+      expect(runtime.startTurn).toHaveBeenCalledWith(expect.objectContaining({
+        model: 'gpt-5.6-sol',
+        approvalPolicy: 'never',
+      }))
+    })
+  })
 })

--- a/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
+++ b/test/unit/server/fresh-agent/opencode-serve-adapter.test.ts
@@ -124,6 +124,48 @@ function makeAdapter(manager: FakeManager, overrides: Partial<Parameters<typeof 
 }
 
 describe('OpenCode serve adapter: create + send', () => {
+
+  // ── configure (live settings): the /model convergence lane ───────────────
+  it('configure records the pair and emits sdk.session.metadata; an idempotent configure stays silent', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+    const created = await adapter.create({
+      requestId: 'req-cfg',
+      sessionType: 'freshopencode',
+      provider: 'opencode',
+      model: 'opencode-go/glm-5.2',
+      effort: 'high',
+    })
+    const events: Array<Record<string, unknown>> = []
+    await adapter.subscribe?.(created.sessionId, (event) => events.push(event as Record<string, unknown>))
+
+    await adapter.configure?.(created.sessionId, {
+      settings: { sessionType: 'freshopencode', model: 'kimi-for-coding/kimi-k3', effort: 'low' },
+    })
+
+    const metadata = events.find((event) => event.type === 'sdk.session.metadata')
+    expect(metadata).toMatchObject({
+      type: 'sdk.session.metadata',
+      sessionId: created.sessionId,
+      model: 'kimi-for-coding/kimi-k3',
+      effort: 'low',
+    })
+
+    // Idempotent: nothing changes, nothing converges.
+    const before = events.length
+    await adapter.configure?.(created.sessionId, {
+      settings: { sessionType: 'freshopencode', model: 'kimi-for-coding/kimi-k3', effort: 'low' },
+    })
+    expect(events.slice(before).filter((event) => event.type === 'sdk.session.metadata')).toHaveLength(0)
+  })
+
+  it('configure for an unknown session surfaces the lost-session error', async () => {
+    const manager = makeFakeManager()
+    const adapter = makeAdapter(manager)
+    await expect(adapter.configure?.('freshopencode-unknown', { settings: { model: 'x' } }))
+      .rejects.toThrow(/not available/i)
+  })
+
   it('creates a placeholder, materializes on first send via POST /session, and awaits idle', async () => {
     const manager = makeFakeManager()
     const adapter = makeAdapter(manager)

--- a/test/unit/server/sdk-bridge.test.ts
+++ b/test/unit/server/sdk-bridge.test.ts
@@ -1405,6 +1405,27 @@ describe('SdkBridge', () => {
       await expect(bridge.configureSession(session.sessionId, { model: 'sonnet' })).rejects.toThrow(/current turn/i)
     })
 
+    it('broadcasts sdk.session.metadata with the effective pair on an applied change (and stays silent when nothing changed)', async () => {
+      mockKeepStreamOpen = true
+      const session = await bridge.createSession({ model: 'opus', effort: 'high' })
+      const received: any[] = []
+      bridge.subscribe(session.sessionId, (msg: any) => received.push(msg))
+
+      await bridge.configureSession(session.sessionId, { model: 'sonnet' })
+      expect(bridge.getSession(session.sessionId)?.model).toBe('sonnet')
+      const metadata = received.find((msg) => msg?.type === 'sdk.session.metadata')
+      expect(metadata).toMatchObject({ type: 'sdk.session.metadata', model: 'sonnet' })
+      // A same-model configure keeps the effort (the bridge's same-model rule),
+      // and the metadata states the effective pair the session now runs with.
+      expect(bridge.getSession(session.sessionId)?.effort).toBeUndefined()
+      expect(metadata.effort).toBeUndefined()
+
+      // Idempotent configure: nothing changes, nothing converges.
+      const before = received.length
+      await bridge.configureSession(session.sessionId, { model: 'sonnet' })
+      expect(received.slice(before).filter((msg: any) => msg?.type === 'sdk.session.metadata')).toHaveLength(0)
+    })
+
     it('does not record a rejected model change and rejects changing the conversation directory', async () => {
       mockKeepStreamOpen = true
       const session = await bridge.createSession({ cwd: '/repo', model: 'opus', effort: 'high' })

--- a/test/unit/server/ws-handler-fresh-agent.test.ts
+++ b/test/unit/server/ws-handler-fresh-agent.test.ts
@@ -372,6 +372,88 @@ describe('WsHandler fresh-agent routing', () => {
     }
   })
 
+  it('routes freshAgent.configure through the runtime manager and surfaces a refusal as the session-scoped error banner', async () => {
+    const runtimeManager = {
+      create: vi.fn().mockResolvedValue({
+        sessionId: 'codex-session-2',
+        sessionType: 'freshcodex',
+        runtimeProvider: 'codex',
+      }),
+      subscribe: vi.fn().mockResolvedValue(() => undefined),
+      configure: vi.fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('Wait for the current turn to finish before changing agent settings.')),
+    }
+    const { server } = await createServer({ freshAgentRuntimeManager: runtimeManager })
+
+    try {
+      const ws = await connectAndAuth(server)
+      const seenMessages: any[] = []
+      ws.on('message', (data) => {
+        seenMessages.push(JSON.parse(data.toString()))
+      })
+
+      ws.send(JSON.stringify({
+        type: 'freshAgent.create',
+        requestId: 'req-2',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+      }))
+      await vi.waitFor(() => {
+        expect(seenMessages.some((message) => message.type === 'freshAgent.created')).toBe(true)
+      })
+
+      // A successful configure answers with nothing on this socket (the
+      // adapter-emitted freshAgent.session.metadata event is the convergence
+      // frame, delivered through the session subscription).
+      ws.send(JSON.stringify({
+        type: 'freshAgent.configure',
+        requestId: 'cfg-ok',
+        sessionId: 'codex-session-2',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        settings: { model: 'gpt-5.6-luna', effort: 'low' },
+      }))
+      const locator = { sessionId: 'codex-session-2', sessionType: 'freshcodex', provider: 'codex' }
+      await vi.waitFor(() => {
+        expect(runtimeManager.configure).toHaveBeenCalledWith(locator, {
+          settings: { model: 'gpt-5.6-luna', effort: 'low' },
+        })
+      })
+
+      // A refused configure surfaces as the pane's session-scoped error
+      // banner (freshAgent.error), never silence.
+      ws.send(JSON.stringify({
+        type: 'freshAgent.configure',
+        requestId: 'cfg-busy',
+        sessionId: 'codex-session-2',
+        sessionType: 'freshcodex',
+        provider: 'codex',
+        settings: { model: 'gpt-5.6-sol' },
+      }))
+      await vi.waitFor(() => {
+        expect(runtimeManager.configure).toHaveBeenCalledTimes(2)
+      })
+      await vi.waitFor(() => {
+        const banner = seenMessages.find((message) => (
+          message.type === 'freshAgent.event'
+          && message.event?.type === 'freshAgent.error'
+          && message.event?.message?.includes('current turn')
+        ))
+        expect(banner).toBeTruthy()
+        expect(banner.sessionId).toBe('codex-session-2')
+      })
+
+      ws.close()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    } finally {
+      // ensure the server is closed even on assertion failures mid-test
+      if (server.listening) {
+        await new Promise<void>((resolve) => server.close(() => resolve()))
+      }
+    }
+  })
+
   it('routes freshAgent.send, freshAgent.interrupt, freshAgent approvals/questions, freshAgent.kill, and freshAgent.fork through the runtime manager after create ownership is established', async () => {
     const runtimeManager = {
       create: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## What

Model changes now apply to a LIVE fresh-agent session at commit time and converge every device's model surfaces (the lower-left status-strip chip, tooltips, the gear popover) immediately — for all four session types (freshclaude, kilroy, freshcodex, freshopencode).

Reproduced live on the production server before the fix:
- **codex**: `/model` → commit → chip stayed on the pre-change model (the stale REST snapshot's `settings.model` outranked the staged pick; the session record only updates when a settings-carrying send is accepted).
- **claude/kilroy**: after a real turn, the session-init model (a raw runtime id) masked every commit and never updated; the chip could vanish entirely when no display label resolved.
- **opencode**: the dialog commit updated the local chip (no session-truth term existed) but nothing propagated to other devices or restored panes.

Root cause: the protocol already specified `freshAgent.session.metadata` and the client already folded it, but **no server ever emitted it**, and there was no client→server way to apply a model change to a live session except piggybacking on the next `freshAgent.send`.

## How

- **`freshAgent.configure`** (new client→server message, additive — old servers accept-and-strip it): applies settings (model / effort / permissionMode / sandbox) to a LIVE session without a turn. The model+thinking dialog commit, the settings-gear model radio, the thinking select, and the permission-mode select each fire it. Claude/kilroy applies it for real through the sidecar's configure lane (`setModel` / `applyFlagSettings` — a genuine mid-conversation change); codex and opencode record it as the next turn's per-send settings (their advertised `per-send` scope).
- **`freshAgent.session.metadata` broadcasts** now fire at every live-settings change site — the configure handlers plus the send-apply paths (claude `configure_for_send`, codex turn-accept persist, opencode send record) — stating the effective model/effort (JSON null = an explicit clear, e.g. opencode's Default thinking row), keyed at the client-addressed session id so every subscribed device folds it.
- **Client**: `sessionMetadataReceived` folds model + effort with stated/null/absent semantics; the chip tooltip prefers the fresh fold over the REST snapshot's `settings.effort`; the view's frame send delegates to one shared suppression-aware seam.
- **Contract**: schema + inventory regenerated (40 → 41 client→server types), no protocol version bump (additive, never-awaited — the `pane.opened.result` precedent).
- **Node parity**: adapter `configure` lanes (claude bridges to `configureSession`; codex/opencode record + emit), the manager's capability guard, the ws-handler dispatch with the session-scoped `freshAgent.error` banner on refusal (e.g. changing model mid-turn on claude), and `sdk-bridge.configureSession` broadcasting the metadata event on applied changes.

## Tests

- Rust: per-slice handler suites (record/broadcast, idempotent silence, unknown-session + killed-gate refusals, send-path convergence, binding-row re-snapshot, claude scripted-refusal banner), the shared frame builder's wire-shape tests, and the protocol inventory conformance.
- Node: bridge emission, claude chain serialization + recovery, codex record/emission + next-turn carry, opencode record/emission, ws dispatch + refusal banner.
- Client: ws-contract metadata fold (stated/clear/no-statement), dialog/popover configure frames, the chip flip over a stale snapshot, the null-effort tooltip clear.
- E2E: `freshopencode-model-picker.spec.ts` (chromium/legacy) pins the dialog commit → configure frame → injected metadata → chip flips over the pane's own stale stub; `freshagent-live-model-convergence-rust.spec.ts` (rust-chromium, registered in RUST_ONLY_SPECS + the rust testMatch) proves the wire end-to-end: configure → metadata broadcast → next turn's prompt body carries the configured pair, and the claude sidecar lane applied. Both specs pass on the **cloud** backend as well as locally.

## Along the way (pre-existing, worth noting)

- De-flaked three wall-clock-tight suites that failed intermittently under this box's concurrent agent load (pinned on an unmodified checkout): the zrrj coalescing test converted to the 429-sibling's deterministic fake-timer pattern; the claude Rust test-module's 15s drain budget → 45s; the storage-migration perf budget 500ms → 5s (still a ~100x bound against the O(n²) class it exists to catch).
- Known pre-existing gap NOT touched here: `freshagent-settings-resume-rust.spec.ts` and `fresh-agent-control-rust.spec.ts` point `CODEX_CMD` at a nonexistent fixture path (`fixtures/coding-cli/codex-app-server/fake-app-server.mjs` — the real one is `fixtures/providers/fake-codex-app-server.mjs`); their codex legs cannot currently pass.
- Node and Rust diverge on absent-model opencode settings (Rust clears, Node keeps — each internally consistent with its own send path); the client always sends the model explicitly, so no behavior change.